### PR TITLE
docs(agent): add Agent Harness anatomy note

### DIFF
--- a/docs/zh/tech/evaluation/generative-benchmarking.md
+++ b/docs/zh/tech/evaluation/generative-benchmarking.md
@@ -1,0 +1,138 @@
+# Generative Benchmarking
+
+> 原文: [Generative Benchmarking - Chroma](https://research.trychroma.com/generative-benchmarking)
+
+## 背景问题
+
+当前 benchmark 的核心局限：**公开 benchmark 上的强性能并不能直接泛化到真实生产环境**。
+
+### 现有 Benchmark 的问题
+
+| 问题 | 说明 |
+|------|------|
+| **数据集通用性** | 泛化数据集无法捕获特定领域的真实用例 |
+| **数据过于干净** | 与真实数据的混乱性形成对比 |
+| **记忆效应** | 模型在训练数据中见过 benchmark，导致性能虚高 |
+
+这导致一个常见误解：公开 benchmark 上的好成绩 = 生产环境的好表现。
+
+## 核心方案：生成式 Benchmark
+
+生成式 Benchmark 针对用户私有数据定制，更准确、更代表真实场景：
+
+- 数据集定制到用户文档 → 确保与用例相关
+- 使用真实混乱数据 → 包含模糊查询
+- 真正未见过的数据 → 基于用户文档生成，消除记忆可能
+
+## 方法论
+
+### 两步流程
+
+```
+文档过滤 → 使用对齐的 LLM judge + 用户上下文识别相关文档
+    ↓
+查询生成 → 使用上下文和示例查询引导生成
+```
+
+### 第一步：文档过滤
+
+使用对齐的 LLM judge 评估每个文档是否适合生成查询：
+
+**判断标准**：
+- **相关性**：文档是否与用例相关
+- **完整性**：文档是否包含有用信息
+- **意图**：文档是否适合 ML 用户的使用场景
+
+通过 5 轮迭代，LLM judge 与人类判断的对齐率从 46% 提升到 75.2%。
+
+### 第二步：Distinct Query Generation
+
+**核心创新**：将目标文档和 ground truth 查询同时给 LLM，ground truth 作为负面示例，要求生成与之不同的查询。
+
+```markdown
+基于以下信息：
+<document>...</document>
+
+这是一个示例查询：
+<query>ground truth query</query>
+
+请生成一个与示例不同但相关的查询。
+```
+
+**效果**：显著降低 query-query 相似度（从 0.716 → 0.628），同时保持 query-document 相关性分布相似。
+
+## 实验验证
+
+### 公开数据集实验（9 个数据集，5 个 embedding 模型）
+
+**关键发现：Naive 生成大量复制了 ground truth**
+
+```
+Wikipedia Multilingual (en):
+- 11.91% 的生成查询与 ground truth 相似度 > 0.9（几乎相同）
+- 65.89% 介于 0.6-0.9（轻微改写）
+```
+
+### Distinct 生成验证
+
+**生成的查询是独特的**：
+- 平均 query-query 相似度显著降低
+- 在所有数据集和模型上保持一致
+
+**生成的查询具有代表性**：
+
+| 指标 | 验证方式 |
+|------|---------|
+| 相对 embedding 模型排名 | Recall@k 排名一致 |
+| Query-Document 分布 | KL 散度低（~0.05-0.2） |
+
+## 生产环境验证（Weights & Biases）
+
+### 实验设置
+
+- 数据：WandBot（技术文档支持机器人）的生产查询
+- 2003 个唯一查询
+- 13,319 → 8,490 个过滤后的文档
+
+### 查询生成方法
+
+```
+提供上下文 + 示例查询 → Claude 生成 → 与 ground truth 对比
+```
+
+### 关键结果
+
+| Embedding 模型 | Ground Truth Recall@10 | Generated Recall@10 |
+|---------------|----------------------|-------------------|
+| text-embedding-3-small | 0.439 | 0.530 |
+| text-embedding-3-large | 0.552 | 0.602 |
+| jina-embeddings-v3 | 0.511 | 0.532 |
+| voyage-3-large | 0.670 | 0.679 |
+
+**重要发现**：
+- 生成查询保持了模型间相对排名
+- MTEB 表现与生产环境表现存在差异：jina-embeddings-v3 在 MTEB 上优于 text-embedding-3-large，但在 WandBot 上相反
+
+**这验证了核心论点：公开 benchmark 性能不能直接泛化到真实生产环境。**
+
+### 消融实验
+
+| 方法 | KL 散度（与 ground truth） |
+|------|------------------------|
+| Naive 生成（无上下文） | 0.207 |
+| 带上下文和示例生成 | **0.159** |
+
+上下文和示例对于生成代表性查询至关重要。
+
+## 局限性
+
+1. **生产数据集多样性有限**：目前只在 Weights & Biases 数据集上验证
+2. **无匹配文档的查询**：生产中常见的 no-match 场景未被当前指标覆盖
+
+## 核心要点
+
+- 公开 benchmark 性能与生产性能存在偏差，需要针对性评估
+- 生成查询时，提供上下文和示例比 naive 生成更能代表真实查询
+- 通过 document filtering + distinct query generation 流程可生成高质量 benchmark
+- Embedding 模型排名在公开 benchmark 和生产环境可能不同
+- 代码已开源：github.com/chroma-core/generative-benchmarking

--- a/docs/zh/tech/patterns/agent/agentic-engineering-patterns.md
+++ b/docs/zh/tech/patterns/agent/agentic-engineering-patterns.md
@@ -1,0 +1,102 @@
+# Agentic Engineering Patterns
+
+> 原文：[Agentic Engineering Patterns](https://simonwillison.net/guides/agentic-engineering-patterns/) — Simon Willison
+
+## 什么是 Agentic Engineering
+
+**Agentic engineering**：在编码 Agent（如 Claude Code、OpenAI Codex、Gemini CLI）辅助下开发软件的技术。
+
+### Agent 的定义
+
+> Agents run tools in a loop to achieve a goal.
+
+Agent 是软件，它调用 LLM，传入 Prompt 和工具定义，LLM 请求什么工具就执行什么工具，然后把结果反馈给 LLM。对于编码 Agent，那些工具包含**执行代码的能力**。
+
+**代码执行是让 Agentic Engineering 成为可能的关键能力。** 没有直接运行代码的能力，LLM 输出的任何东西价值都有限。有了代码执行，Agent 才能开始迭代，直到产出能工作的软件。
+
+## 核心概念
+
+### LLM = 大语言模型
+
+- 输入是 **Prompt**，输出是 **Completion/Response**
+- 工作在 **Token** 层面（文本转为整数序列），按 Token 计费
+- 多模态：可以接受图像作为输入，图像也会转为 Token 整数处理
+
+### Chat 模板 Prompt
+
+LLM 本质是无状态的，每次执行 Prompt 都是从空白 slate 开始。需要聊天软件自己维护状态，重放整个对话历史。
+
+### Token 缓存
+
+模型提供商对缓存的输入 Token 提供更便宜的费率。编码 Agent 设计时会避免修改早期对话内容，以最大化缓存效率。
+
+### 工具调用
+
+Agent 调用工具时，Prompt 里会包含工具定义，LLM 输出类似 `<tool>get_weather("San Francisco")</tool>` 的文本，Harness 用正则提取并执行工具。
+
+编码 Agent 通常定义十几个工具，最强大的是允许代码执行的工具：Bash() 执行终端命令、Python() 运行 Python 代码。
+
+### System Prompt
+
+编码 Agent 在每次对话开始时都会注入 System Prompt，告诉模型如何行为。这些 Prompt 可能长达数百行。OpenAI Codex 的 System Prompt 是很好的参考例子。
+
+### 推理（Reasoning）
+
+2025 年的大突破：推理能力。模型在正式回复前，先生成"思考"文本来展开问题和解法。推理对调试特别有用，让模型有机会混合工具调用和函数追踪。
+
+## 核心模式
+
+### 1. Red/Green TDD
+
+先写测试再写代码。Agent 可以自动化这个循环。
+
+### 2. First Run the Tests
+
+让 Agent 先运行测试，理解现有代码行为。
+
+### 3. Agentic Manual Testing
+
+Agent 做人工测试时，可以用浏览器自动化测试 Web UI，或者用 Showboat 做笔记。
+
+### 4. Subagents
+
+Claude Code 的 Explore 子 Agent、并行子 Agent、专家型子 Agent。
+
+### 5. Linear Walkthroughs
+
+线性通读代码，配合 Showboat 和 Present 使用。
+
+### 6. Interactive Explanations
+
+交互式解释，理解词云等可视化内容。
+
+## 反模式（Anti-patterns）
+
+### 不要做：Inflicting unreviewed code on collaborators
+
+未经审查的代码会给协作者带来麻烦。Agentic engineering 应该产出经过验证的、达到生产标准的代码，而不仅仅是"能跑"的代码。
+
+## 与 Vibe Coding 的区别
+
+**Vibe coding**（Andrej Karpathy 2025年2月提出）：prompt LLM 写代码时"忘记代码的存在"。
+
+Agentic engineering 不是 vibe coding。区别在于：
+- Vibe coding：未经审查、原型质量的 LLM 生成代码
+- Agentic engineering：需要验证和迭代，确保产出可靠
+
+## 关键洞见
+
+1. **写代码现在很便宜** — 难点在于搞清楚写什么代码
+2. **需要建立新习惯** — 积累自己的"工具箱"并学会重组
+3. **AI 应该帮助我们产出更好的代码** — 而不只是更多代码
+4. **拥抱复合工程循环** — 不断迭代改进
+
+## 对前端 AI 学习的启发
+
+| 模式 | 前端场景 |
+|---|---|
+| Red/Green TDD | Vitest + Playwright E2E |
+| Subagents | Cursor 多 Agent 协作 |
+| Token 缓存优化 | 控制 Prompt 长度 |
+| System Prompt 工程 | Cursor Rules 编写 |
+| Reasoning 调优 | Claude Code 思考深度配置 |

--- a/docs/zh/tech/patterns/agent/harness.md
+++ b/docs/zh/tech/patterns/agent/harness.md
@@ -1,0 +1,115 @@
+# Agent Harness 剖析
+
+> 原文：[The Anatomy of an Agent Harness](https://blog.langchain.com/the-anatomy-of-an-agent-harness/) — Vivek Trivedy
+
+## 核心公式
+
+```
+Agent = Model + Harness
+```
+
+如果不是在设计模型，那就在设计 Harness。
+
+**Harness** 是将模型转化为工作引擎的所有代码、配置和执行逻辑。模型提供智能，Harness 让智能变得有用。
+
+## 模型做不到的事
+
+模型（大多数）只能输入文本/图像/音频/视频，输出文本。天生无法：
+
+- 在交互间维持持久状态
+- 执行代码
+- 访问实时知识
+- 搭建环境来完成任务
+
+这些全部是 Harness 层解决的。
+
+## 核心组件
+
+### 1. 文件系统（持久存储 & 上下文管理）
+
+模型只能操作上下文窗口内的知识。Harness 提供文件系统抽象，让 Agent：
+
+- 拥有工作空间，读取数据、代码、文档
+- 将中间结果存储到磁盘而非全部塞进上下文
+- 跨 session 保持状态
+- 多 Agent / 人类通过共享文件协作
+
+**Git** 为文件系统增加了版本控制，Agent 可追踪工作、回滚错误、分支实验。
+
+### 2. Bash + 代码（通用工具）
+
+Harness 提供 Bash 工具，让模型能自主编写和执行代码来解决问题，而不需要预定义的每一个工具。
+
+ReAct Loop：`推理 → 行动 → 观察 → 重复`
+
+代码执行是实现自主问题求解的默认通用策略。
+
+### 3. 沙箱 & 验证工具
+
+模型无法自己配置执行环境。Harness 负责：
+
+- **沙箱**：隔离、安全的代码执行环境，按需创建/销毁
+- **预装工具**：语言运行时、Git、测试框架、浏览器
+- **自验证循环**：Agent 写代码 → 运行测试 → 检查日志 → 修复错误
+
+### 4. 记忆 & 搜索（持续学习）
+
+模型的知识截止于训练数据。Harness 通过文件系统实现**持续学习**：
+
+- `AGENTS.md` 等记忆文件在 Agent 启动时注入上下文
+- Web Search / MCP (如 Context7) 获取训练后产生的新知识
+
+### 5. 对抗 Context Rot
+
+Context Rot：上下文窗口填充后，模型推理和完成任务的能力下降。
+
+Harness 的主要工作就是**传递好的上下文工程**。
+
+| 策略 | 说明 |
+|------|------|
+| **压缩 (Compaction)** | 上下文快满时，智能卸载和摘要已有内容 |
+| **工具输出卸载** | 大工具输出只保留首尾 token，完整内容存文件系统 |
+| **Skills** | 渐进式加载工具，避免启动时上下文过载 |
+
+### 6. 长期自主执行
+
+复杂任务需要跨越多个上下文窗口的规划、观察和验证。
+
+- **Ralph Loop**：拦截模型的退出尝试，在干净上下文中重新注入原始 Prompt，强迫 Agent 继续工作
+- **规划**：将目标分解为步骤，通过 Prompt 和文件系统中的计划文件引导
+- **自验证**：Agent 完成后自行检查正确性，或通过测试套件创建反馈循环
+
+## 模型训练 & Harness 设计的耦合
+
+Claude Code、Codex 等产品采用 **post-training**：模型和 Harness 在循环中共同训练。
+
+这创造了反馈循环：发现有用原语 → 加入 Harness → 用于训练下一代模型。
+
+**有趣的副作用**：改变工具逻辑会导致模型性能下降——这是 Harness 层面的过拟合。
+
+> 但这不意味着模型预训练用的 Harness 就是最优的。Terminal Bench 2.0 上，Opus 4.6 在 Claude Code 中得分远低于在其他 Harness 中——纯粹改变 Harness 就能让一个 Agent 从 Top 30 提升到 Top 5。
+
+## Harness 的未来
+
+随着模型能力增强，部分 Harness 功能会被吸收进模型本身。但：
+
+> 正如 Prompt Engineering 今天仍然有价值，Harness Engineering 仍将是构建好 Agent 的关键。
+
+Harness 不只是补丁模型缺陷的工具，更是**围绕模型智能构建系统**的工程化手段。
+
+## 对前端 AI 学习的启发
+
+| Harness 组件 | 前端场景 |
+|---|---|
+| 文件系统 | 工作区管理、跨项目上下文 |
+| 沙箱 | 本地开发环境、Docker 隔离 |
+| 自验证 | 自动化测试、Playwright E2E |
+| Context 管理 | Cursor Rules、上下文注入策略 |
+| Skills | VitePress 插件、浏览器扩展 |
+
+## 相关文章
+
+- [Agent 设计模式](./agent-design-patterns.md)
+- [MCP 协议](../protocols/mcp.md)
+- [Skills 机制](./skills.md)
+- [Hooks 模式](./hooks.md)

--- a/docs/zh/tech/patterns/agent/hello-agents.md
+++ b/docs/zh/tech/patterns/agent/hello-agents.md
@@ -1,0 +1,72 @@
+# Hello-Agents 学习指南
+
+> 原文：[Hello-Agents - 从零开始构建智能体](https://datawhalechina.github.io/hello-agents/) — Datawhale
+
+## 项目概述
+
+如果说 2024 年是"百模大战"元年，2025 年则开启了 **Agent 元年**。Hello-Agents 是 Datawhale 社区的系统性智能体学习教程，旨在提供从零开始、理论与实战并重的智能体构建指南。
+
+## 两类 Agent 构建路径
+
+| 类型 | 代表 | 本质 |
+|------|------|------|
+| **流程驱动类** | Dify、Coze、n8n | 软件工程，LLM 作为后端数据处理 |
+| **AI 原生类** | AutoGen、LangGraph、helloagents | 真正以 AI 驱动的 Agent（本教程重点）|
+
+## 教程内容导航
+
+### 第一部分：智能体基础
+| 章节 | 关键内容 |
+|------|---------|
+| 初识智能体 | Agent 定义、类型、范式与应用 |
+| 智能体发展史 | 从符号主义到 LLM 驱动的演进 |
+| 大语言模型基础 | Transformer、提示工程、主流 LLM 及其局限 |
+
+### 第二部分：构建 LLM 智能体
+| 章节 | 关键内容 |
+|------|---------|
+| 智能体经典范式构建 | ReAct、Plan-and-Solve、Reflection 手把手实现 |
+| 基于低代码平台的搭建 | Coze、Dify、n8n 等平台使用 |
+| 框架开发实践 | AutoGen、AgentScope、LangGraph 等主流框架 |
+| 构建你的 Agent 框架 | 从 0 开始构建自己的智能体框架 |
+
+### 第三部分：高级知识扩展
+| 章节 | 关键内容 |
+|------|---------|
+| 记忆与检索 | 记忆系统、RAG、存储 |
+| 上下文工程 | 持续交互的"情境理解" |
+| 智能体通信协议 | MCP、A2A、ANP 等协议解析 |
+| Agentic-RL | 从 SFT 到 GRPO 的 LLM 训练实战 |
+| 智能体性能评估 | 核心指标、基准测试与评估框架 |
+
+### 第四部分：综合案例
+| 案例 | 说明 |
+|------|------|
+| 智能旅行助手 | MCP 与多智能体协作的真实世界应用 |
+| 自动化深度研究 Agent | DeepResearch Agent 复现与解析 |
+| 赛博小镇 | Agent 与游戏结合，模拟社会动态 |
+
+## 核心范式速查
+
+| 范式 | 说明 |
+|------|------|
+| **ReAct** | Reason + Act，推理-行动循环 |
+| **Plan-and-Solve** | 先规划再执行 |
+| **Reflection** | 自我反思改进 |
+| **Tool Use** | 函数调用/工具调用 |
+| **Memory** | 短/长期记忆管理 |
+| **Multi-Agent** | 多智能体协作 |
+
+## 协议对比
+
+| 协议 | 说明 |
+|------|------|
+| **MCP** | Model Context Protocol，模型上下文协议 |
+| **A2A** | Agent to Agent，智能体间通信协议 |
+| **ANP** | Agent Network Protocol |
+
+## 资源链接
+
+- 在线阅读：[datawhalechina.github.io/hello-agents](https://datawhalechina.github.io/hello-agents/)
+- GitHub：[datawhalechina/Hello-Agents](https://github.com/datawhalechina/hello-agents)
+- 自研框架：[jjyaoao/helloagents](https://github.com/jjyaoao/helloagents)


### PR DESCRIPTION
## 任务
阅读 [The Anatomy of an Agent Harness](https://blog.langchain.com/the-anatomy-of-an-agent-harness/) 并整理笔记

## 产出
新增 docs/zh/tech/patterns/agent/harness.md，内容包括：
- Agent = Model + Harness 核心公式
- 6大核心组件：文件系统、Bash+代码、沙箱验证、记忆搜索、Context Rot 对抗、长期自主执行
- 模型训练与 Harness 设计的耦合关系
- 对前端 AI 学习的启发

来源：Walle 通讯表格 (inbox-20260411-025)