### PR TITLE
docs(zh): MCP 协议文档优化

### DIFF
--- a/docs/zh/integration/protocols/mcp/architecture.md
+++ b/docs/zh/integration/protocols/mcp/architecture.md
@@ -1,0 +1,223 @@
+# MCP 协议架构详解
+
+> 本文档深入分析 MCP 协议的分层架构、通讯流程，以及 MCP Proxy 模式如何桥接纯 HTTP 第三方服务。
+
+## 一、协议分层
+
+MCP 协议分为两层：
+
+| 层级 | 职责 | 关键技术 |
+|------|------|----------|
+| **Transport Layer** (传输层) | 消息的物理传输通道 | Stdio / Streamable HTTP |
+| **Data Layer** (数据层) | JSON-RPC 2.0 消息的格式和语义 | `initialize`、`tools/call`、`tools/list` 等方法 |
+
+```
+┌─────────────────────────────────────┐
+│         MCP Host (AI 应用)           │
+│  ┌────────────────────────────────┐ │
+│  │        Data Layer               │ │
+│  │   JSON-RPC 2.0 Messages        │ │
+│  └────────────────────────────────┘ │
+│  ┌────────────────────────────────┐ │
+│  │     Transport Layer             │ │
+│  │   Stdio ◄──────► Streamable HTTP│ │
+│  └────────────────────────────────┘ │
+└──────────────────┬──────────────────┘
+                   │
+         ┌─────────┴─────────┐
+         │                     │
+    Local Process          Remote Server
+    (Stdio)               (HTTP/SSE)
+```
+
+## 二、MCP Proxy 模式（桥接 HTTP 第三方服务）
+
+MCP Server 可以作为 **协议转换桥**，让不支持 MCP 的普通 HTTP 服务接入 MCP 生态。
+
+### 完整时序图
+
+```mermaid
+sequenceDiagram
+    participant User as 用户
+    participant Host as MCP Host<br/>(Claude Desktop / Cursor)
+    participant Client as MCP Client<br/>(Host 内置)
+    participant Server as MCP Server<br/>(Node.js Proxy)
+    participant LLM as 大模型 (LLM)
+    participant HTTP as 纯 HTTP 第三方服务
+
+    %% 1. 用户输入
+    User->>+Host: 1. 输入自然语言 Prompt
+
+    %% 2. 启动 MCP Server
+    Host->>+Server: 2. 启动 MCP Server 进程<br/>(node mcp-proxy.js via Stdio)
+
+    %% 3-5. 初始化 & 工具发现 (MCP 生命周期)
+    Client->>+Server: 3. initialize (JSON-RPC over Stdio)
+    Server-->>-Client: 4. initialize response<br/>(capabilities)
+    Client->>+Server: 5. tools/list request
+    Server-->>-Client: 6. 返回工具定义列表<br/>(JSON Schema)
+
+    %% 7. Host 将 prompt + 工具注入 LLM
+    Host->>+LLM: 7. 注入 system prompt + 工具定义 + User Prompt
+
+    %% 8-9. LLM 决策，Host 格式化
+    LLM-->>-Host: 8. 输出 (自然语言 + tool use 意图)
+    Host->>+Client: 9. 解析意图，构建 JSON-RPC<br/>(tools/call)
+
+    %% 10. Client 经 Stdio 转发
+    Client->>+Server: 10. tools/call 请求 (JSON-RPC over Stdio)
+
+    %% 11-12. Proxy 转换为 HTTP
+    Server->>+HTTP: 11. 标准 HTTP 请求<br/>(fetch/axios)
+    HTTP-->>-Server: 12. 返回纯 JSON<br/>(无 MCP 感知)
+
+    %% 13. Server 包装响应
+    Server-->>-Client: 13. MCP JSON-RPC Response<br/>(经 stdout)
+
+    %% 14. 结果注入 LLM
+    Client->>+LLM: 14. 工具执行结果注入上下文
+
+    %% 15. 生成最终回复
+    LLM-->>-Host: 15. 自然语言回复
+
+    %% 16. 输出
+    Host->>-User: 16. 展示最终结果
+
+    Note over Server,HTTP: MCP Server (Proxy) 双重角色:<br/>• 对 Host/Client: 标准 MCP Server (Stdio)<br/>• 对第三方: 普通 HTTP Client
+```
+
+### 关键要点
+
+| 步骤 | 说明 |
+|------|------|
+| **2** | MCP Server 通过 **Stdio** 启动，本质是一个子进程 |
+| **3-6** | MCP **握手协议**：先 `initialize`，再 `tools/list` 获取工具清单 |
+| **8-9** | LLM 输出结构化**意图**，由 Host 应用**解析**后构建 JSON-RPC（LLM 不直接输出 JSON-RPC） |
+| **10** | `tools/call` 通过 **Stdio stdin** 发送，不是网络请求 |
+| **11-12** | Server 作为 **HTTP Client**，调用第三方 API（无 MCP 感知） |
+
+## 三、Transport Layer 详解
+
+MCP 支持两种传输机制：
+
+### 3.1 Stdio Transport（本地进程）
+
+```
+Host 进程  ←→  [Stdin/Stdout]  ←→  MCP Server 子进程
+```
+
+- **适用场景**：本地 MCP Server（如文件系统、数据库工具）
+- **优点**：无网络开销，性能最优
+- **通信格式**：JSON-RPC 消息直接写入 stdin/stdout
+
+### 3.2 Streamable HTTP Transport（远程服务）
+
+```
+MCP Client  ←→  [HTTP POST + SSE]  ←→  MCP Server (远程)
+```
+
+- **适用场景**：远程 MCP Server、第三方服务
+- **HTTP 方法**：
+  - Client → Server：`POST` (发送 JSON-RPC 请求)
+  - Server → Client：Server-Sent Events (流式响应)
+- **认证方式**：Bearer Token、API Key、OAuth
+
+## 四、MCP Proxy 工作原理
+
+### 为什么需要 MCP Proxy？
+
+| 场景 | 问题 | 解决方案 |
+|------|------|----------|
+| 第三方 API 不支持 MCP | REST API 不认识 MCP 协议 | MCP Server 作为协议转换层 |
+| 工具需要聚合 | 多个 API 需要统一暴露 | Proxy 聚合多个 HTTP API |
+| 安全控制 | 不希望 LLM 直接访问外网 | Proxy 添加认证、限流、审计 |
+
+### Proxy 的双重身份
+
+```
+┌──────────────────────────────────────┐
+│           MCP Server (Proxy)          │
+├──────────────────────────────────────┤
+│  对 MCP Host/Client：                 │
+│    • 遵循 MCP 协议                    │
+│    • 暴露 tools/list、tools/call      │
+│    • 通过 Stdio/HTTP 通讯              │
+├──────────────────────────────────────┤
+│  对第三方 HTTP 服务：                  │
+│    • 普通的 HTTP Client               │
+│    • 发送标准 REST 请求                │
+│    • 接收纯 JSON 响应                  │
+└──────────────────────────────────────┘
+```
+
+### 代码示例
+
+```typescript
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+// 1. 创建 MCP Server（对 Host 表现为标准 MCP Server）
+const server = new Server(
+  { name: "http-proxy", version: "1.0.0" },
+  { capabilities: { tools: {} } }
+);
+
+// 2. 定义工具（暴露给 LLM）
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "search_flights",
+      description: "搜索航班",
+      inputSchema: {
+        type: "object",
+        properties: {
+          from: { type: "string" },
+          to: { type: "string" },
+          date: { type: "string" }
+        }
+      }
+    }
+  ]
+}));
+
+// 3. 处理工具调用（对第三方表现为普通 HTTP Client）
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  if (name === "search_flights") {
+    // 发起标准 HTTP 请求（无 MCP 感知）
+    const response = await fetch("https://api.example.com/flights", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(args)
+    });
+    const data = await response.json();
+
+    // 包装为 MCP JSON-RPC 响应格式
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }]
+    };
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+main();
+```
+
+## 五、常见误解澄清
+
+| 误解 | 事实 |
+|------|------|
+| "LLM 直接输出 JSON-RPC" | LLM 输出结构化意图，由 Host 解析后构建 JSON-RPC |
+| "MCP Server 直接调用 HTTP" | 是的，但 Server 同时要遵循 MCP 协议（双重身份） |
+| "工具调用走 HTTP" | 本地场景走 Stdio；远程场景才走 HTTP |
+| "MCP 是一个 HTTP API" | MCP 是协议，HTTP 只是传输层的一种实现 |
+
+## 六、下一章
+
+- **[MCP 入门指南](./index.md)**: 快速上手 MCP 开发
+- **[工具定义最佳实践](./tool-schema.md)**: 如何设计 AI-Friendly 的工具 Schema

--- a/docs/zh/integration/protocols/mcp/index.md
+++ b/docs/zh/integration/protocols/mcp/index.md
@@ -9,8 +9,10 @@
 ## 核心实现概念
 
 MCP 连接两端：
-1.  **宿主 (Client)**: AI 应用程序（例如 Claude Desktop, Cursor 或你的自定义应用）。
+1.  **宿主 (Host)**: AI 应用程序（例如 Claude Desktop, Cursor 或你的自定义应用）。
 2.  **服务器 (Server)**: 工具和资源的提供者（例如你的 Node.js 脚本）。
+
+> 📚 **[深入理解 MCP 架构](./architecture.md)**: 协议分层、Proxy 模式、完整时序图分析。
 
 ### 通信流程
 
@@ -179,5 +181,5 @@ const result = await client.callTool({
 
 ## 下一步
 
-- **[工具调用指南](../tool-calling.md)**: 深入了解函数调用模式。
+- **[深入理解 MCP 架构](./architecture.md)**: 协议分层、Proxy 模式、完整时序图分析。
 - **[MCP Lab 示例](../../../examples/mcp-lab/)**: 在本地运行完整代码。

--- a/docs/zh/integration/protocols/mcp/index.md
+++ b/docs/zh/integration/protocols/mcp/index.md
@@ -1,41 +1,86 @@
-# 模型上下文协议 (MCP) 实现指南
+# 模型上下文协议 (MCP) 入门指南
 
 **模型上下文协议 (MCP)** 是将 AI 模型连接到外部工具和数据的开放标准。
 
-> **动手示例**: 我们在此仓库中提供了一个完整的工作示例。
->
-> 📂 **[查看 MCP Lab 示例](../../../examples/mcp-lab/README.md)**
+> **类比**: MCP 就像 AI 应用的 **USB-C 接口** —— 正如 USB-C 提供了连接电子设备的标准化方式，MCP 提供了将 AI 应用连接到外部系统的标准化方式。
 
-## 核心实现概念
+## MCP 能做什么？
 
-MCP 连接两端：
-1.  **宿主 (Host)**: AI 应用程序（例如 Claude Desktop, Cursor 或你的自定义应用）。
-2.  **服务器 (Server)**: 工具和资源的提供者（例如你的 Node.js 脚本）。
+| 场景 | 示例 |
+|------|------|
+| **个人助手** | AI 可以访问你的 Google Calendar 和 Notion，成为更个性化的助手 |
+| **开发提效** | Claude Code 可以根据 Figma 设计稿生成整个 Web 应用 |
+| **企业数据** | AI 聊天机器人可以连接企业多个数据库，用户用自然语言分析数据 |
+| **创意工具** | AI 模型可以在 Blender 中创建 3D 设计并打印 |
 
-> 📚 **[深入理解 MCP 架构](./architecture.md)**: 协议分层、Proxy 模式、完整时序图分析。
+## MCP 生态支持
 
-### 通信流程
+MCP 是一个开放协议，支持广泛的客户端和服务端：
+
+- **AI 助手**: Claude, ChatGPT
+- **开发工具**: VS Code, Cursor, JetBrains, Zed
+- **更多客户端**: [查看完整列表](https://modelcontextprotocol.io/clients.md)
+
+## 核心概念
+
+MCP 服务器可以提供三种类型的能力：
+
+| 能力类型 | 说明 | AI 控制权 |
+|----------|------|-----------|
+| **Tools (工具)** | AI 可以主动调用的函数 | 模型控制 |
+| **Resources (资源)** | 只读数据，如文件内容、数据库 schema | 应用控制 |
+| **Prompts (提示)** | 预置的指令模板 | 用户控制 |
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    MCP Host (AI 应用)                │
+│  ┌──────────────────────────────────────────────┐  │
+│  │  MCP Client                                   │  │
+│  │  • 管理与 Server 的连接                      │  │
+│  │  • 将 Tools/Resources/Prompts 提供给 AI      │  │
+│  └──────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+                          │
+           ┌──────────────┼──────────────┐
+           ▼              ▼              ▼
+    ┌────────────┐ ┌────────────┐ ┌────────────┐
+    │   Tools    │ │ Resources  │ │  Prompts   │
+    │ (工具)     │ │ (资源)     │ │ (提示模板) │
+    └────────────┘ └────────────┘ └────────────┘
+           │              │              │
+           ▼              ▼              ▼
+    AI 可调用     AI 可读取       AI 可加载
+    (需用户确认)  (只读)         预置模板
+```
+
+## 通信流程
 
 ```mermaid
 sequenceDiagram
-    participant Client as MCP Client (Claude)
-    participant Server as MCP Server (Node.js)
+    participant User as 用户
+    participant Host as MCP Host<br/>(Claude Desktop / Cursor)
+    participant Client as MCP Client<br/>(Host 内置)
+    participant Server as MCP Server<br/>(Node.js / Python)
 
-    Client->>Server: 初始化 (Capabilities)
-    Server-->>Client: 能力 (Tools, Resources)
-    
-    Client->>Server: ListToolsRequest
-    Server-->>Client: 工具列表 (JSON Schema)
-    
-    Note over Client: 用户问: "Add 5 + 3"
-    
-    Client->>Server: CallToolRequest ("add", {a: 5, b: 3})
-    Server-->>Client: CallToolResult ("8")
+    User->>+Host: 输入自然语言 Prompt
+    Host->>+Client: 启动并连接 Server
+    Client->>+Server: initialize (JSON-RPC)
+    Server-->>-Client: 返回 capabilities
+    Client->>+Server: tools/list
+    Server-->>-Client: 返回工具列表 (JSON Schema)
+    Client->>+Server: resources/list
+    Server-->>-Client: 返回资源列表 (URI templates)
+
+    Host->>+Client: 将 system prompt + 工具定义 + 用户输入发给 LLM
+    LLM-->>-Host: 返回回复 + 可选的工具调用意图
+    Host->>+Client: 构建 tools/call 请求
+    Client->>+Server: CallToolRequest (JSON-RPC over Stdio)
+    Server-->>-Client: CallToolResult (JSON-RPC over Stdout)
+    Client->>+Host: 注入结果到 LLM 上下文
+    Host->>+User: 生成并展示最终回复
 ```
 
 ## 分步实现
-
-以下是如何使用 `@modelcontextprotocol/sdk` 构建生产级 MCP 服务器。
 
 ### 1. 服务器设置
 
@@ -48,7 +93,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
-// Initialize Server with name and version
+// 初始化 MCP Server
 const server = new Server(
   {
     name: "my-mcp-server",
@@ -56,7 +101,7 @@ const server = new Server(
   },
   {
     capabilities: {
-      tools: {}, // We are providing tools
+      tools: {}, // 我们提供工具能力
     },
   }
 );
@@ -64,21 +109,21 @@ const server = new Server(
 
 ### 2. 定义工具
 
-你必须定义 **Schema** (AI 看到什么) 和 **Handler** (运行什么代码)。
+你需要定义 **Schema**（AI 看到什么）和 **Handler**（运行什么代码）。
 
 ```typescript
-// Define what tools are available
+// 定义可用的工具
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
       {
         name: "calculate_sum",
-        description: "Add two numbers together",
+        description: "将两个数字相加",
         inputSchema: {
           type: "object",
           properties: {
-            a: { type: "number" },
-            b: { type: "number" },
+            a: { type: "number", description: "第一个数字" },
+            b: { type: "number", description: "第二个数字" },
           },
           required: ["a", "b"],
         },
@@ -91,48 +136,64 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 ### 3. 处理工具调用
 
 ```typescript
-// Execute the logic when AI calls the tool
+// 当 AI 调用工具时执行逻辑
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
   if (name === "calculate_sum") {
-    // Validate inputs with Zod
+    // 使用 Zod 验证输入
     const schema = z.object({ a: z.number(), b: z.number() });
     const { a, b } = schema.parse(args);
-    
+
     return {
       content: [
         {
           type: "text",
-          text: `The sum is ${a + b}`,
+          text: `结果是 ${a + b}`,
         },
       ],
     };
   }
 
-  throw new Error(`Unknown tool: ${name}`);
+  throw new Error(`未知工具: ${name}`);
 });
 ```
 
 ### 4. 连接传输
 
-MCP 通常通过 Stdio（标准输入/输出）用于本地应用，或 SSE（服务器发送事件）用于远程应用。
+MCP 通常通过 **Stdio**（标准输入/输出）用于本地应用，或 **SSE**（服务器发送事件）用于远程应用。
 
 ```typescript
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  // 注意: 写入 stderr，不要写入 stdout！
   console.error("MCP Server running on Stdio");
 }
 
 main();
 ```
 
+## ⚠️ Stdio 日志最佳实践
+
+> **绝对不要**向 `stdout` 写入日志！`stdout` 用于 JSON-RPC 消息，写入会破坏协议。
+
+```typescript
+// ❌ 错误 (stdio 模式下)
+console.log("Processing request");  // 会破坏 JSON-RPC 消息！
+
+// ✅ 正确 (写入 stderr)
+console.error("Processing request");  // 安全，写入错误流
+
+// ✅ 正确 (使用日志库)
+import pino from "pino";
+const logger = pino({ level: "info" });
+logger.info("Processing request");  // 默认写入 stderr
+```
+
 ## 客户端集成模式
 
-你如何使用此服务器？
-
-### 选项 A: Claude Desktop (最简单)
+### 选项 A: Claude Desktop（最简单）
 
 将此添加到你的 `claude_desktop_config.json`：
 
@@ -147,9 +208,9 @@ main();
 }
 ```
 
-### 选项 B: 自定义客户端 (高级)
+### 选项 B: 自定义客户端（高级）
 
-如果你正在构建自己的 AI 应用程序（例如使用 LangChain），你可以充当 MCP 客户端。
+如果你正在构建自己的 AI 应用（例如使用 LangChain），你可以充当 MCP 客户端。
 
 ```typescript
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -160,13 +221,17 @@ const transport = new StdioClientTransport({
   args: ["./my-server.js"],
 });
 
-const client = new Client({ name: "my-client", version: "1.0" }, { capabilities: {} });
+const client = new Client(
+  { name: "my-client", version: "1.0.0" },
+  { capabilities: {} }
+);
+
 await client.connect(transport);
 
-// List available tools
+// 列出可用工具
 const { tools } = await client.listTools();
 
-// Call a tool
+// 调用工具
 const result = await client.callTool({
   name: "calculate_sum",
   arguments: { a: 10, b: 20 },
@@ -175,11 +240,12 @@ const result = await client.callTool({
 
 ## 安全最佳实践
 
-1.  **输入验证**: 始终使用 Zod 验证参数。AI 可能会产生类型的幻觉。
-2.  **路径遍历**: 如果创建文件系统工具，确保用户无法访问 `../../etc/passwd`。
-3.  **只读默认值**: 在允许写入/删除操作之前，先从只读工具开始。
+1. **输入验证**: 始终使用 Zod 验证参数。AI 可能会产生类型幻觉。
+2. **路径遍历**: 如果创建文件系统工具，确保用户无法访问 `../../etc/passwd`。
+3. **只读默认值**: 在允许写入/删除操作之前，先从只读工具开始。
 
 ## 下一步
 
 - **[深入理解 MCP 架构](./architecture.md)**: 协议分层、Proxy 模式、完整时序图分析。
 - **[MCP Lab 示例](../../../examples/mcp-lab/)**: 在本地运行完整代码。
+- **[官方构建服务器指南](https://modelcontextprotocol.io/docs/develop/build-server)**: Python/Node.js 实战教程。


### PR DESCRIPTION
## 优化内容

### docs/zh/integration/protocols/mcp/index.md
- 新增 USB-C 接口类比（官方文档核心比喻）
- 新增 MCP 能做什么（4个真实场景）
- 新增 MCP 生态支持（Claude/ChatGPT/VS Code/Cursor）
- 新增三种能力类型（Tools/Resources/Prompts 表格对比）
- 新增 Stdio 日志最佳实践（⚠️ 禁止写 stdout）
- 优化通信时序图（增加 User/Host/Client 三层）
- 更新下一步指引（链接官方构建指南）

### docs/zh/integration/protocols/mcp/architecture.md
- 新增协议分层（Transport Layer + Data Layer）
- 新增 MCP Proxy 完整时序图（修正 LLM→JSON-RPC 流程）
- 新增 Transport 机制对比（Stdio vs Streamable HTTP）
- 新增 Proxy 双重身份原理
- 新增常见误解澄清