### PR TITLE
docs(grok): add Grok Build documentation set in EN and ZH (Diataxis)

### DIFF
--- a/.claude/skills/doc-research/references/grok.md
+++ b/.claude/skills/doc-research/references/grok.md
@@ -35,7 +35,7 @@
 
 - 发布公告 `https://x.ai/news/grok-build-cli`（2026-05-25）原文：「Today we're launching an early beta of Grok Build」「Available now to all SuperGrok and X Premium Plus subscribers.」
 - `https://x.ai/build` 当前文案：「Available to try for Free」，且横幅为「Meet Grok 4.6 • Now powering Grok Build」。
-- npm `@xai-official/grok` 至 2026-08-16 已发布 552 个版本（首个版本 2025-10-22），近期 1.0.0(08-07) → 1.0.1/1.0.2(08-11) → 1.0.3(08-12) → 1.0.4(08-13) → 1.0.5 alpha(08-16)。
+- npm `@xai-official/grok` 的 `time` 字段从 2025-10-22 起累计 552 个历史版本号（含已从 `versions` 下架的）；2026-08-18 抽查时 `versions` 里仍列出 191 个可安装版本。`dist-tags.latest` 与 `alpha` 均为 `1.0.5`（发布时间 2026-08-16T00:25:35Z）。近期 `latest` 轨迹：1.0.0 → 1.0.1 / 1.0.2 → 1.0.3（08-12）→ 1.0.4（08-13）→ 1.0.5（08-16）。不要把 552 写成「当前可安装版本数」。
 
 **结论五：文档分两套站点，写作时不要混引。**
 
@@ -52,8 +52,9 @@
 
 - 工具名：Grok Build（CLI 可执行文件 `grok`）
 - 官方文档根地址：<https://docs.x.ai/build/overview>
-- 发版节奏：约 1-3 天一个版本（npm 552 个版本 / 2025-10-22 起），属于本站收录工具里最快的一档
-- 当前覆盖版本：v1.0.4（2026-08-13，npm `latest`；`https://x.ai/build/changelog` 头部显示 v1.0.3 / Aug 12, 2026）
+- 发版节奏：npm `latest` 在 2026-08-12 / 08-13 / 08-16 连续换了 1.0.3 → 1.0.4 → 1.0.5。不要写死「每 1–3 天一版」——那是对近期轨迹的概括，不是官方 SLA。
+- 当前覆盖版本：v1.0.5（2026-08-16，npm `latest` 与 `alpha`；`https://x.ai/build/changelog` 头部在 2026-08-18 仍显示 v1.0.3 / Aug 12, 2026）
+- 官方两处对 subagent 默认开关说法不一致，文档里必须并列引用、禁止猜哪个赢：`/build/features/subagents` 原文 “Enabled by default when the setting is unset.”；`/build/settings/reference` 里 `GROK_SUBAGENTS` 默认值是 `0`。
 
 ## 文档文件结构（Diataxis 四象限）
 

--- a/.claude/skills/doc-research/references/grok.md
+++ b/.claude/skills/doc-research/references/grok.md
@@ -48,6 +48,14 @@
 - `grok-4.6`：`/developers/models` 原文「For everything else, including code, use Grok 4.6.」当前驱动 Grok Build。
 - `grok-build-0.1`：`/developers/release-notes` 原文「xAI's coding model, trained specifically for agentic coding workflows.」
 
+**结论七：消费端还有独立形态，index 必须画决策树，只有 Grok Bot 够独立密度才立页。**（复核 2026-08-18，仅官方）
+
+- **Grok 聊天**：`docs.x.ai/grok/overview`、`x.ai/grok`、`grok.com`。对话 / 搜索 / 语音 / 上传文件。对位 Claude.ai。
+- **Imagine**：消费端 `grok.com/imagine` + `x.ai/news/grok-imagine-image-2`；API `docs.x.ai/developers/model-capabilities/imagine`。生图生视频。对位 Claude Design（创作面）。**不立页**——本站读者要的是编程工具，密度不够单独成章。
+- **Build Mode ≠ Grok Build**：`x.ai/news/grok-build-mode`、`x.ai/grok/build-mode`。grok.com 模式切换选 Build；Early Beta 仅 SuperGrok Heavy；发布到 **grok.me** 或自定义域名。grok.me 是发布域名，不是产品。**不立页**——官方只有营销页 + 一篇 news。
+- **Grok Bot**：`docs.x.ai/grok-bot/*`（overview / get-started / computer-and-apps / approvals / faq / teams）、`x.ai/bot`、`x.ai/news/introducing-grok-bot`（2026-08-11 beta）。持久云电脑同事；资格 SuperGrok Heavy / Cursor Ultra / Cursor Teams Premium；认证走 **Cursor**。对位 Cowork。**立页** `grok-bot.md`。
+- **禁止当事实写**：官方 VS Code 插件、「Grok Code / Grok CLI」产品名、三方博客的 Grok 4.3 / 200 万 token / Arena Mode / 8 路并行。账号不是一口池子（Grok Build 用 SuperGrok 或 API key，Grok Bot 用 Cursor 账号）。
+
 ## 基本信息
 
 - 工具名：Grok Build（CLI 可执行文件 `grok`）
@@ -58,32 +66,38 @@
 
 ## 文档文件结构（Diataxis 四象限）
 
-最终采用 5 文件结构。判断依据不是「和 Claude 同构」，而是实际表面积：CLI 有约 20 个子命令 + 约 25 个全局 flag + 约 55 个 slash command + 约 40 个 `[ui]` 配置键 + 约 35 个环境变量，Reference 内容独立成章是必须的；同时 hooks/MCP/skills/sandbox 等场景化配方也足够多，How-to 单独成章。
+最终采用 6 文件结构。Grok Build 仍是 5 文件 Diataxis；2026-08-18 官方确认 Grok Bot 有独立文档树（`docs.x.ai/grok-bot/*`），才加一张产品地图。Imagine / Build Mode / grok.me 只进 index 决策树和 glossary，不立页。
 
 ```
 docs/zh/products/ai-coding/grok/
-├── index.md              # 🗺️ 学习地图（导航 + 功能速查 + 模型参考）
+├── index.md              # 🗺️ 学习地图（家族决策树 + Grok Build 功能速查 + 模型参考）
 ├── grok-cli.md           # 📘 Tutorial+How-to — 安装、认证、TUI、headless、ACP、核心功能怎么用
 ├── grok-cookbook.md      # 🔧 How-to — 场景化配方（Claude Code 迁移、CI、hooks、MCP、skills、subagents、worktrees、sandbox）
 ├── grok-cheatsheet.md    # 📐 Reference — 子命令/flag/slash/配置键/环境变量/模型价格 + 高质量信息源
-└── grok-glossary.md      # 📖 Explanation — 概念是什么/为什么（Grok Build vs Grok vs xAI API、TUI/headless/ACP、权限模式 vs sandbox 等）
+├── grok-glossary.md      # 📖 Explanation — 概念是什么/为什么（家族撞名、TUI/headless/ACP、权限模式 vs sandbox 等）
+└── grok-bot.md           # 🗺️ 周边产品地图 — 云电脑同事（只写官方页，对位 Cowork）
 ```
 
 每个文件的职责边界：
 
 | 文件 | 象限 | 写什么 | 不写什么 |
 |------|------|--------|----------|
-| `index.md` | Tutorial 导航 + Reference 速查 | 跨页面学习地图、功能速查表、模型选择 | 具体操作步骤 |
+| `index.md` | Tutorial 导航 + Reference 速查 | 家族决策树、Grok Build 功能速查表、模型选择 | 具体操作步骤 |
 | `grok-cli.md` | Tutorial + How-to | 安装、认证、TUI 交互、headless、ACP、各功能怎么用 | 完整参数清单（→ cheatsheet）、概念定义（→ glossary） |
 | `grok-cookbook.md` | How-to | 场景化配方与避坑 | 基础安装（→ cli）、概念定义（→ glossary） |
 | `grok-cheatsheet.md` | Reference | 命令/flag/配置键/环境变量/价格表/信息源 | 概念解释、学习路径 |
 | `grok-glossary.md` | Explanation | 是什么、为什么、概念之间的关系 | 参数清单（→ cheatsheet）、操作步骤 |
+| `grok-bot.md` | 周边产品地图 | Grok Bot 是什么、资格、共享电脑、官方链接 | 臆造配额；Grok Build 操作步骤 |
 
 跨页顺序（两轴法）：`index` → `grok-cli` → `grok-cookbook` → `grok-cheatsheet` → `grok-glossary`。Axis A（概念依赖）允许 glossary 更早，但 Axis B（读者复杂度）把它压到最后——前端工程师读者的第一诉求是「装上能跑」，概念辨析是回查内容。
 
 ## 监控页面（What's New 驱动更新的信息源，日常追踪用的最小子集）
 
 - What's New / Changelog（CLI）：<https://x.ai/build/changelog>
+- Grok Bot 文档树：<https://docs.x.ai/grok-bot/overview>
+- Grok 消费端总览：<https://docs.x.ai/grok/overview>
+- Build Mode（不要和 CLI 混）：<https://x.ai/grok/build-mode>
+- Imagine API：<https://docs.x.ai/developers/model-capabilities/imagine>
 - Release Notes（API/模型）：<https://docs.x.ai/developers/release-notes>
 - 配置 / Settings 参考：<https://docs.x.ai/build/settings/reference>
 - CLI Reference：<https://docs.x.ai/build/cli/reference>

--- a/.claude/skills/doc-research/references/grok.md
+++ b/.claude/skills/doc-research/references/grok.md
@@ -1,0 +1,110 @@
+# Grok 维护参考
+
+> 通用维护流程见 [`maintenance-workflow.md`](./maintenance-workflow.md)；高质量数据源清单发布在 `docs/zh/products/ai-coding/grok/grok-cheatsheet.md` 的「高质量信息源」章节（方法论见 [`sources/_template.md`](./sources/_template.md)）。文档架构的 Diataxis 四象限设计见 [`documentation-architecture.md`](./documentation-architecture.md)。
+
+## 产品形态调研结论（写教程前必须先有这一节）
+
+调研时间：2026-08-18。以下每条都来自一手官方来源，来源标在括号里。
+
+**结论一：xAI 有第一方 agentic 编程 CLI，官方产品名是 Grok Build，不叫 "Grok Code"。**
+
+- `https://docs.x.ai/build/overview` 原文：「**Grok Build** is a powerful and extensible coding agent. Use it via an interactive TUI, headlessly in scripts or bots, or through the Agent Client Protocol (ACP) in other apps.」
+- 开源仓库 `github.com/xai-org/grok-build` README 原文：「**Grok Build** is SpaceXAI's terminal-based AI coding agent. It runs as a full-screen TUI that understands your codebase, edits files, executes shell commands, searches the web, and manages long-running tasks — interactively, headlessly for scripting/CI, or embedded in editors via the Agent Client Protocol (ACP).」
+- 可执行文件名是 `grok`（不是 `grok-build`）。仓库 README 说明：编译产物名为 `xai-grok-pager`，「official installs ship it as `grok`」。
+
+**结论二：产品形态是 CLI/TUI，不是 IDE 插件，也不是「仅 API」。**
+
+三种使用面（来自 `/build/overview` 与 `/build/cli/reference`）：
+
+| 使用面 | 入口 | 典型场景 |
+|--------|------|----------|
+| 交互式 TUI | `grok`（无参数） | 日常开发 |
+| Headless | `grok -p "<prompt>"` | 脚本、CI |
+| ACP | `grok agent stdio` | 被编辑器/编排器嵌入（JSON-RPC over stdin/stdout） |
+
+编辑器集成是通过 ACP 由第三方宿主实现的，xAI 自己没有发布 VS Code/JetBrains 插件（`/build/cli/terminal-support` 只讨论 VS Code / Cursor / Windsurf / Zed 内置终端里的按键差异，没有插件条目）。
+
+**结论三：适合本站「前端工程师 AI 编程工具」定位。**
+
+依据：
+- 安装门槛低，有 npm 通道：`npm install -g @xai-official/grok`（`/build/enterprise` 原文把它列为 curl 安装的替代方案；npm registry 确认 `bin.grok`、`engines.node >= 20`、Apache-2.0）。
+- 能力面与 Claude Code 同级：plan mode、subagents、skills、hooks、MCP、AGENTS.md 项目规则、memory、sandbox、worktrees、background tasks、dashboard、theming（`https://x.ai/build` 的 18 项功能网格 + `/build/*` 各专题页）。
+- 官方主打 Claude Code 兼容，迁移成本极低（`/build/skills-plugins-marketplaces` 原文：「Grok is fully compatible with Claude Code with zero configuration needed.」）：读 `CLAUDE.md` / `.claude/settings.json` / `~/.claude.json` / `.cursor/*`，接受 Claude Code 的 flag 别名，`grok import` 与 `/import-claude` 可导入 Claude Code 会话。
+
+**结论四：处于 beta 阶段，迭代极快，写文档必须避免绑定版本号。**
+
+- 发布公告 `https://x.ai/news/grok-build-cli`（2026-05-25）原文：「Today we're launching an early beta of Grok Build」「Available now to all SuperGrok and X Premium Plus subscribers.」
+- `https://x.ai/build` 当前文案：「Available to try for Free」，且横幅为「Meet Grok 4.6 • Now powering Grok Build」。
+- npm `@xai-official/grok` 至 2026-08-16 已发布 552 个版本（首个版本 2025-10-22），近期 1.0.0(08-07) → 1.0.1/1.0.2(08-11) → 1.0.3(08-12) → 1.0.4(08-13) → 1.0.5 alpha(08-16)。
+
+**结论五：文档分两套站点，写作时不要混引。**
+
+- `https://docs.x.ai/build/*` = Grok Build CLI（TUI、配置、hooks、MCP、sandbox、企业策略）
+- `https://docs.x.ai/developers/*` = xAI API（模型、价格、限流、SDK、release notes）
+- `https://x.ai/build/changelog` = CLI 的版本变更日志（比 docs 更新更快，出现过 docs 里还没有的子命令，如 `grok du`、`grok trace`）
+
+**结论六：编程相关模型有两个，不要写错 slug。**
+
+- `grok-4.6`：`/developers/models` 原文「For everything else, including code, use Grok 4.6.」当前驱动 Grok Build。
+- `grok-build-0.1`：`/developers/release-notes` 原文「xAI's coding model, trained specifically for agentic coding workflows.」
+
+## 基本信息
+
+- 工具名：Grok Build（CLI 可执行文件 `grok`）
+- 官方文档根地址：<https://docs.x.ai/build/overview>
+- 发版节奏：约 1-3 天一个版本（npm 552 个版本 / 2025-10-22 起），属于本站收录工具里最快的一档
+- 当前覆盖版本：v1.0.4（2026-08-13，npm `latest`；`https://x.ai/build/changelog` 头部显示 v1.0.3 / Aug 12, 2026）
+
+## 文档文件结构（Diataxis 四象限）
+
+最终采用 5 文件结构。判断依据不是「和 Claude 同构」，而是实际表面积：CLI 有约 20 个子命令 + 约 25 个全局 flag + 约 55 个 slash command + 约 40 个 `[ui]` 配置键 + 约 35 个环境变量，Reference 内容独立成章是必须的；同时 hooks/MCP/skills/sandbox 等场景化配方也足够多，How-to 单独成章。
+
+```
+docs/zh/products/ai-coding/grok/
+├── index.md              # 🗺️ 学习地图（导航 + 功能速查 + 模型参考）
+├── grok-cli.md           # 📘 Tutorial+How-to — 安装、认证、TUI、headless、ACP、核心功能怎么用
+├── grok-cookbook.md      # 🔧 How-to — 场景化配方（Claude Code 迁移、CI、hooks、MCP、skills、subagents、worktrees、sandbox）
+├── grok-cheatsheet.md    # 📐 Reference — 子命令/flag/slash/配置键/环境变量/模型价格 + 高质量信息源
+└── grok-glossary.md      # 📖 Explanation — 概念是什么/为什么（Grok Build vs Grok vs xAI API、TUI/headless/ACP、权限模式 vs sandbox 等）
+```
+
+每个文件的职责边界：
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | Tutorial 导航 + Reference 速查 | 跨页面学习地图、功能速查表、模型选择 | 具体操作步骤 |
+| `grok-cli.md` | Tutorial + How-to | 安装、认证、TUI 交互、headless、ACP、各功能怎么用 | 完整参数清单（→ cheatsheet）、概念定义（→ glossary） |
+| `grok-cookbook.md` | How-to | 场景化配方与避坑 | 基础安装（→ cli）、概念定义（→ glossary） |
+| `grok-cheatsheet.md` | Reference | 命令/flag/配置键/环境变量/价格表/信息源 | 概念解释、学习路径 |
+| `grok-glossary.md` | Explanation | 是什么、为什么、概念之间的关系 | 参数清单（→ cheatsheet）、操作步骤 |
+
+跨页顺序（两轴法）：`index` → `grok-cli` → `grok-cookbook` → `grok-cheatsheet` → `grok-glossary`。Axis A（概念依赖）允许 glossary 更早，但 Axis B（读者复杂度）把它压到最后——前端工程师读者的第一诉求是「装上能跑」，概念辨析是回查内容。
+
+## 监控页面（What's New 驱动更新的信息源，日常追踪用的最小子集）
+
+- What's New / Changelog（CLI）：<https://x.ai/build/changelog>
+- Release Notes（API/模型）：<https://docs.x.ai/developers/release-notes>
+- 配置 / Settings 参考：<https://docs.x.ai/build/settings/reference>
+- CLI Reference：<https://docs.x.ai/build/cli/reference>
+- 模型与价格：<https://docs.x.ai/developers/models>、<https://docs.x.ai/developers/pricing>
+- GitHub 源码（周期性从 monorepo 同步）：<https://github.com/xai-org/grok-build>
+- npm 版本节奏：<https://www.npmjs.com/package/@xai-official/grok>
+
+## Git 提交 scope
+
+```
+docs(grok): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+1. **`x.ai` 有 Cloudflare 防护，`curl` 和 WebFetch 一律 403**（`status.x.ai`、`console.x.ai` 同样 403）。读 `x.ai/*` 页面只能用 `mcp__web-reader__webReader`；`docs.x.ai` 反而可以直接 curl（200）。
+2. **`https://docs.x.ai/llms.txt` 是整站全文镜像**（约 1.4 MB / 38,745 行），一次抓取即可离线检索，比逐页抓省得多。用 `grep -n "^==="` 取章节索引。注意：这类大文件要放在仓库外（如 `/tmp`），避免误提交。
+3. **产品名不要写成 "Grok Code" / "Grok CLI"**。官方名是 Grok Build，可执行文件是 `grok`，仓库是 `grok-build`，营销页是 `x.ai/build`（`x.ai/cli` 会跳到同一页）。
+4. **`x.ai/build/changelog` 比 docs 更新更快**，出现过 docs 的 CLI reference 里还没有的子命令（`grok du`、`grok trace`）。写 Reference 时以 docs 为准，changelog 独有的条目要标注出处。
+5. **权限模式命名有两套**：TUI 里是 Ask / Auto / Always-approve（`Shift+Tab` 循环），headless/企业策略里出现 Claude Code 风格的 `--permission-mode dontAsk` / `acceptEdits`。教程里必须说明这是两套表述，不要混用。
+6. **权限规则优先级是 deny > ask > allow**（`/build/settings/reference` 原文），和「后写覆盖先写」的直觉相反。
+7. **project 级 `.grok/config.toml` 只生效 `[mcp_servers]`、`[plugins]`、`[permission]` 三个段**，其余键必须写在用户级 `~/.grok/config.toml`。这是最容易写错的一条。
+8. **`MCP_TIMEOUT` 是毫秒，`GROK_MCP_STARTUP_TIMEOUT_SECS` 是秒**，官方文档明确前者是为兼容 Claude Code 而保留的。
+9. **`GROK_WEB_FETCH` 默认为 `0`（关闭）**，官方给的理由是安全。写教程时不要假设 web fetch 开箱可用。
+10. **`xai-org/grok-build` 不接受外部 PR**（README 原文「External contributions are not accepted.」），不要在文档里引导读者提 PR，反馈渠道是 TUI 里的 `/feedback`。

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -345,6 +345,15 @@ export default withMermaid(defineConfig({
                                  ]
                               },
                               { text: 'Gemini CLI', link: '/products/ai-coding/gemini-cli' },
+                              {
+                                 text: 'Grok', link: '/products/ai-coding/grok/', items: [
+                                    { text: '🗺️ Learning Map', link: '/products/ai-coding/grok/' },
+                                    { text: 'Grok Build Tutorial', link: '/products/ai-coding/grok/grok-cli' },
+                                    { text: 'Cookbook', link: '/products/ai-coding/grok/grok-cookbook' },
+                                    { text: 'Cheatsheet', link: '/products/ai-coding/grok/grok-cheatsheet' },
+                                    { text: 'Glossary', link: '/products/ai-coding/grok/grok-glossary' },
+                                 ]
+                              },
                               { text: 'Pi Agent', link: '/products/ai-coding/pi-agent' },
                               { text: 'Other Tools', link: '/products/ai-coding/othertools' },
                               {
@@ -845,6 +854,15 @@ export default withMermaid(defineConfig({
                                     { text: 'Canvas', link: '/zh/products/ai-coding/gemini/canvas' },
                                     { text: 'Code Assist', link: '/zh/products/ai-coding/gemini/code-assist' },
                                     { text: 'Jules', link: '/zh/products/ai-coding/gemini/jules' },
+                                 ]
+                              },
+                              {
+                                 text: 'Grok', link: '/zh/products/ai-coding/grok/', items: [
+                                    { text: '🗺️ 学习地图', link: '/zh/products/ai-coding/grok/' },
+                                    { text: 'Grok Build 教程', link: '/zh/products/ai-coding/grok/grok-cli' },
+                                    { text: '实战 Cookbook', link: '/zh/products/ai-coding/grok/grok-cookbook' },
+                                    { text: '速查表', link: '/zh/products/ai-coding/grok/grok-cheatsheet' },
+                                    { text: '术语表', link: '/zh/products/ai-coding/grok/grok-glossary' },
                                  ]
                               },
                               { text: 'Vibe Coding 报告', link: '/zh/products/ai-coding/reporter' },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -360,7 +360,12 @@ export default withMermaid(defineConfig({
                                        text: 'More Products',
                                        collapsed: true,
                                        items: [
+                                          { text: 'Grok Chat', link: '/products/ai-coding/grok/grok-chat' },
+                                          { text: 'Imagine', link: '/products/ai-coding/grok/grok-imagine' },
+                                          { text: 'Voice', link: '/products/ai-coding/grok/grok-voice' },
+                                          { text: 'Connectors', link: '/products/ai-coding/grok/grok-connectors' },
                                           { text: 'Grok Bot', link: '/products/ai-coding/grok/grok-bot' },
+                                          { text: 'Business & Enterprise', link: '/products/ai-coding/grok/grok-business' },
                                        ]
                                     },
                                     {
@@ -890,7 +895,12 @@ export default withMermaid(defineConfig({
                                        text: '更多产品',
                                        collapsed: true,
                                        items: [
+                                          { text: 'Grok 聊天', link: '/zh/products/ai-coding/grok/grok-chat' },
+                                          { text: 'Imagine', link: '/zh/products/ai-coding/grok/grok-imagine' },
+                                          { text: 'Voice', link: '/zh/products/ai-coding/grok/grok-voice' },
+                                          { text: 'Connectors', link: '/zh/products/ai-coding/grok/grok-connectors' },
                                           { text: 'Grok Bot', link: '/zh/products/ai-coding/grok/grok-bot' },
+                                          { text: 'Business & Enterprise', link: '/zh/products/ai-coding/grok/grok-business' },
                                        ]
                                     },
                                     {

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -348,10 +348,29 @@ export default withMermaid(defineConfig({
                               {
                                  text: 'Grok', link: '/products/ai-coding/grok/', items: [
                                     { text: '🗺️ Learning Map', link: '/products/ai-coding/grok/' },
-                                    { text: 'Grok Build Tutorial', link: '/products/ai-coding/grok/grok-cli' },
-                                    { text: 'Cookbook', link: '/products/ai-coding/grok/grok-cookbook' },
-                                    { text: 'Cheatsheet', link: '/products/ai-coding/grok/grok-cheatsheet' },
-                                    { text: 'Glossary', link: '/products/ai-coding/grok/grok-glossary' },
+                                    {
+                                       text: 'Core Products',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Grok Build Tutorial', link: '/products/ai-coding/grok/grok-cli' },
+                                          { text: 'Cookbook', link: '/products/ai-coding/grok/grok-cookbook' },
+                                       ]
+                                    },
+                                    {
+                                       text: 'More Products',
+                                       collapsed: true,
+                                       items: [
+                                          { text: 'Grok Bot', link: '/products/ai-coding/grok/grok-bot' },
+                                       ]
+                                    },
+                                    {
+                                       text: 'Reference',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Cheatsheet', link: '/products/ai-coding/grok/grok-cheatsheet' },
+                                          { text: 'Glossary', link: '/products/ai-coding/grok/grok-glossary' },
+                                       ]
+                                    },
                                  ]
                               },
                               { text: 'Pi Agent', link: '/products/ai-coding/pi-agent' },
@@ -859,10 +878,29 @@ export default withMermaid(defineConfig({
                               {
                                  text: 'Grok', link: '/zh/products/ai-coding/grok/', items: [
                                     { text: '🗺️ 学习地图', link: '/zh/products/ai-coding/grok/' },
-                                    { text: 'Grok Build 教程', link: '/zh/products/ai-coding/grok/grok-cli' },
-                                    { text: '实战 Cookbook', link: '/zh/products/ai-coding/grok/grok-cookbook' },
-                                    { text: '速查表', link: '/zh/products/ai-coding/grok/grok-cheatsheet' },
-                                    { text: '术语表', link: '/zh/products/ai-coding/grok/grok-glossary' },
+                                    {
+                                       text: '核心产品',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Grok Build 教程', link: '/zh/products/ai-coding/grok/grok-cli' },
+                                          { text: '实战 Cookbook', link: '/zh/products/ai-coding/grok/grok-cookbook' },
+                                       ]
+                                    },
+                                    {
+                                       text: '更多产品',
+                                       collapsed: true,
+                                       items: [
+                                          { text: 'Grok Bot', link: '/zh/products/ai-coding/grok/grok-bot' },
+                                       ]
+                                    },
+                                    {
+                                       text: '速查与参考',
+                                       collapsed: false,
+                                       items: [
+                                          { text: '速查表', link: '/zh/products/ai-coding/grok/grok-cheatsheet' },
+                                          { text: '术语表', link: '/zh/products/ai-coding/grok/grok-glossary' },
+                                       ]
+                                    },
                                  ]
                               },
                               { text: 'Vibe Coding 报告', link: '/zh/products/ai-coding/reporter' },

--- a/docs/products/ai-coding/grok/grok-bot.md
+++ b/docs/products/ai-coding/grok/grok-bot.md
@@ -1,0 +1,135 @@
+# Grok Bot
+
+> **Grok Bot** is xAI's always-on teammate product. Official definition ([docs.x.ai/grok-bot/overview](https://docs.x.ai/grok-bot/overview)):
+> "Bots are AI teammates you can give real work to. Bots can sign and use apps and websites just like you do on a persistent cloud computer."
+>
+> This page is a product map sourced only from [docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview), [x.ai/bot](https://x.ai/bot), and [x.ai/news/introducing-grok-bot](https://x.ai/news/introducing-grok-bot). It is **not** the Grok Build CLI tutorial — that is [grok-cli.md](./grok-cli.md).
+
+## Goals and non-goals
+
+**Goals:** tell Grok Bot apart from Grok Build / grok.com chat / Imagine / Build Mode, and point at the official docs for setup, the shared computer, and approvals.
+
+**Non-goals:** a second copy of the official get-started walkthrough, invented quotas, or third-party claims that do not appear on docs.x.ai / x.ai / grok.com.
+
+## What it is
+
+In the docs and in the app, **a Bot = a single persistent, named agent** ([overview](https://docs.x.ai/grok-bot/overview)). You message it like a teammate. It keeps working on a cloud computer after you close the laptop ([faq](https://docs.x.ai/grok-bot/faq)).
+
+Official differences from a chat assistant ([overview](https://docs.x.ai/grok-bot/overview), [faq](https://docs.x.ai/grok-bot/faq)):
+
+- Each Bot runs on a **persistent cloud VM** with a browser, filesystem, and terminal.
+- It can use connectors / MCP where available, and computer use for apps and websites without a clean API.
+- Multiple Bots share **one user-scoped computer** and can run in parallel, message each other, and hand off work.
+- It can learn a workflow from a live demonstration and persist it as a **routine**.
+- Named Bots keep memory, files, browser sessions, and preferences across turns.
+
+| | Grok (chat) | Grok Build | Grok Bot |
+|---|-------------|------------|----------|
+| Job | Conversation, search, voice, Imagine | Edit a real local / CI repo | Finish work inside apps and websites |
+| Computer | None of its own | Your machine (optional sandbox) | One persistent **cloud** computer per user |
+| Stops when the laptop closes? | Yes (it is a chat) | Yes (the process is local) | No — cloud work continues |
+| Official entry | [grok.com](https://grok.com) | `grok` | Desktop + iOS apps ([x.ai/bot](https://x.ai/bot)) |
+
+The launch post ([2026-08-11](https://x.ai/news/introducing-grok-bot)) says Grok Bot is **in beta**.
+
+## Who can use it
+
+[get-started](https://docs.x.ai/grok-bot/get-started) lists eligible plans:
+
+- SuperGrok Heavy
+- Cursor Ultra
+- Cursor Teams Premium (sign in with your Cursor account)
+
+[x.ai/bot](https://x.ai/bot) adds: "Already on Cursor Ultra or SuperGrok Heavy? Grok Bot is included." Enterprise access is on a waitlist in the [launch post](https://x.ai/news/introducing-grok-bot); the [faq](https://docs.x.ai/grok-bot/faq) says team / enterprise rollout varies by organization.
+
+**Authentication is Cursor**, not `grok login`. Grok Bot requires cloud data storage; Legacy Privacy Mode is not supported ([get-started](https://docs.x.ai/grok-bot/get-started), [faq](https://docs.x.ai/grok-bot/faq)).
+
+### Platforms ([faq](https://docs.x.ai/grok-bot/faq))
+
+| Supported at launch | Not supported at launch |
+|---------------------|-------------------------|
+| macOS (Apple silicon and Intel) | Linux desktop |
+| Windows (x64 and Arm64) | Android |
+| iPhone on iOS 18 or later | iPad |
+
+The same Bots and conversations sync across signed-in devices.
+
+## The shared cloud computer
+
+Every Bot on the account uses **the same** computer ([computer-and-apps](https://docs.x.ai/grok-bot/computer-and-apps)):
+
+- Browser cookies and signed-in sessions are shared.
+- Files are visible to every Bot.
+- Command-line credentials are shared.
+- One Bot can continue from work another Bot saved.
+
+The computer is assigned to the **user account**, not to an individual Bot. Official warning, twice: **do not use separate Bots as a security boundary**.
+
+Each Bot gets its own screen on that shared computer, so several Bots can use browser and desktop tools in parallel. One Bot can run only one computer-use task on its screen at a time. The screens are work surfaces, **not** separate security boundaries.
+
+Durable project files go in the shared workspace at `/workspace`. Temporary directories, manually installed packages, and uncommitted application state are treated as replaceable.
+
+The cloud computer is **separate** from the Mac or Windows machine in front of you. Local-command policy lives under **Settings → General → Agent → Execution on Local Computer**; the default is **Ask every time** ([approvals](https://docs.x.ai/grok-bot/approvals-security-and-privacy)). Those settings do not stop the Bot from using its cloud computer.
+
+## Get started (official sequence)
+
+Follow [get-started](https://docs.x.ai/grok-bot/get-started). Condensed:
+
+1. Install the desktop app from the [Grok Bot access page](https://x.ai/bot) (macOS: drag to Applications; Windows: run the installer).
+2. Sign in with your Cursor account in the browser window the app opens.
+3. Create a Bot: a short name, one primary job, and a description of how it should work. Official advice: focused Bots beat one catch-all Bot.
+4. Give a first task that names the outcome, sources, constraints, deliverable, and review point.
+5. When a site needs a password, passkey, 2FA, or CAPTCHA, open **Agent Computer**, take over, complete only that step yourself, then return control. **Do not paste passwords or one-time codes into chat.**
+
+Connectors appear as **Plugins** in the current app: **Settings → Plugins**. Type `@` to attach a connector; type `/` to reference a saved skill. Prefer a connector when one exists; use the browser for services without one.
+
+## Skills vs routines
+
+Official split ([faq](https://docs.x.ai/grok-bot/faq)):
+
+- A **skill** describes how to perform a task.
+- A **routine** assigns a workflow to one Bot and tells it when to run — on a schedule or, where supported, after an event.
+
+Test the skill on a real one-time task before turning it into a routine.
+
+**Teach a task** (when available) records one browser workflow from the computer view, limited to ten minutes. The rollout may be gradual.
+
+Deleting a Bot removes its profile, conversation, and routines. Files and logins on the shared computer may remain.
+
+## Approvals you should set
+
+[approvals-security-and-privacy](https://docs.x.ai/grok-bot/approvals-security-and-privacy) tells you to put standing boundaries in the Bot description and to keep these behind approval:
+
+- Sending messages or invitations
+- Publishing content
+- Purchases and financial transfers
+- Deleting or overwriting data
+- Changing permissions
+- Production changes
+- Accepting legal terms
+
+When Auto Review is available: **Require Approval** always wins over **Always Allow**. Do not write a rule like "allow everything in the browser."
+
+## Cost (only what official pages say)
+
+The [faq](https://docs.x.ai/grok-bot/faq) says availability and billing depend on the account and plan, Grok Bot subscriptions include weekly usage, and eligible accounts can add on-demand usage billed from model and token cost. [x.ai/bot](https://x.ai/bot) currently lists Cursor Ultra at $200 / month and Cursor Premium Teams at $120 / seat / month, with SuperGrok Heavy / Cursor Ultra already including Grok Bot. This page does **not** invent a SuperGrok Heavy price or a token quota.
+
+## Official docs
+
+| Page | Use |
+|------|-----|
+| [docs.x.ai/grok-bot/overview](https://docs.x.ai/grok-bot/overview) | What a Bot is |
+| [docs.x.ai/grok-bot/get-started](https://docs.x.ai/grok-bot/get-started) | Install, sign-in, first task |
+| [docs.x.ai/grok-bot/files-and-results](https://docs.x.ai/grok-bot/files-and-results) | Attach files and review results |
+| [docs.x.ai/grok-bot/computer-and-apps](https://docs.x.ai/grok-bot/computer-and-apps) | Shared computer, connectors, `/workspace` |
+| [docs.x.ai/grok-bot/approvals-security-and-privacy](https://docs.x.ai/grok-bot/approvals-security-and-privacy) | Approvals, local computer, privacy |
+| [docs.x.ai/grok-bot/faq](https://docs.x.ai/grok-bot/faq) | Platforms, memory, cost, delete |
+| [docs.x.ai/grok-bot/teams-and-enterprises](https://docs.x.ai/grok-bot/teams-and-enterprises) | Per-member computer, org controls |
+| [x.ai/bot](https://x.ai/bot) | Marketing + downloads |
+| [x.ai/news/introducing-grok-bot](https://x.ai/news/introducing-grok-bot) | Launch (2026-08-11, beta) |
+
+## Related pages
+
+- [Grok learning map](./index.md) — family decision tree
+- [Grok Build tutorial](./grok-cli.md) — the terminal coding agent
+- [Glossary](./grok-glossary.md) — name collisions

--- a/docs/products/ai-coding/grok/grok-business.md
+++ b/docs/products/ai-coding/grok/grok-business.md
@@ -1,0 +1,118 @@
+# Grok Business & Enterprise
+
+> Official positioning ([docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide)):
+> "**Grok Business provides dedicated workspaces for personal and team use, with enhanced privacy and sharing controls.**"
+>
+> [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) lists **Business & Enterprise** as a first-class next step: "team workspaces, licenses, and organization controls."
+>
+> This page is a product map for that official entry. On this site's complexity axis it sits later than Grok Build. It still gets a page because xAI put it on the Grok docs home.
+
+## Goals and non-goals
+
+**Audience:** someone whose company already has (or is buying) Grok Business / Enterprise, not a solo SuperGrok subscriber.
+
+**Goals:** explain personal vs team workspaces, licenses, sharing, and the admin console. Point at official pages.
+
+**Non-goals:** invented seat prices, a second copy of Enterprise legal terms, or Grok Build's `/etc/grok/requirements.toml` policy (that is [enterprise CLI policy](https://docs.x.ai/build/enterprise), a different product).
+
+## What you get
+
+A **team workspace** ([user-guide](https://docs.x.ai/grok/user-guide)):
+
+- Privacy guarantees as outlined in xAI's [enterprise terms](https://x.ai/legal/terms-of-service-enterprise).
+- Full benefits of **SuperGrok** (or **SuperGrok Heavy** for upgraded licenses).
+- Secure sharing of conversations limited to **active** team members.
+
+Two workspace types:
+
+| Workspace | Who it is for | Gate |
+|-----------|---------------|------|
+| **Personal** | Individual use | Available unless the org disables it on an Enterprise license |
+| **Team** | Collaborative work | Only with an **active license** |
+
+Switch workspaces with the selector in the **bottom-left** navigation on grok.com. Start new conversations in the correct workspace.
+
+If you cannot open the team workspace, you lack an active license — contact a team admin. If you **do not see a personal workspace**, the org disabled it; enabling/disabling that is an Enterprise / sales conversation ([user-guide](https://docs.x.ai/grok/user-guide)).
+
+Enterprise adds custom retention policies. This page does not paraphrase the legal terms — read [x.ai/legal/terms-of-service-enterprise](https://x.ai/legal/terms-of-service-enterprise).
+
+## Licenses and users
+
+Hub: the Grok Business overview at [console.x.ai](https://console.x.ai) ([management](https://docs.x.ai/grok/management), [user-guide](https://docs.x.ai/grok/user-guide)).
+
+Official license types ([management](https://docs.x.ai/grok/management)):
+
+- **SuperGrok** — standard business access with enhanced quotas and features.
+- **SuperGrok Heavy** — upgraded performance for demanding workloads.
+
+This page does **not** invent a dollar price per seat.
+
+Admin flow (condensed from [management](https://docs.x.ai/grok/management) and [user-guide](https://docs.x.ai/grok/user-guide)):
+
+1. Buy licenses on the overview (type + quantity). Needs **Billing Read-Write**.
+2. Invite users by email; optionally pick a license to auto-provision on accept. Needs **Team Read-Write**. Invited users get team workspace access and basic team read (so conversations can be shared).
+3. Assign / revoke licenses from the user list. Revoke returns the license to the pool and drops **team** workspace access; **personal** workspace remains.
+4. Cancel unused licenses on the overview. Cancellations may take a few days; eligible refunds go to the billing method.
+
+End-user activation ([user-guide](https://docs.x.ai/grok/user-guide)): console.x.ai → **Assign license** → pick the type. Then the team workspace appears on grok.com.
+
+## Sharing
+
+Team conversation sharing ([user-guide](https://docs.x.ai/grok/user-guide)):
+
+1. Open the conversation **in the team workspace**.
+2. Share button → select team members → generate the link.
+3. Links open only for **licensed** team members. Non-members and unlicensed teammates cannot open them.
+4. Inbox: [grok.com/history?tab=shared-with-me](https://grok.com/history?tab=shared-with-me).
+
+Org-wide sharing policy is a **ceiling**, not a default share ([management](https://docs.x.ai/grok/management)). Admins set it in console.x.ai → **Sharing & Retention** → **Product Sharing**. Each resource type has its own policy: conversations, projects, skills.
+
+| Level | What members can do |
+|-------|---------------------|
+| **Private** | Sharing off for that resource |
+| **Team** | Individual teammates and the member's own team. No org-wide / cross-team |
+| **Organization** | Team, plus other teams and everyone in the org |
+| **Public** | Organization, plus public links anyone can open |
+
+Public links apply to **conversations only**. Projects and skills cap at Organization. Defaults: conversations and projects can be shared organization-wide; **skills start at Private**. Tightening a policy applies immediately, including existing shares that now sit above the ceiling.
+
+## Connectors in a team
+
+Business / Enterprise members do **not** add connectors on their own first. A team admin must provision the connector in the console; then members connect their own accounts on [grok.com/connectors](https://grok.com/connectors). Details: [Connectors](./grok-connectors.md) and [connector-management](https://docs.x.ai/grok/connector-management).
+
+## Not this page
+
+| Product | Why it is different |
+|---------|---------------------|
+| Personal SuperGrok on grok.com | No team workspace, no license pool. See [Grok Chat](./grok-chat.md) |
+| xAI API "teams" in the consumer [FAQ](https://docs.x.ai/grok/faq) | Console teams for **API usage / invoices**, not Grok Business workspaces |
+| Grok Build enterprise policy | Five config layers, OIDC, MDM on the **CLI** ([docs.x.ai/build/enterprise](https://docs.x.ai/build/enterprise)) |
+| Grok Bot teams | Per-member cloud computer ([docs.x.ai/grok-bot/teams-and-enterprises](https://docs.x.ai/grok-bot/teams-and-enterprises)) |
+
+## Common pitfalls
+
+- Starting a confidential thread in the **personal** workspace, then wondering why team sharing links do not work.
+- Expecting an unlicensed teammate to open a share link. Officially they cannot.
+- Mixing Grok Business licenses with `XAI_API_KEY` API credit.
+- Looking for a seat price on this page. Official docs list **license types**, not consumer dollar amounts.
+
+## Official docs
+
+| Page | Use |
+|------|-----|
+| [docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide) | Workspaces, privacy, conversation sharing, activate license |
+| [docs.x.ai/grok/management](https://docs.x.ai/grok/management) | Buy / invite / assign / revoke / cancel, sharing policy |
+| [docs.x.ai/grok/connector-management](https://docs.x.ai/grok/connector-management) | Admin provisions connectors |
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | First-class "Business & Enterprise" link |
+| [console.x.ai](https://console.x.ai) | Admin hub |
+| [enterprise terms](https://x.ai/legal/terms-of-service-enterprise) | Privacy / data handling |
+
+White-glove / Enterprise upgrades: contact xAI sales (the docs pages leave the address as a site widget).
+
+## Related pages
+
+- [Grok Chat](./grok-chat.md) — what members use inside a workspace
+- [Connectors](./grok-connectors.md) — admin provision + member OAuth
+- [Grok Bot](./grok-bot.md) — different team product
+- [Grok Build tutorial](./grok-cli.md) — CLI enterprise policy is elsewhere
+- [Grok learning map](./index.md)

--- a/docs/products/ai-coding/grok/grok-chat.md
+++ b/docs/products/ai-coding/grok/grok-chat.md
@@ -1,0 +1,145 @@
+# Grok Chat
+
+> **Grok** is xAI's assistant. Official definition ([docs.x.ai/grok/overview](https://docs.x.ai/grok/overview)):
+> "Grok is xAI's assistant, available on the web at [grok.com](https://grok.com) and in the iOS and Android apps. Sign in once and your conversations, settings, and subscription stay in sync across every platform."
+>
+> This page is a product map sourced only from [docs.x.ai/grok](https://docs.x.ai/grok/overview), [x.ai/grok](https://x.ai/grok), and [grok.com](https://grok.com). It is the Claude.ai analog. It is **not** Grok Build — that is [grok-cli.md](./grok-cli.md).
+
+## Goals and non-goals
+
+**Audience:** frontend engineers picking a Grok surface. You need a browser or the Grok app, not a repo checkout.
+
+**Goals:** list what grok.com / iOS / Android actually do, how accounts sync, and where files / Voice / Imagine / Connectors live.
+
+**Non-goals:** a Grok Build tutorial, invented SuperGrok prices, third-party Arena Mode / 8-parallel claims, or treating Grok 4.3 as the current flagship. Coding models stay on [developers/models](https://docs.x.ai/developers/models): `grok-4.6` and `grok-build-0.1`.
+
+## What it is
+
+One assistant, three official clients ([overview](https://docs.x.ai/grok/overview), [x.ai/grok](https://x.ai/grok)):
+
+| Client | Official entry |
+|--------|----------------|
+| Web | [grok.com](https://grok.com) — the [FAQ](https://docs.x.ai/grok/faq) says use this address in Chrome/Chromium; `grok.x.ai` can miss features such as Projects |
+| iOS | Grok on the App Store ([x.ai/grok](https://x.ai/grok)) |
+| Android | Grok on Google Play ([x.ai/grok](https://x.ai/grok)) |
+| Inside X | Grok inside X.com / X apps (the [FAQ](https://docs.x.ai/grok/faq) sends X-product issues to X Help, not xAI) |
+
+There is **no official Grok desktop chat app** on these pages. The desktop + iOS product with a cloud computer is [Grok Bot](./grok-bot.md).
+
+Official "what you can do" list ([overview](https://docs.x.ai/grok/overview)):
+
+- **Chat** — ask questions, brainstorm, write, and work through problems in a natural back-and-forth.
+- **Create images and video** with Grok Imagine. Product page: [grok-imagine.md](./grok-imagine.md).
+- **Talk to Grok** hands-free with voice. Product + API map: [grok-voice.md](./grok-voice.md).
+- **Upload files** — PDFs, images, spreadsheets, code, audio, and more — for analysis, extraction, and summarization.
+- **Connect your tools** so Grok can reach your email, files, and calendar inside a chat. See [Connectors](./grok-connectors.md).
+
+[x.ai/grok](https://x.ai/grok) adds live web + 𝕏 search, deep reasoning, multi-agent mode on SuperGrok, code generation **in the thread**, memory across chats, canvas for long-form writing, custom instructions, and shareable conversation links. That is still chat, not a repo agent.
+
+## Accounts and subscription sync
+
+Sign in once. Conversations, settings, and the subscription stay in sync across web and the apps ([overview](https://docs.x.ai/grok/overview)).
+
+The [FAQ](https://docs.x.ai/grok/faq) is explicit about common account traps:
+
+- The subscription is tied to the **account you bought it with**. A web SuperGrok that does not appear in the iOS/Android app is usually a different login, not a double charge. X Premium+ only applies to the account linked to that X account.
+- Link X at **Settings → Account → Connect your X Account** on grok.com. Manage sign-in methods at [accounts.x.ai](https://accounts.x.ai).
+- Apple "Hide My Email" subscriptions must be signed in **with Apple**, not the relay address via Google/email.
+- Delete the xAI account at [accounts.x.ai/account](https://accounts.x.ai/account). Restorable for 30 days. API access on the same account is removed too.
+
+Billing location depends on where you subscribed ([FAQ](https://docs.x.ai/grok/faq)):
+
+| Where you bought it | Where you manage it |
+|---------------------|---------------------|
+| Web (grok.com) | [grok.com/?_s=billing](https://grok.com/?_s=billing) or Settings → Billing |
+| Apple App Store | Apple subscription / refund pages |
+| Google Play | Google Play cancel; refunds via the [xAI refund form](https://accounts.x.ai/refund) |
+| X Premium | X, not xAI ([X Help](https://help.x.com/using-x/x-premium)) |
+
+**API credits are not refundable** ([FAQ](https://docs.x.ai/grok/faq)).
+
+## Plans and the weekly usage pool
+
+[overview](https://docs.x.ai/grok/overview): Grok is **free to start**. Paid SuperGrok plans raise limits and unlock more across every product, from **one weekly usage allowance** you can spend however you like.
+
+The [FAQ](https://docs.x.ai/grok/faq) (rolling out June 2026) replaces per-product daily caps:
+
+- One weekly pool for Chat, Imagine, Voice, Build, and related products.
+- Different products cost different amounts of the pool. A chat message uses little compute; a high-quality video or a long coding task uses more.
+- Check **Settings → Usage** (web and mobile): percent used, breakdown by product (API, Build, Chat, Imagine, Voice), weekly reset time, Extra Usage Credits.
+- Hitting the weekly cap pauses **paid** features. Free-tier Chat and Voice limits remain and reset on their own schedule.
+- Extra Usage Credits can currently be bought **on the web only**, from $5, expire one year after purchase unless otherwise stated, and cost more per action than included weekly usage.
+- Auto Top Up is a web setting (amount + monthly cap).
+
+This page does **not** invent a SuperGrok dollar price or a token quota. Trust the Usage tab.
+
+Team / Enterprise workspaces are a different product surface: [Grok Business](./grok-business.md).
+
+## File uploads
+
+Official path ([FAQ](https://docs.x.ai/grok/faq)): in any chat, click or tap **+** next to the input (or drag-and-drop on the web). Multiple files per message. Grok confirms a successful upload before it answers.
+
+| Limit | Official number |
+|-------|-----------------|
+| How many at once | Web: up to ~100. Android: up to 20. iOS: multiple files |
+| Size | Most files (documents, images, code, audio): **150 MB** per file |
+| Documents | PDF, DOCX, TXT, CSV, XLSX, PPTX, HTML, XML, JSON, MD, LaTeX, ODT, RTF, code (`.py`, `.cpp`, `.java`, `.html`, `.css`) |
+| Images | JPEG/JPG, PNG, WebP, HEIC, BMP. GIF and SVG vary by platform |
+| Audio | MP3, WAV, M4A, OGG, FLAC, AAC |
+| Video | MP4, MOV |
+
+What Grok does with files ([FAQ](https://docs.x.ai/grok/faq)): synthesis across files, transformation (summarize / rewrite), extraction (tables, quotes), analysis (charts, code, audio/video), multimodal reasoning.
+
+Official caveats:
+
+- Very long files may be summarized or handled in sections.
+- Embedded images inside **non-PDF** files may not be processed visually.
+- Audio/video transcription quality varies.
+- Manage stored assets at [grok.com/files](https://grok.com/files). Data controls: **Profile → Settings → Data Controls**.
+
+## Nearby surfaces (do not mix them)
+
+| Surface | What it is | Page |
+|---------|------------|------|
+| **Grok Chat** | This page. Conversation, search, files, Voice, Imagine in-thread | grok.com / apps |
+| **Imagine** | Dedicated image/video studio + Imagine API | [grok-imagine.md](./grok-imagine.md) |
+| **Voice** | Hands-free talk in the app + Voice API | [grok-voice.md](./grok-voice.md) |
+| **Connectors** | Email / files / calendar / MCP inside chat | [grok-connectors.md](./grok-connectors.md) |
+| **Build Mode** | Chat mode that builds a live preview and publishes to grok.me. SuperGrok Heavy Early Beta | [x.ai/grok/build-mode](https://x.ai/grok/build-mode) — not Grok Build |
+| **Grok Build** | Terminal coding agent (`grok`) | [grok-cli.md](./grok-cli.md) |
+| **Grok Bot** | Named teammates on a persistent cloud computer | [grok-bot.md](./grok-bot.md) |
+| **Grok Business** | Team workspaces and licenses | [grok-business.md](./grok-business.md) |
+
+[FAQ](https://docs.x.ai/grok/faq) product notes worth keeping:
+
+- **Grok Studio is no longer supported.** Use **Grok Build** instead.
+- **Companions** are iOS-only. Official text: no plans to bring them to web or Android.
+
+## Common pitfalls
+
+- Signing in with a different Google / Apple / X identity on the phone than on the web, then assuming the subscription is missing.
+- Using `grok.x.ai` and wondering why Projects disappeared — official address is **grok.com**.
+- Treating in-chat code generation as a repo agent. For a real checkout, use [Grok Build](./grok-cli.md).
+- Pasting the same files every turn instead of using [Connectors](./grok-connectors.md) for mail / Drive / calendar.
+- Writing third-party "Grok 4.3 / 2M context" as the chat flagship. Official coding guidance on [developers/models](https://docs.x.ai/developers/models): **Grok 4.6**.
+
+## Official docs
+
+| Page | Use |
+|------|-----|
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | What Grok is, platforms, next links |
+| [docs.x.ai/grok/faq](https://docs.x.ai/grok/faq) | Billing, weekly usage, files, Imagine, accounts |
+| [docs.x.ai/grok/connectors](https://docs.x.ai/grok/connectors) | Link apps inside chat |
+| [docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide) | Business & Enterprise workspaces |
+| [x.ai/grok](https://x.ai/grok) | Marketing + store links |
+| [grok.com](https://grok.com) | The product |
+
+## Related pages
+
+- [Grok learning map](./index.md) — family decision tree
+- [Imagine](./grok-imagine.md) — images and video
+- [Voice](./grok-voice.md) — product Voice + Voice API
+- [Connectors](./grok-connectors.md)
+- [Grok Business](./grok-business.md)
+- [Grok Build tutorial](./grok-cli.md)
+- [Glossary](./grok-glossary.md)

--- a/docs/products/ai-coding/grok/grok-cheatsheet.md
+++ b/docs/products/ai-coding/grok/grok-cheatsheet.md
@@ -426,6 +426,12 @@ Last verified 2026-08-18. Ordered by reliability and freshness. **The changelog 
 | [docs.x.ai/build/features/background-tasks](https://docs.x.ai/build/features/background-tasks) | Background tasks, `/loop`, monitors |
 | [docs.x.ai/build/features/dashboard](https://docs.x.ai/build/features/dashboard) | Agent Dashboard |
 | [docs.x.ai/developers/models](https://docs.x.ai/developers/models) | Model list and pricing |
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | grok.com / apps consumer overview |
+| [docs.x.ai/developers/model-capabilities/imagine](https://docs.x.ai/developers/model-capabilities/imagine) | Imagine API (images and video) |
+| [docs.x.ai/grok-bot/overview](https://docs.x.ai/grok-bot/overview) | Grok Bot product entry |
+| [docs.x.ai/grok-bot/get-started](https://docs.x.ai/grok-bot/get-started) | Grok Bot install and first task |
+| [docs.x.ai/grok-bot/computer-and-apps](https://docs.x.ai/grok-bot/computer-and-apps) | Shared cloud computer |
+| [docs.x.ai/grok-bot/faq](https://docs.x.ai/grok-bot/faq) | Grok Bot platforms, cost, memory |
 
 ### Efficiency tricks
 
@@ -442,6 +448,12 @@ Last verified 2026-08-18. Ordered by reliability and freshness. **The changelog 
 | [x.ai/build/changelog](https://x.ai/build/changelog) | Changelog; updated faster than the docs site |
 | [x.ai/news/grok-build-cli](https://x.ai/news/grok-build-cli) | Launch announcement (2026-05-25, early beta) |
 | [x.ai/news/grok-4-6](https://x.ai/news/grok-4-6) | Grok 4.6 announcement (mentions time-boxed 2x included usage in Grok Build; no standing quota number) |
+| [x.ai/grok](https://x.ai/grok) | Consumer Grok (chat / Imagine / voice) |
+| [grok.com/imagine](https://grok.com/imagine) | Consumer Imagine |
+| [x.ai/grok/build-mode](https://x.ai/grok/build-mode) | Build Mode marketing (not Grok Build CLI) |
+| [x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode) | Build Mode launch; SuperGrok Heavy Early Beta; grok.me publish host |
+| [x.ai/bot](https://x.ai/bot) | Grok Bot marketing + downloads |
+| [x.ai/news/introducing-grok-bot](https://x.ai/news/introducing-grok-bot) | Grok Bot launch (2026-08-11, beta) |
 | [github.com/xai-org/grok-build](https://github.com/xai-org/grok-build) | Source (Rust, Apache-2.0); **external PRs are not accepted**, feedback goes through `/feedback` |
 | [github.com/xai-org/plugin-marketplace](https://github.com/xai-org/plugin-marketplace) | Official plugin marketplace catalog |
 | [npmjs.com/package/@xai-official/grok](https://www.npmjs.com/package/@xai-official/grok) | Release cadence and version history |
@@ -454,3 +466,4 @@ Last verified 2026-08-18. Ordered by reliability and freshness. **The changelog 
 - [Grok Build tutorial](./grok-cli.md)
 - [Grok Build cookbook](./grok-cookbook.md)
 - [Grok Build glossary](./grok-glossary.md)
+- [Grok Bot](./grok-bot.md)

--- a/docs/products/ai-coding/grok/grok-cheatsheet.md
+++ b/docs/products/ai-coding/grok/grok-cheatsheet.md
@@ -1,0 +1,455 @@
+# Grok Build Cheatsheet
+
+Lookup only, no teaching. Every entry comes from xAI's official documentation, with the source page linked next to each section heading. The authoritative full command set is always `grok --help` / `grok <subcommand> --help`.
+
+Covers v1.0.4 (npm latest as of 2026-08-13). Grok Build is in beta and moves fast — if something does not match, run `grok --version` and check the [changelog](https://x.ai/build/changelog).
+
+## Install and update
+
+| Scenario | Command |
+| --- | --- |
+| macOS / Linux | `curl -fsSL https://x.ai/cli/install.sh \| bash` |
+| Windows PowerShell | `irm https://x.ai/cli/install.ps1 \| iex` |
+| npm channel | `npm install -g @xai-official/grok` |
+| Check for updates | `grok update --check` |
+| Install a specific version | `grok update --version <V>` |
+| Switch channel | `grok update --alpha` / `grok update --stable` |
+| Show version | `grok version` |
+
+The npm package requires `node >= 20`; the binary is named `grok`.
+
+## Subcommands
+
+Source: [CLI Reference](https://docs.x.ai/build/cli/reference)
+
+| Command | Purpose |
+| --- | --- |
+| `grok` | No arguments starts the interactive TUI |
+| `grok login` | Log in; `--device-auth` uses the device-code flow (no browser) |
+| `grok logout` | Log out and clear cached credentials |
+| `grok inspect [--json]` | Show what was discovered in this directory: rules, skills, plugins, hooks, MCP servers |
+| `grok models` | List available models |
+| `grok mcp <list\|add\|remove\|doctor>` | Manage MCP servers |
+| `grok plugin <list\|install\|uninstall\|update\|enable\|disable\|details\|validate>` | Manage plugins |
+| `grok plugin marketplace <list\|add\|remove\|update>` | Manage marketplace sources |
+| `grok sessions <list\|search\|delete>` | List, search, delete sessions |
+| `grok export <session-id> [output]` | Export a session as Markdown |
+| `grok import [targets...]` | Import sessions from Claude Code |
+| `grok memory clear [--workspace\|--global\|--all]` | Clear cross-session memory files |
+| `grok worktree <list\|show\|rm\|gc>` | Manage git worktrees created by sessions |
+| `grok dashboard` | Open the Agent Dashboard |
+| `grok agent stdio` | Run as an ACP agent over stdin/stdout |
+| `grok wrap <command...>` | Run a command in a local PTY, forwarding OSC 52 clipboard writes |
+| `grok update` | Check for or install updates |
+| `grok version` | Print version information |
+| `grok completions <shell>` | Generate a shell completion script |
+| `grok setup` | Fetch and install managed configuration |
+
+## Common flags
+
+| Flag | Purpose |
+| --- | --- |
+| `--cwd <PATH>` | Working directory |
+| `-r, --resume [<ID>]` | Resume a session; omit the ID for the most recent |
+| `-c, --continue` | Continue the most recent session in this directory |
+| `-s, --session-id <UUID>` | Assign a UUID to a **new** session (not a resume) |
+| `--fork-session` | Fork into a new session ID when resuming |
+| `-w, --worktree [<NAME>]` | Start the session in a new git worktree |
+| `--ref <REF>` | Branch / tag / commit the worktree is based on |
+| `-m, --model <MODEL>` | Model ID |
+| `--effort <LEVEL>` | Reasoning effort |
+| `--always-approve` | Auto-approve all tool calls (alias `--yolo`) |
+| `--allow <RULE>` / `--deny <RULE>` | Permission rules |
+| `--sandbox <PROFILE>` | Sandbox profile |
+| `--rules <TEXT>` | Extra rules appended to the system prompt |
+| `--system-prompt-override <TEXT>` | Replace the system prompt entirely |
+| `--tools <LIST>` / `--disallowed-tools <LIST>` | Expose or remove built-in tools |
+| `--max-turns <N>` | Maximum agent turns |
+| `--no-plan` / `--no-subagents` / `--no-memory` / `--disable-web-search` | Disable a feature for this session |
+| `--experimental-memory` | Enable cross-session memory |
+| `--oauth` | Use OAuth on the welcome-screen auth flow |
+| `--trust` | Trust project-level hooks / MCP / LSP at startup |
+| `--plugin-dir <PATH>` | Additional plugin directory |
+
+Claude Code flag names are accepted as aliases: `--allowedTools`, `--disallowedTools`, `--append-system-prompt`, `--system-prompt`, `--dangerously-skip-permissions`.
+
+### Headless-specific
+
+| Flag | Purpose |
+| --- | --- |
+| `-p <PROMPT>` | Run one prompt non-interactively |
+| `--output-format plain\|json\|streaming-json` | Output format, default `plain` |
+| `--permission-mode dontAsk\|acceptEdits` | Permission mode for CI |
+| `--no-alt-screen` | Do not use the alternate screen buffer |
+| `--no-auto-update` | Skip auto-update for this run |
+
+## Permissions and modes
+
+Sources: [Permissions](https://docs.x.ai/build/features/permissions), [Modes and Commands](https://docs.x.ai/build/modes-and-commands)
+
+| Mode | Behavior | How to enter |
+| --- | --- | --- |
+| Ask (default) | Anything not allowed prompts | Default |
+| Auto | A classifier auto-approves safe tools; dangerous ones may still prompt | `/auto`, `Shift+Tab` (when enabled) |
+| Always-approve | Auto-approves tool calls (`deny` rules and `PreToolUse` hooks still apply) | `/always-approve`, `Ctrl+O`, `Shift+Tab`, `grok --always-approve` |
+| Plan | Only the session plan file is editable until you approve | `/plan [description]`, `Shift+Tab` |
+| `dontAsk` | Silently denies anything without an explicit allow (headless / CI) | `--permission-mode dontAsk` |
+| `acceptEdits` | Auto-approves file edits, still asks for shell commands | `--permission-mode acceptEdits` |
+
+`Shift+Tab` cycles: Normal → Plan → Auto (when available) → Always-approve.
+
+Rule syntax (`deny` always beats `allow`):
+
+```toml
+[permission]
+rules = [
+  { action = "allow", tool = "bash", pattern = "git *" },
+  { action = "allow", tool = "read" },
+  { action = "deny",  tool = "bash", pattern = "rm -rf *" },
+]
+```
+
+Supported filters: `Bash`, `Edit`, `Read`, `Grep`, `MCPTool`, `WebFetch`, `WebSearch`.
+
+`[ui] permission_mode` only takes effect in **user** configuration (`~/.grok/config.toml`, or managed / requirements files); setting it in a project `.grok/config.toml` does nothing. The legacy keys `approval_mode` and `yolo = true` still work; when both are set, `permission_mode` wins.
+
+## Sandbox profiles
+
+Source: [Sandbox](https://docs.x.ai/build/features/sandbox)
+
+Off by default. Landlock on Linux, Seatbelt on macOS.
+
+| Profile | Read | Write | Network | Positioning |
+| --- | --- | --- | --- | --- |
+| `off` | Unrestricted | Unrestricted | Allowed | No sandbox (default) |
+| `workspace` | Anywhere | CWD, `~/.grok/`, temp dirs | Allowed | Normal development |
+| `devbox` | Anywhere | Top-level dirs except `/data` | Allowed | Cloud dev machine |
+| `read-only` | Anywhere | Only `~/.grok/` and temp dirs | Blocked | Code review, audit |
+| `strict` | CWD and system paths | CWD, `~/.grok/`, temp dirs | Blocked | Untrusted repos |
+
+Three limitations: subprocess network restrictions **only apply on Linux** (on macOS the blocking in `read-only` / `strict` is a no-op); built-in profiles do **not** permanently protect paths like `~/.ssh`, so write your own `deny` list; `~/.grok/` stays writable under every profile. The model API and web tools are unaffected by subprocess network settings.
+
+Custom profiles go in `~/.grok/sandbox.toml` or `.grok/sandbox.toml`; built-in names cannot be redefined:
+
+```toml
+[profiles.my-profile]
+extends = "workspace"
+restrict_network = true
+deny = ["/secrets", "**/.env", "**/*.pem"]
+```
+
+## Slash commands
+
+Source: [Modes and Commands](https://docs.x.ai/build/modes-and-commands)
+
+### Session
+
+| Command | Purpose |
+| --- | --- |
+| `/quit` (alias `/exit`) | Quit |
+| `/help` | Browse commands and key bindings |
+| `/home` | Back to the welcome screen |
+| `/new` (alias `/clear`) | New session |
+| `/resume` | Resume a past session |
+| `/sessions` | Switch, rename, close active sessions |
+| `/fork` | Fork the current session into a peer agent |
+| `/rename <title>` (alias `/title`) | Rename the current session |
+| `/share` | Share the current session as a URL |
+| `/session-info` | Session information |
+| `/context` | Context usage |
+| `/compact [context]` | Compact conversation history |
+| `/rewind` | Roll back to an earlier turn |
+| `/export` | Export the conversation to a file or the clipboard |
+| `/copy [N]` | Copy the last (or Nth-from-last) response |
+| `/find` | Search the scrollback |
+| `/transcript` | View the full transcript with `$PAGER` |
+
+### Models and modes
+
+| Command | Purpose |
+| --- | --- |
+| `/model <name>` (alias `/m`) | Switch model |
+| `/effort` | Set reasoning effort for the current model |
+| `/always-approve` | Toggle always-approve |
+| `/auto` | Toggle auto mode |
+| `/plan [description]` | Enter plan mode |
+| `/view-plan` | View the current plan |
+
+### Tasks and orchestration
+
+| Command | Purpose |
+| --- | --- |
+| `/btw <question>` | Ask a side question without derailing the main thread |
+| `/loop [interval] <prompt>` | Repeat a prompt on an interval |
+| `/tasks` | List background tasks, subagents, scheduled jobs |
+| `/queue` | List prompts queued behind the current turn |
+| `/create-workflow [description]` | Write and save a new workflow |
+| `/workflow <name> [args]` | Start a workflow, or `pause` / `resume` / `stop` / `save` |
+| `/workflows` | Full-screen workflow run board |
+| `/deep-research <query>` | Run the built-in research workflow |
+| `/dashboard` | Open the Agent Dashboard |
+| `/imagine <prompt>` | Text to image |
+| `/imagine-video <prompt>` | Text to video |
+
+### Extensions and configuration
+
+| Command | Purpose |
+| --- | --- |
+| `/hooks` / `/plugins` / `/marketplace` / `/skills` / `/mcps` | Different tabs of the same extensions dialog |
+| `/config-agents` (alias `/agents`) | Manage agent definitions |
+| `/personas` | Manage personas |
+| `/settings` (alias `/config`) | Settings dialog |
+| `/theme [name]` (alias `/t`) | Switch theme |
+| `/compact-mode` | More compact UI |
+| `/multiline` (alias `/ml`) | Toggle multiline input |
+| `/vim-mode` | Toggle vim-style scrollback keys |
+| `/timestamps` | Toggle message timestamps |
+| `/terminal-setup` | Check terminal and clipboard configuration |
+| `/hooks-trust` | Trust the current project's hooks |
+| `/import-claude` | Open the Claude settings-import dialog |
+
+### Account and memory
+
+| Command | Purpose |
+| --- | --- |
+| `/login` / `/logout` | Log in / out |
+| `/usage` | View quota usage or manage billing |
+| `/privacy` | View or change privacy and data-retention status |
+| `/feedback [text]` | Send feedback about the current session |
+| `/release-notes` (alias `/changelog`) | Release notes for the current version |
+| `/remember <note>` | Store a memory |
+| `/flush` | Write conversation memory to disk now |
+| `/memory` (alias `/mem`) | Browse and manage memories |
+| `/dream` | Run memory consolidation |
+
+`/flush`, `/memory`, and `/dream` are provided by the shell and only appear when cross-session memory is enabled. User-invocable skills also become `/<skill-name>`; on a name collision use the qualified form such as `/local:commit`.
+
+## Key bindings
+
+Source: [Keyboard Shortcuts](https://docs.x.ai/build/keyboard-shortcuts). Press `Ctrl+.` in the TUI for the full list (`Ctrl+X` on Windows or terminals without Kitty keyboard protocol support).
+
+### Essential
+
+| Key | Action |
+| --- | --- |
+| `Enter` | Send |
+| `Tab` | Move focus between the input box and the scrollback |
+| `Esc` | Cancel the running turn |
+| `Esc Esc` | Clear the input box; opens rewind when the input is empty |
+| `Ctrl+C` | Cancel the turn |
+| `Shift+Tab` | Cycle modes |
+| `Ctrl+P` or `?` | Command palette |
+| `F2` or `Ctrl+,` | Settings |
+| `Ctrl+Q` / `Ctrl+D` | Quit (press twice) |
+
+### Input
+
+| Key | Action |
+| --- | --- |
+| `Ctrl+Enter` or `Ctrl+I` | Interject during a running turn |
+| `Shift+Enter` | Newline; sends in multiline mode (use `Alt+Enter` where unsupported) |
+| `Ctrl+M` | Toggle multiline input |
+| `Ctrl+R` | Search prompt history |
+| `!` | Enter shell mode from an empty input box |
+
+### Panels and sessions
+
+| Key | Action |
+| --- | --- |
+| `Ctrl+T` | Toggle the todo panel |
+| `Ctrl+B` | Send the running command to the background |
+| `Ctrl+;` or `Ctrl+'` | Toggle the prompt-queue panel |
+| `Ctrl+S` | Open the session list |
+| `Ctrl+L` | Open the extensions dialog |
+| `Ctrl+G` | Toggle the task panel |
+| `Ctrl+O` | Toggle always-approve |
+| `Ctrl+N` | New session (press twice) |
+| `Ctrl+M` | Pick a model when the input box is not focused |
+| `Ctrl+\` | Open the Agent Dashboard |
+
+### Terminal differences (important)
+
+- VS Code-family terminals (VS Code, Cursor, Windsurf, Zed): quit is `Ctrl+D` only, interject is `Ctrl+L`, half-page scroll is `Shift+D`, `Ctrl+L` does **not** open the extensions dialog (use `/plugins`), newline is `Alt+Enter`
+- Apple Terminal: `Ctrl+O` also interjects
+- WezTerm: needs `enable_kitty_keyboard = true` for `Ctrl+Enter` and `Shift+Enter`
+
+Letter keys in the scrollback (`j`/`k`/`g`/`e`/`y`/`/` and friends) require vim mode (`/vim-mode` or `[ui] vim_mode = true`); the arrow-key equivalents always work.
+
+## Configuration files
+
+| Path | Purpose |
+| --- | --- |
+| `~/.grok/config.toml` | User configuration (Windows: `%USERPROFILE%\.grok\config.toml`) |
+| `<project>/.grok/config.toml` | Project configuration; **only** `[mcp_servers]`, `[plugins]`, `[permission]` are read |
+| `~/.grok/sandbox.toml` / `.grok/sandbox.toml` | Custom sandbox profiles |
+| `~/.grok/hooks/*.json` / `<project>/.grok/hooks/*.json` | Hook definitions |
+| `~/.grok/skills/` / `./.grok/skills/` | Skill directories |
+| `~/.grok/plugins/` / `./.grok/plugins/` | Plugin directories |
+| `~/.grok/agents/` / `.grok/agents/` | Custom subagent types |
+| `~/.grok/personas/*.toml` / `.grok/personas/*.toml` | Persona definitions |
+| `~/.grok/workflows/*.rhai` / `.grok/workflows/*.rhai` | Workflows |
+| `~/.grok/sessions/` | Session history (indexed by working directory) |
+| `~/.grok/worktrees/<repo>/<name>` | Session worktrees |
+| `~/.grok/mcp_credentials.json` | MCP OAuth tokens |
+| `~/.grok/trusted_folders.toml` | Trusted project directories |
+| `~/.grok/logs/mcp/<server>.stderr.log` | stderr of MCP stdio servers |
+| `/etc/grok/requirements.toml` | System-level managed policy (the tamper lock is honored only from root-owned sources) |
+
+Instruction files: the `AGENTS.md` family (`AGENTS.md` / `Agents.md` / `AGENT.md`) and the Claude family (`CLAUDE.md` / `Claude.md` / `CLAUDE.local.md` / `.claude/rules/`) are read from the cwd upward to the repository root.
+
+## Common configuration keys
+
+Source: [Settings Reference](https://docs.x.ai/build/settings/reference)
+
+| Section | Key | Notes |
+| --- | --- | --- |
+| `[models]` | `default` | Model used by new sessions |
+| `[models]` | `allowed_models` / `hidden_models` / `disabled_models` | Restrict selectable models (glob list / ID list) |
+| `[model.<id>]` | `model` / `base_url` / `name` / `env_key` / `api_backend` | Custom or BYOK model |
+| `[model.<id>]` | `context_window` | Context window size; affects when auto-compaction kicks in |
+| `[tools]` | `respect_gitignore` | Default `false`; when `true`, search/read tools skip gitignored files |
+| `[toolset]` | `file_toolset` | `standard` (default) or `hashline` |
+| `[toolset.bash]` | `timeout_secs` / `output_byte_limit` / `max_timeout_secs` | Defaults `120` s / `20000` bytes / `36000` s |
+| `[toolset.bash]` | `auto_background_on_timeout` | Default `true`; moves to background on timeout |
+| `[toolset.web_fetch]` | `allowed_domains` / `proxy_endpoint` | Domain allowlist and egress proxy for `web_fetch` |
+| `[sandbox]` | `profile` / `auto_allow_bash` | Sandbox profile; skip bash prompts while the sandbox is active |
+| `[permission]` | `rules` | allow / deny rules |
+| `[ui]` | `permission_mode` | `"ask"` / `"auto"` / `"always-approve"`; user config only |
+| `[ui]` | `disable_bypass_permissions_mode` | Globally lock out always-approve (root-owned sources only) |
+| `[ui]` | `vim_mode` | vim keys in the scrollback |
+| `[features]` | `web_fetch` / `lsp_tools` / `write_file` / `tool_search` | `lsp_tools` off by default; `write_file` / `tool_search` on |
+| `[subagents]` | `enabled` / `toggle` / `models` | Master switch / per-type switch / per-type model routing |
+| `[memory]` | `enabled` | Cross-session memory master switch, **off by default** |
+| `[skills]` / `[plugins]` | `paths` / `disabled` / `enabled` | Extra directories / discovered but inactive / explicitly enabled |
+| `[compat.claude]` / `[compat.cursor]` | `skills` / `rules` / `agents` / `mcps` / `hooks` | Whether to scan those directories; all default `true` |
+| `[dashboard]` | `enabled` | Agent Dashboard master switch |
+| `[workflows]` | `enabled` | Workflow master switch |
+| `[mcp_servers.<name>]` | `startup_timeout_sec` / `tool_timeout_sec` | Defaults `30` / `6000` seconds |
+
+## Environment variables
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `GROK_HOME` | `~/.grok` | Home for configuration, auth, sessions, skills, plugins, logs |
+| `XAI_API_KEY` | — | API key when not using browser login (CI / headless) |
+| `GROK_DEFAULT_MODEL` | directory / config | Default model for sessions |
+| `GROK_XAI_API_BASE_URL` | `https://api.x.ai/v1` | xAI API base when authenticating with an API key |
+| `GROK_MODELS_BASE_URL` | — | Custom inference base URL |
+| `GROK_DISABLE_AUTOUPDATER` | unset | Set to disable auto-update (CI / containers) |
+| `GROK_SANDBOX` | `off` | Sandbox profile, equivalent to `--sandbox` |
+| `GROK_SANDBOX_AUTO_ALLOW_BASH` | `0` | Auto-allow bash while the sandbox is active |
+| `GROK_RESPECT_GITIGNORE` | follows config | Force search/read filtering by gitignore |
+| `GROK_WEB_FETCH` | `0` | Enable the `web_fetch` tool, **off by default (security)** |
+| `GROK_WEB_FETCH_PROXY` | — | Egress proxy for `web_fetch` |
+| `GROK_MEMORY` | `0` | Cross-session memory |
+| `GROK_SUBAGENTS` | `0` | Subagent / task tools |
+| `GROK_WRITE_FILE` | `1` | Set `0` to disable the `write` tool (read-only sessions) |
+| `GROK_TOOL_SEARCH` | `1` | On-demand MCP tool discovery for large tool sets |
+| `GROK_LSP_TOOLS` | `0` | LSP code-intelligence tools |
+| `GROK_AGENT` | `grok-build` | Built-in agent name, profile, or absolute path to an agent definition |
+| `GROK_AGENT_DASHBOARD` | — | Set `0` to disable the Agent Dashboard |
+| `GROK_WORKFLOWS` | — | Set `0` to disable workflows |
+| `GROK_THEME` | built-in | Color theme |
+| `GROK_MCP_STARTUP_TIMEOUT_SECS` | `30` | Global MCP startup handshake timeout, in **seconds** |
+| `MCP_TIMEOUT` | same setting | Claude-compatible MCP startup timeout, in **milliseconds**; checked before the one above |
+| `GROK_LOG_FILE` | — | Write logs to this path |
+| `RUST_LOG` | — | Log filter (e.g. `debug`) |
+| `GROK_CRASH_HANDLER` | `0` | Write panic reports to `$GROK_HOME/crash/` |
+| `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | system | Standard proxy variables |
+
+The compatibility-scanner switches all default to on: `GROK_CURSOR_{SKILLS,RULES,AGENTS,MCPS,HOOKS}_ENABLED`, `GROK_CLAUDE_{SKILLS,RULES,AGENTS,MCPS,HOOKS}_ENABLED`.
+
+Additional UI variables include `GROK_SHOW_THINKING_BLOCKS`, `GROK_GROUP_TOOL_VERBS`, `GROK_COLLAPSED_EDIT_BLOCKS`, `GROK_PROMPT_SUGGESTIONS`, `GROK_SCROLL_SPEED`, `GROK_SCROLL_MODE`, `GROK_SCROLL_LINES`, `GROK_INVERT_SCROLL`, `GROK_DEFAULT_SELECTED_PERMISSION`, `GROK_REMEMBER_TOOL_APPROVALS`, `GROK_MOUSE_REPORTING_TOGGLE`, `GROK_DISPLAY_REFRESH_AUTO_CADENCE`; full defaults are in the official [Settings Reference](https://docs.x.ai/build/settings/reference).
+
+## Hook events
+
+| Event | When it fires |
+| --- | --- |
+| `SessionStart` / `SessionEnd` | Session starts / ends |
+| `UserPromptSubmit` | You submit a prompt |
+| `PreToolUse` | A tool is about to run — **the only blocking event** |
+| `PostToolUse` / `PostToolUseFailure` | Tool finished / failed |
+| `PermissionDenied` | The permission system denied a call |
+| `Stop` / `StopFailure` | Turn ended / ended due to an API error |
+| `Notification` | The agent emits a notification |
+| `SubagentStart` / `SubagentStop` | Subagent starts / stops |
+| `PreCompact` / `PostCompact` | Before / after conversation compaction |
+
+Exit code 0 allows, exit code 2 blocks, and everything else (timeout, crash, malformed output) **fails open**.
+
+## Models and pricing
+
+Source: [Models](https://docs.x.ai/developers/models). Prices are US dollars per million tokens.
+
+| Model | Context | Input | Cached input | Output |
+| --- | --- | --- | --- | --- |
+| `grok-4.6` (prompt < 200k) | 500k | $2.00 | $0.50 | $6.00 |
+| `grok-4.6` (prompt ≥ 200k) | 500k | $4.00 | $1.00 | $12.00 |
+| `grok-build-0.1` (prompt < 200k) | 256k | $1.00 | $0.20 | $2.00 |
+| `grok-build-0.1` (prompt ≥ 200k) | 256k | $2.00 | $0.40 | $4.00 |
+
+Long-context billing rule: **once a prompt reaches the threshold, every token in that request is billed at the higher tier** — it is not just the excess that costs more.
+
+Official model-selection advice:
+
+> For everything else, including code, use Grok 4.6. It is the most intelligent and fastest model we've built.
+
+`grok-4.6` has a knowledge cutoff of 2026-02-01. Alias rules: `<modelname>` points at the latest stable release, `<modelname>-latest` at the latest release, and `<modelname>-<date>` pins a specific one.
+
+Prices for other models (`grok-4.5`, `grok-4.3`, the `grok-4.20-*` series, Imagine image/video, Voice) are on the official page.
+
+## High-quality sources
+
+Ordered by reliability and freshness. **The changelog is usually ahead of the docs site** — check it first for behavior the docs do not mention.
+
+### First-party official
+
+| Source | Use |
+| --- | --- |
+| [docs.x.ai/build/overview](https://docs.x.ai/build/overview) | Grok Build documentation entry point |
+| [docs.x.ai/build/cli/reference](https://docs.x.ai/build/cli/reference) | Subcommands and flags |
+| [docs.x.ai/build/cli/headless-scripting](https://docs.x.ai/build/cli/headless-scripting) | Headless and ACP |
+| [docs.x.ai/build/cli/terminal-support](https://docs.x.ai/build/cli/terminal-support) | Terminal compatibility and diagnostics |
+| [docs.x.ai/build/modes-and-commands](https://docs.x.ai/build/modes-and-commands) | Full mode and slash-command tables |
+| [docs.x.ai/build/keyboard-shortcuts](https://docs.x.ai/build/keyboard-shortcuts) | Full key-binding table |
+| [docs.x.ai/build/settings](https://docs.x.ai/build/settings) | Config layers and precedence |
+| [docs.x.ai/build/settings/reference](https://docs.x.ai/build/settings/reference) | Full env var and TOML key tables |
+| [docs.x.ai/build/enterprise](https://docs.x.ai/build/enterprise) | Managed config, SSO, ZDR, CI permission modes |
+| [docs.x.ai/build/features/permissions](https://docs.x.ai/build/features/permissions) | Permission model |
+| [docs.x.ai/build/features/sandbox](https://docs.x.ai/build/features/sandbox) | Sandbox profiles |
+| [docs.x.ai/build/features/hooks](https://docs.x.ai/build/features/hooks) | Hook events and the script contract |
+| [docs.x.ai/build/features/mcp-servers](https://docs.x.ai/build/features/mcp-servers) | MCP configuration |
+| [docs.x.ai/build/features/skills-plugins-marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces) | Skills / plugins / marketplaces |
+| [docs.x.ai/build/features/sessions](https://docs.x.ai/build/features/sessions) | Sessions, fork, rewind, compact |
+| [docs.x.ai/build/features/worktrees](https://docs.x.ai/build/features/worktrees) | Worktrees |
+| [docs.x.ai/build/features/subagents](https://docs.x.ai/build/features/subagents) | Subagents and personas |
+| [docs.x.ai/build/features/background-tasks](https://docs.x.ai/build/features/background-tasks) | Background tasks, `/loop`, monitors |
+| [docs.x.ai/build/features/dashboard](https://docs.x.ai/build/features/dashboard) | Agent Dashboard |
+| [docs.x.ai/developers/models](https://docs.x.ai/developers/models) | Model list and pricing |
+
+### Efficiency tricks
+
+| Trick | Notes |
+| --- | --- |
+| [docs.x.ai/llms.txt](https://docs.x.ai/llms.txt) | Single-file full-text mirror of the whole docs site; good for local grep or feeding a model (it is large — do not commit it to a repo) |
+| `https://docs.x.ai/api/mcp` | Official docs MCP endpoint (Streamable HTTP, stateless); tools `list_doc_pages` / `get_doc_page` |
+| `grok inspect --json` | Fastest way to answer "what is actually loaded on this machine" |
+
+### Versions and source
+
+| Source | Use |
+| --- | --- |
+| [x.ai/build/changelog](https://x.ai/build/changelog) | Changelog; updated faster than the docs site |
+| [x.ai/news/grok-build-cli](https://x.ai/news/grok-build-cli) | Launch announcement (2026-05-25, early beta) |
+| [github.com/xai-org/grok-build](https://github.com/xai-org/grok-build) | Source (Rust, Apache-2.0); **external PRs are not accepted**, feedback goes through `/feedback` |
+| [github.com/xai-org/plugin-marketplace](https://github.com/xai-org/plugin-marketplace) | Official plugin marketplace catalog |
+| [npmjs.com/package/@xai-official/grok](https://www.npmjs.com/package/@xai-official/grok) | Release cadence and version history |
+
+**Access note**: `x.ai` and its subdomains (including `status.x.ai` and `console.x.ai`) sit behind Cloudflare and return 403 to command-line `curl`; `docs.x.ai` can be curled directly.
+
+## Related pages
+
+- [Grok learning map](./index.md)
+- [Grok Build tutorial](./grok-cli.md)
+- [Grok Build cookbook](./grok-cookbook.md)
+- [Grok Build glossary](./grok-glossary.md)

--- a/docs/products/ai-coding/grok/grok-cheatsheet.md
+++ b/docs/products/ai-coding/grok/grok-cheatsheet.md
@@ -2,7 +2,7 @@
 
 Lookup only, no teaching. Every entry comes from xAI's official documentation, with the source page linked next to each section heading. The authoritative full command set is always `grok --help` / `grok <subcommand> --help`.
 
-Covers v1.0.4 (npm latest as of 2026-08-13). Grok Build is in beta and moves fast — if something does not match, run `grok --version` and check the [changelog](https://x.ai/build/changelog).
+Covers npm `@xai-official/grok` `1.0.5` (`dist-tags.latest` and `alpha` as of 2026-08-16). The [changelog](https://x.ai/build/changelog) header still showed v1.0.3 / Aug 12, 2026 when re-checked on 2026-08-18. If something does not match, run `grok version` and check the changelog.
 
 ## Install and update
 
@@ -342,7 +342,7 @@ Source: [Settings Reference](https://docs.x.ai/build/settings/reference)
 | `GROK_WEB_FETCH` | `0` | Enable the `web_fetch` tool, **off by default (security)** |
 | `GROK_WEB_FETCH_PROXY` | — | Egress proxy for `web_fetch` |
 | `GROK_MEMORY` | `0` | Cross-session memory |
-| `GROK_SUBAGENTS` | `0` | Subagent / task tools |
+| `GROK_SUBAGENTS` | `0` | Enable subagents / the task tool (`1`/`0`). The [subagents](https://docs.x.ai/build/features/subagents) page also says they are "Enabled by default when the setting is unset." Those two official sentences disagree — do not guess which wins; check `grok inspect` on your machine. |
 | `GROK_WRITE_FILE` | `1` | Set `0` to disable the `write` tool (read-only sessions) |
 | `GROK_TOOL_SEARCH` | `1` | On-demand MCP tool discovery for large tool sets |
 | `GROK_LSP_TOOLS` | `0` | LSP code-intelligence tools |
@@ -400,7 +400,7 @@ Prices for other models (`grok-4.5`, `grok-4.3`, the `grok-4.20-*` series, Imagi
 
 ## High-quality sources
 
-Ordered by reliability and freshness. **The changelog is usually ahead of the docs site** — check it first for behavior the docs do not mention.
+Last verified 2026-08-18. Ordered by reliability and freshness. **The changelog can list commands before [CLI Reference](https://docs.x.ai/build/cli/reference) does** (the research note recorded `grok du` and `grok trace` appearing on the changelog first) — check it first for behavior the docs do not mention.
 
 ### First-party official
 
@@ -431,8 +431,8 @@ Ordered by reliability and freshness. **The changelog is usually ahead of the do
 
 | Trick | Notes |
 | --- | --- |
-| [docs.x.ai/llms.txt](https://docs.x.ai/llms.txt) | Single-file full-text mirror of the whole docs site; good for local grep or feeding a model (it is large — do not commit it to a repo) |
-| `https://docs.x.ai/api/mcp` | Official docs MCP endpoint (Streamable HTTP, stateless); tools `list_doc_pages` / `get_doc_page` |
+| [docs.x.ai/llms.txt](https://docs.x.ai/llms.txt) | Single-file full-text mirror of the whole docs site; good for local grep or feeding a model (it is large — do not commit it to a repo). Last verified 2026-08-18, HTTP 200. |
+| `https://docs.x.ai/api/mcp` | Official docs MCP endpoint (Streamable HTTP, stateless); tools `list_doc_pages` / `get_doc_page`. Browser GET/HEAD is not a docs page — 2026-08-18: HEAD 405, GET/POST 406, OPTIONS 204. Use an MCP client, not a browser. |
 | `grok inspect --json` | Fastest way to answer "what is actually loaded on this machine" |
 
 ### Versions and source
@@ -441,11 +441,12 @@ Ordered by reliability and freshness. **The changelog is usually ahead of the do
 | --- | --- |
 | [x.ai/build/changelog](https://x.ai/build/changelog) | Changelog; updated faster than the docs site |
 | [x.ai/news/grok-build-cli](https://x.ai/news/grok-build-cli) | Launch announcement (2026-05-25, early beta) |
+| [x.ai/news/grok-4-6](https://x.ai/news/grok-4-6) | Grok 4.6 announcement (mentions time-boxed 2x included usage in Grok Build; no standing quota number) |
 | [github.com/xai-org/grok-build](https://github.com/xai-org/grok-build) | Source (Rust, Apache-2.0); **external PRs are not accepted**, feedback goes through `/feedback` |
 | [github.com/xai-org/plugin-marketplace](https://github.com/xai-org/plugin-marketplace) | Official plugin marketplace catalog |
 | [npmjs.com/package/@xai-official/grok](https://www.npmjs.com/package/@xai-official/grok) | Release cadence and version history |
 
-**Access note**: `x.ai` and its subdomains (including `status.x.ai` and `console.x.ai`) sit behind Cloudflare and return 403 to command-line `curl`; `docs.x.ai` can be curled directly.
+**Access note** (re-checked 2026-08-18): `x.ai/build` and `x.ai/build/changelog` return 403 to command-line `curl` (Cloudflare). `x.ai/news/grok-build-cli` and `x.ai/cli/install.sh` returned 200. `docs.x.ai` pages above returned 200. npmjs.com HTML returned 403; the registry JSON at `https://registry.npmjs.org/@xai-official/grok` is readable.
 
 ## Related pages
 

--- a/docs/products/ai-coding/grok/grok-cli.md
+++ b/docs/products/ai-coding/grok/grok-cli.md
@@ -2,7 +2,7 @@
 
 > This page covers Grok Build (executable `grok`) from installation through daily use. Parameter lists are in the [cheatsheet](./grok-cheatsheet.md), concept distinctions in the [glossary](./grok-glossary.md), and task recipes in the [cookbook](./grok-cookbook.md).
 >
-> Grok Build is in beta and ships very fast (recently roughly one npm release every one to three days), so this page deliberately avoids pinning version numbers. If a command or config key does not match your machine's actual behavior, check [x.ai/build/changelog](https://x.ai/build/changelog) first.
+> Grok Build is in beta and ships very fast (`latest` moved 1.0.3 → 1.0.5 between 2026-08-12 and 2026-08-16), so this page deliberately avoids pinning version numbers. If a command or config key does not match your machine's actual behavior, check [x.ai/build/changelog](https://x.ai/build/changelog) first.
 
 ## 1. Install
 
@@ -30,8 +30,10 @@ npm install -g @xai-official/grok
 Verify the install:
 
 ```bash
-grok --version
+grok version
 ```
+
+The [repository README](https://github.com/xai-org/grok-build) also shows `grok --version` in the install snippet. The command listed in [CLI Reference](https://docs.x.ai/build/cli/reference) is `grok version`.
 
 > **Naming note**: a binary you build from source is called `xai-grok-pager`; official installs ship it as `grok` (the [README](https://github.com/xai-org/grok-build) says: "The binary artifact is named `xai-grok-pager`; official installs ship it as `grok`.").
 
@@ -48,9 +50,9 @@ Four methods, from [docs.x.ai/build/enterprise](https://docs.x.ai/build/enterpri
 
 Credential resolution order (highest to lowest): `model.api_key` > `model.env_key` > active session token > `XAI_API_KEY`.
 
-Subscription requirements: the [launch announcement](https://x.ai/news/grok-build-cli) (2026-05-25) says "Available now to all SuperGrok and X Premium Plus subscribers.", while the marketing page [x.ai/build](https://x.ai/build) currently says "Available to try for Free". The two disagree — trust the quota you actually see after logging in. xAI publishes no concrete figure for the free tier.
+Subscription requirements: the [launch announcement](https://x.ai/news/grok-build-cli) (2026-05-25) says "Available now to all SuperGrok and X Premium Plus subscribers.", while the marketing page [x.ai/build](https://x.ai/build) currently says "Available to try for Free". The [Grok 4.6 announcement](https://x.ai/news/grok-4-6) adds a time-boxed "2x included usage inside Grok Build … for the first week" — still no standing free-tier number. Trust the quota you actually see after logging in. Do not invent a number.
 
-<!-- TODO: 待核实 —— 免费额度的具体数值、SuperGrok/X Premium Plus 与 Grok Build 用量的换算关系，官方文档与营销页均未给出说明 -->
+<!-- TODO: 待核实 —— 免费额度的具体数值、SuperGrok/X Premium Plus 与 Grok Build 用量的换算关系；发布公告、营销页、Grok 4.6 公告三处口径不同，且都没有给出可引用的配额数字。console.x.ai 对非浏览器客户端 403，无法代查。 -->
 
 Log out with `grok logout`.
 
@@ -85,16 +87,16 @@ The full key table is available inside the TUI with `Ctrl+.` (`Ctrl+X` on Window
 |-----|--------|
 | `Enter` | Send |
 | `Shift+Enter` | Newline (not recognized by the built-in terminals in VS Code / Cursor / Windsurf / Zed — use `Alt+Enter` there) |
-| `Shift+Tab` | Cycle Normal → Plan → Auto → Always-approve |
+| `Shift+Tab` | Cycle Normal → Plan → Auto (when available) → Always-approve |
 | `Esc` | Interrupt the current action |
-| `Esc Esc` | Trigger `/rewind` (roll the session back) |
+| `Esc Esc` | Clear the input box; open rewind when the input is empty ([keyboard-shortcuts](https://docs.x.ai/build/keyboard-shortcuts)) |
 | `Ctrl+Enter` / `Ctrl+I` | Interject (`Ctrl+L` in VS Code-family terminals) |
 | `Ctrl+P` or `?` | Command palette |
 | `Ctrl+T` | Todo panel |
 | `Ctrl+B` | Background task panel |
 | `Ctrl+G` | Task panel |
 | `Ctrl+S` | Session panel |
-| `Ctrl+M` | Model picker |
+| `Ctrl+M` | Toggle multiline when the input is focused; pick a model when it is not |
 | `Ctrl+\` | Dashboard |
 | `Ctrl+O` | Switch to always-approve |
 | `F2` / `Ctrl+,` | Settings |
@@ -110,7 +112,9 @@ This is the easiest part of Grok Build to get wrong. From the official [permissi
 
 **Permissions decide whether a tool call may run at all; the sandbox decides what it can touch once it does.** The two are orthogonal and can be used together.
 
-Three permission modes:
+TUI modes and headless `--permission-mode` values are **two vocabularies**. The TUI cycles Ask / Auto / Always-approve. CI uses Claude Code-style `dontAsk` / `acceptEdits` (see [enterprise](https://docs.x.ai/build/enterprise) and the [cheatsheet](./grok-cheatsheet.md#permissions-and-modes)). Do not mix the two lists.
+
+Three TUI permission modes:
 
 | Mode | Behavior | How to enter |
 |------|----------|--------------|
@@ -191,7 +195,7 @@ Sessions are stored under `~/.grok/sessions/`, indexed by working directory ([se
 | Resume a specific session | `grok --resume <id>` |
 | Resume from inside the TUI | `/resume` |
 | Fork the current session | `/fork [directive]`, optionally `--worktree` / `--no-worktree` |
-| Roll back history | `/rewind` or `Esc Esc` |
+| Roll back history | `/rewind`, or `Esc Esc` on an empty input |
 | Compact the context | `/compact [focus]`; also happens automatically |
 | Check context usage | `/context`, `/session-info` |
 | List / search / delete | `grok sessions list` / `search` / `delete` |

--- a/docs/products/ai-coding/grok/grok-cli.md
+++ b/docs/products/ai-coding/grok/grok-cli.md
@@ -314,3 +314,4 @@ Feedback goes through `/feedback` in the TUI. **Do not open PRs against [xai-org
 - [Cookbook](./grok-cookbook.md) — hooks, MCP, skills, subagents, CI recipes
 - [Cheatsheet](./grok-cheatsheet.md) — full commands / flags / config keys / env vars
 - [Glossary](./grok-glossary.md) — permissions vs. sandbox, skill vs. plugin, and other distinctions
+- [Grok Bot](./grok-bot.md) — cloud-computer teammates, not this CLI

--- a/docs/products/ai-coding/grok/grok-cli.md
+++ b/docs/products/ai-coding/grok/grok-cli.md
@@ -1,0 +1,312 @@
+# Grok Build Tutorial
+
+> This page covers Grok Build (executable `grok`) from installation through daily use. Parameter lists are in the [cheatsheet](./grok-cheatsheet.md), concept distinctions in the [glossary](./grok-glossary.md), and task recipes in the [cookbook](./grok-cookbook.md).
+>
+> Grok Build is in beta and ships very fast (recently roughly one npm release every one to three days), so this page deliberately avoids pinning version numbers. If a command or config key does not match your machine's actual behavior, check [x.ai/build/changelog](https://x.ai/build/changelog) first.
+
+## 1. Install
+
+There are three official installation channels.
+
+::: code-group
+
+```bash [macOS / Linux]
+curl -fsSL https://x.ai/cli/install.sh | bash
+```
+
+```powershell [Windows PowerShell]
+irm https://x.ai/cli/install.ps1 | iex
+```
+
+```bash [npm (cross-platform)]
+npm install -g @xai-official/grok
+```
+
+:::
+
+- The first two come from [docs.x.ai/build/overview](https://docs.x.ai/build/overview) and the [repository README](https://github.com/xai-org/grok-build).
+- The npm channel is documented in [docs.x.ai/build/enterprise](https://docs.x.ai/build/enterprise), which lists it as the alternative when a network policy forbids `curl | bash`. The npm package requires Node.js `>= 20` and supports x64 and arm64 on macOS / Linux / Windows.
+
+Verify the install:
+
+```bash
+grok --version
+```
+
+> **Naming note**: a binary you build from source is called `xai-grok-pager`; official installs ship it as `grok` (the [README](https://github.com/xai-org/grok-build) says: "The binary artifact is named `xai-grok-pager`; official installs ship it as `grok`.").
+
+## 2. Authenticate
+
+Four methods, from [docs.x.ai/build/enterprise](https://docs.x.ai/build/enterprise):
+
+| Method | How | When to use |
+|--------|-----|-------------|
+| Browser OIDC | `grok login` (the first launch opens a browser automatically) | Local development |
+| Device code | `grok login --device-auth` (RFC 8628) | SSH / remote hosts / no browser |
+| API key | `export XAI_API_KEY="xai-..."`, then run `grok` | CI, containers |
+| External auth provider | Configure `auth_provider_command` | Enterprise SSO |
+
+Credential resolution order (highest to lowest): `model.api_key` > `model.env_key` > active session token > `XAI_API_KEY`.
+
+Subscription requirements: the [launch announcement](https://x.ai/news/grok-build-cli) (2026-05-25) says "Available now to all SuperGrok and X Premium Plus subscribers.", while the marketing page [x.ai/build](https://x.ai/build) currently says "Available to try for Free". The two disagree — trust the quota you actually see after logging in. xAI publishes no concrete figure for the free tier.
+
+<!-- TODO: 待核实 —— 免费额度的具体数值、SuperGrok/X Premium Plus 与 Grok Build 用量的换算关系，官方文档与营销页均未给出说明 -->
+
+Log out with `grok logout`.
+
+## 3. First run
+
+```bash
+cd your-project
+grok
+```
+
+Launching with no arguments enters the interactive TUI ([cli/reference](https://docs.x.ai/build/cli/reference): "Running `grok` with no arguments starts the interactive TUI.").
+
+The first prompts xAI suggests ([overview](https://docs.x.ai/build/overview)):
+
+```text
+Explain this repo.
+@src/main.rs Walk me through this file.
+```
+
+`@` references a file. **Run `grok inspect` right after installing** — it prints everything Grok discovered in the current directory: config sources, instruction files (with token counts), skills, plugins, hooks, and MCP servers. It is the first diagnostic to reach for whenever configuration seems to have no effect.
+
+```bash
+grok inspect
+grok inspect --json
+```
+
+## 4. Essential TUI keys
+
+The full key table is available inside the TUI with `Ctrl+.` (`Ctrl+X` on Windows or terminals without Kitty keyboard protocol support). The subset below is enough to get started, from [keyboard-shortcuts](https://docs.x.ai/build/keyboard-shortcuts):
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Send |
+| `Shift+Enter` | Newline (not recognized by the built-in terminals in VS Code / Cursor / Windsurf / Zed — use `Alt+Enter` there) |
+| `Shift+Tab` | Cycle Normal → Plan → Auto → Always-approve |
+| `Esc` | Interrupt the current action |
+| `Esc Esc` | Trigger `/rewind` (roll the session back) |
+| `Ctrl+Enter` / `Ctrl+I` | Interject (`Ctrl+L` in VS Code-family terminals) |
+| `Ctrl+P` or `?` | Command palette |
+| `Ctrl+T` | Todo panel |
+| `Ctrl+B` | Background task panel |
+| `Ctrl+G` | Task panel |
+| `Ctrl+S` | Session panel |
+| `Ctrl+M` | Model picker |
+| `Ctrl+\` | Dashboard |
+| `Ctrl+O` | Switch to always-approve |
+| `F2` / `Ctrl+,` | Settings |
+| `Ctrl+Q` / `Ctrl+D` | Quit (only `Ctrl+D` works in VS Code-family terminals) |
+
+When the terminal misbehaves (copy-paste broken, keys mis-read), run `/terminal-setup` inside the TUI for a self-check; see [terminal-support](https://docs.x.ai/build/cli/terminal-support).
+
+## 5. Permissions: understand that these are two separate things
+
+This is the easiest part of Grok Build to get wrong. From the official [permissions](https://docs.x.ai/build/features/permissions) page:
+
+> "Permissions decide which tool calls may run. The sandbox is separate: it limits what an approved call can do on the filesystem and network."
+
+**Permissions decide whether a tool call may run at all; the sandbox decides what it can touch once it does.** The two are orthogonal and can be used together.
+
+Three permission modes:
+
+| Mode | Behavior | How to enter |
+|------|----------|--------------|
+| Ask (default) | Anything not covered by an allow rule prompts for confirmation | — |
+| Auto | A classifier auto-approves safe tools; dangerous ones may still prompt (`deny` rules and hooks still apply) | `/auto`, `Shift+Tab` (when the feature is enabled) |
+| Always-approve | Tool calls are auto-approved (`deny` rules and `PreToolUse` hooks still apply) | `/always-approve`, `Ctrl+O`, `Shift+Tab`, `grok --always-approve` |
+
+The default mode can only be set in the **user-level** `~/.grok/config.toml` (a project-level `.grok/config.toml` has no effect):
+
+```toml
+[ui]
+permission_mode = "auto"  # or "ask" | "always-approve"
+```
+
+Rule syntax (`--allow` / `--deny` accept the same patterns):
+
+```toml
+[permission]
+rules = [
+  { action = "allow", tool = "bash", pattern = "git *" },
+  { action = "allow", tool = "read" },
+  { action = "deny",  tool = "bash", pattern = "rm -rf *" },
+]
+```
+
+Three rules worth memorizing:
+
+1. **`deny` always beats `allow`.** The full precedence is deny > ask > allow ([settings/reference](https://docs.x.ai/build/settings/reference)) — it is not "last one wins".
+2. Supported filters: `Bash`, `Edit`, `Read`, `Grep`, `MCPTool`, `WebFetch`, `WebSearch`.
+3. Clicking "always allow" interactively still re-prompts for dangerous patterns like `rm` or `git push`. Only explicit allow rules in config or on the CLI truly auto-approve.
+
+## 6. Sandbox: off by default
+
+Per [sandbox](https://docs.x.ai/build/features/sandbox): Landlock on Linux, Seatbelt on macOS, and **`off` by default**.
+
+| Profile | Read | Write | Subprocess network | Use case |
+|---------|------|-------|--------------------|----------|
+| `off` | Unrestricted | Unrestricted | Allowed | Default, no sandbox |
+| `workspace` | Everywhere | CWD, `~/.grok/`, temp dirs | Allowed | Normal development |
+| `devbox` | Everywhere | Top-level dirs except `/data` | Allowed | Cloud devbox |
+| `read-only` | Everywhere | Only `~/.grok/` and temp dirs | Blocked | Code review, audit |
+| `strict` | CWD and system paths | CWD, `~/.grok/`, temp dirs | Blocked | Untrusted repos |
+
+Three ways to turn it on: `grok --sandbox workspace`, `[sandbox] profile = "workspace"`, or `GROK_SANDBOX=workspace`.
+
+Two limitations you must know (both stated explicitly by xAI):
+
+- **Subprocess network restrictions only apply on Linux.** On macOS, the network blocking in `read-only` / `strict` is a no-op.
+- Built-in profiles do **not** permanently protect sensitive paths such as `~/.ssh`; write your own deny list:
+
+```toml
+# ~/.grok/sandbox.toml
+[profiles.my-profile]
+extends = "workspace"
+restrict_network = true
+deny = ["/secrets", "**/.env", "**/*.pem"]
+```
+
+On Linux, "readable but with certain paths denied" requires `bubblewrap` installed on the system.
+
+## 7. Plan mode
+
+Enter with `/plan [description]`; view with `/view-plan` (aliases `/show-plan`, `/plan-view`). Keys on the plan review screen: `a` approve, `s` request changes, `c` comment, `q` quit, `Tab` switch focus.
+
+Two things to know ([plan-mode](https://docs.x.ai/build/features/plan-mode)):
+
+- Plan mode and permission mode are **independent**: even under auto or always-approve, the plan review screen is not skipped.
+- In plan mode only the session plan file is editable, but **bash can still write through redirection** — it is not hard isolation. If you need hard isolation, configure the sandbox.
+
+## 8. Session management
+
+Sessions are stored under `~/.grok/sessions/`, indexed by working directory ([sessions](https://docs.x.ai/build/features/sessions)).
+
+| Goal | How |
+|------|-----|
+| Resume the last session | `grok -c` (or `--continue`) |
+| Pick a session to resume | `grok --resume` (lists candidates when no ID is given) |
+| Resume a specific session | `grok --resume <id>` |
+| Resume from inside the TUI | `/resume` |
+| Fork the current session | `/fork [directive]`, optionally `--worktree` / `--no-worktree` |
+| Roll back history | `/rewind` or `Esc Esc` |
+| Compact the context | `/compact [focus]`; also happens automatically |
+| Check context usage | `/context`, `/session-info` |
+| List / search / delete | `grok sessions list` / `search` / `delete` |
+| Export | `grok export <session-id> [output]`, `--clipboard` for the clipboard |
+| Rename | `/rename` (alias `/title`) |
+
+Grabbing the session ID from headless mode:
+
+```bash
+grok -p "Start the refactor" --output-format json | jq -r '.sessionId'
+```
+
+## 9. Project rules: AGENTS.md
+
+Grok Build's primary project-rules file is `AGENTS.md`. Loading starts with the global rules in `~/.grok/`, then walks from the repository root down to the current directory ([project-rules](https://docs.x.ai/build/features/project-rules)).
+
+Files it reads:
+
+- `AGENTS.md`, `Agents.md`, `AGENT.md`
+- `CLAUDE.md`, `Claude.md`, `CLAUDE.local.md`
+- Every `*.md` under `.grok/rules/`, plus `.claude/rules/` and `.cursor/rules/`
+
+Gitignored files are skipped. For a one-off addition use `--rules <TEXT>`; to replace the whole system prompt use `--system-prompt-override <TEXT>`. `grok inspect` lists which rules files were actually loaded and each one's token count — start there when rules seem to be ignored.
+
+## 10. Switching models
+
+```bash
+grok -m grok-build-0.1 -p "Refactor this module"
+```
+
+Inside the TUI use `/model` (alias `/m`) or `Ctrl+M`. Reasoning effort is set with `/effort` or `--effort <LEVEL>`.
+
+Pointing at a self-hosted or third-party OpenAI-compatible endpoint ([overview](https://docs.x.ai/build/overview)):
+
+```toml
+# ~/.grok/config.toml (Windows: %USERPROFILE%\.grok\config.toml)
+[model.my-model]
+model = "model-id"
+base_url = "https://api.example.com/v1"
+name = "Display Name"
+env_key = "API_KEY"
+
+[models]
+default = "my-model"
+```
+
+After editing, confirm it was picked up with `grok inspect`, then verify with `grok -p "Hello" -m my-model`.
+
+## 11. Headless mode
+
+```bash
+grok -p "Explain this codebase"
+grok -p "Explain the architecture" --output-format streaming-json
+```
+
+Common parameters ([headless-scripting](https://docs.x.ai/build/cli/headless-scripting)):
+
+| Parameter | Purpose |
+|-----------|---------|
+| `-p, --single <PROMPT>` | Send a single prompt |
+| `-s, --session-id <ID>` | Create or reuse a named headless session |
+| `-r, --resume <ID>` / `-c, --continue` | Resume a session |
+| `--cwd <PATH>` | Set the working directory |
+| `--output-format <FMT>` | `plain` (human) / `json` (one object at the end) / `streaming-json` (line-delimited JSON events) |
+| `--always-approve` | Skip confirmations |
+| `--no-alt-screen` | Inline output instead of taking over the screen |
+
+Headless sessions live in `~/.grok/sessions` too.
+
+**Always disable auto-update in CI**: pass `--no-auto-update`, or persist it in `~/.grok/config.toml`:
+
+```toml
+[cli]
+auto_update = false
+```
+
+## 12. ACP: embed in an editor or your own orchestrator
+
+```bash
+grok agent stdio
+```
+
+This runs Grok as an ACP (Agent Client Protocol) agent, speaking JSON-RPC over stdin/stdout. The handshake order in the official example ([headless-scripting](https://docs.x.ai/build/cli/headless-scripting)):
+
+1. `initialize`, passing `protocolVersion: 1` and `clientCapabilities` (`fs.readTextFile` / `fs.writeTextFile` / `terminal`)
+2. `authenticate`: choose `xai.api_key` if `XAI_API_KEY` is set, otherwise `cached_token` (with neither, the official error text is "Run `grok login` first, or set XAI_API_KEY.")
+3. `session/new`, passing `{ cwd, mcpServers: [] }`
+4. `session/prompt`, passing `prompt: [{ type: "text", text: "..." }]`
+
+One critical detail: **the return value of `session/prompt` is only completion metadata. The assistant's actual text arrives as a stream of `agent_message_chunk` events via `session/update`** — reading only the return value makes it look like nothing was produced.
+
+## 13. Updating and troubleshooting
+
+```bash
+grok update --check        # check only
+grok update                # update
+grok update --version <V>  # install a specific version
+grok update --alpha        # switch to the alpha channel
+grok update --stable       # switch back to stable
+```
+
+| Symptom | Check first |
+|---------|-------------|
+| Config / rules / MCP not taking effect | `grok inspect` (see what was actually loaded) |
+| A project-level config key has no effect | A project `.grok/config.toml` **only supports `[mcp_servers]`, `[plugins]`, and `[permission]`**; every other key must go in `~/.grok/config.toml` |
+| MCP server will not start | `grok mcp doctor [name]`; logs are at `~/.grok/logs/mcp/<server>.stderr.log` |
+| Copy-paste or keys behaving oddly | `/terminal-setup` |
+| Web fetch tool does nothing | `GROK_WEB_FETCH` defaults to `0` (off for security); enable it explicitly |
+| Cannot connect from a corporate network | `cli-chat-proxy.grok.com` and `auth.x.ai` must be allowed ([enterprise](https://docs.x.ai/build/enterprise)) |
+
+Feedback goes through `/feedback` in the TUI. **Do not open PRs against [xai-org/grok-build](https://github.com/xai-org/grok-build)** — the README states "External contributions are not accepted."
+
+## Related pages
+
+- [Grok learning map](./index.md)
+- [Cookbook](./grok-cookbook.md) — hooks, MCP, skills, subagents, CI recipes
+- [Cheatsheet](./grok-cheatsheet.md) — full commands / flags / config keys / env vars
+- [Glossary](./grok-glossary.md) — permissions vs. sandbox, skill vs. plugin, and other distinctions

--- a/docs/products/ai-coding/grok/grok-connectors.md
+++ b/docs/products/ai-coding/grok/grok-connectors.md
@@ -1,0 +1,109 @@
+# Grok Connectors
+
+> Official definition ([docs.x.ai/grok/connectors](https://docs.x.ai/grok/connectors)):
+> "Connectors are available to all Grok users and let Grok access your external tools and data sources directly within a conversation. Search your email, browse files in cloud storage, check your calendar, and more without leaving the chat."
+>
+> Analog: [Claude Connectors](../claude/connectors.md). This page is the **chat** connector catalog. It is not Grok Build MCP (`grok mcp add`) and not Grok Bot plugins.
+
+## Goals and non-goals
+
+**Audience:** people who want Grok to read mail, Drive, calendar, or a custom MCP server **inside grok.com chat**.
+
+**Goals:** list the three official kinds, the built-in table, the Business admin gate, and the local-tunnel rule.
+
+**Non-goals:** a second MCP protocol tutorial, invented catalog entries, or Grok Build `[mcp_servers]` config (that is [grok-cli.md](./grok-cli.md) / [cookbook](./grok-cookbook.md)).
+
+## Three kinds
+
+[connectors](https://docs.x.ai/grok/connectors):
+
+| Kind | Who maintains it | How you add it |
+|------|------------------|----------------|
+| **Built-in** | xAI, native OAuth | [grok.com/connectors](https://grok.com/connectors) → **New Connector** → pick the service → OAuth |
+| **Catalog** | Pre-configured OAuth for more third-party services | Same page; browse the catalog. Official docs do not freeze a full name list |
+| **Custom MCP** | You (public MCP server) | **New Connector** → **Custom** → MCP server URL + auth |
+
+Once connected, Grok can use the connector's tools automatically when the question relates to that service. No extra per-chat toggle is documented on this page.
+
+### Built-in connectors
+
+Official table ([connectors](https://docs.x.ai/grok/connectors)):
+
+| Connector | What it connects |
+|-----------|------------------|
+| **Gmail & Google Calendar** | Gmail messages and Google Calendar events |
+| **Google Drive** | Google Drive files, Docs, Sheets, and Slides |
+| **OneDrive** | Microsoft OneDrive personal storage |
+| **Outlook Mail & Calendar** | Outlook email and calendar events |
+| **Microsoft Teams** | Microsoft Teams messages, channels, and chats |
+| **SharePoint** | Microsoft SharePoint sites and document libraries |
+| **Salesforce** | Salesforce CRM — explore objects, query records, create and update |
+
+### Custom MCP connectors
+
+Official capabilities ([connectors](https://docs.x.ai/grok/connectors)):
+
+- Expose any internal API, database, or SaaS tool to Grok.
+- Define your own tools with custom schemas and logic.
+- Control authentication and access on your own infrastructure.
+
+The MCP server **must be reachable over the public internet**. `localhost` and RFC1918 addresses (`127.0.0.1`, `10.x`, `172.16.x`, `192.168.x`) are **rejected** ([custom-mcp-tunneling](https://docs.x.ai/grok/connectors/custom-mcp-tunneling)).
+
+Tunnel pattern from that page:
+
+```text
+Grok ──► https://your-tunnel.example.com ──► tunnel provider ──► localhost:3001
+```
+
+Official examples: **ngrok** (`ngrok http 3001`) and **Cloudflare Tunnel** (`cloudflared tunnel --url http://localhost:3001`). Cloudflare **quick** tunnels do **not** support SSE — if your server uses SSE, use ngrok. Streamable HTTP is fine on Cloudflare.
+
+Tunnels are temporary on free tiers. Restart → new URL → remove the old connector and add the new one. Keep the local server running; Grok calls it on demand.
+
+## Business and Enterprise
+
+[connectors](https://docs.x.ai/grok/connectors):
+
+> For Grok Business and Enterprise users, a team admin must first provision a connector in the [cloud console](https://docs.x.ai/grok/connector-management) before it is available to members of the organization.
+
+Admin path ([connector-management](https://docs.x.ai/grok/connector-management)): [console.x.ai](https://console.x.ai) → team → **Grok Business → Connectors**. Adding/removing needs **Team Read-Write**.
+
+1. **+ Add Connector** from the catalog, or **Other** + MCP URL.
+2. Some Microsoft / Salesforce connectors need extra admin consent. The management page points at service-specific guides for SharePoint, OneDrive, and Salesforce.
+3. After the admin provisions it, members still connect **their own** accounts on [grok.com/connectors](https://grok.com/connectors).
+4. **Remove** deletes it for the team; indexed data associated with the connector may be removed.
+
+Personal (non-Business) accounts skip the admin step.
+
+## Not these connectors
+
+| Looks similar | Actually is |
+|---------------|-------------|
+| Grok chat Connectors | This page |
+| Grok Build MCP | `grok mcp add` / `[mcp_servers]` in `~/.grok/config.toml` — tools namespaced `<server>__<tool>` |
+| Grok Bot "Plugins" | [Grok Bot](./grok-bot.md) Settings → Plugins; `@` to attach |
+| Voice API `mcp` tool | Server-side MCP on `wss://api.x.ai/v1/realtime` ([Voice](./grok-voice.md)) |
+
+## Common pitfalls
+
+- Pointing a custom connector at `http://localhost:3001`. Officially rejected.
+- Expecting a Business member to see Gmail before an admin provisions it.
+- Copying Grok Build MCP config into grok.com. Different product, different host.
+- Using Cloudflare quick tunnels with an SSE MCP server.
+
+## Official docs
+
+| Page | Use |
+|------|-----|
+| [docs.x.ai/grok/connectors](https://docs.x.ai/grok/connectors) | Three kinds + built-in table |
+| [docs.x.ai/grok/connector-management](https://docs.x.ai/grok/connector-management) | Business admin provision |
+| [docs.x.ai/grok/connectors/custom-mcp-tunneling](https://docs.x.ai/grok/connectors/custom-mcp-tunneling) | Public URL / tunnels |
+| [grok.com/connectors](https://grok.com/connectors) | User-facing add/connect UI |
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | Connectors as a chat capability |
+
+## Related pages
+
+- [Grok Chat](./grok-chat.md)
+- [Grok Business](./grok-business.md) — admin must provision first
+- [Grok Build cookbook](./grok-cookbook.md) — CLI MCP, not this
+- [Grok Bot](./grok-bot.md)
+- [Grok learning map](./index.md)

--- a/docs/products/ai-coding/grok/grok-cookbook.md
+++ b/docs/products/ai-coding/grok/grok-cookbook.md
@@ -319,3 +319,4 @@ paths = ["/path/to/extra/plugins"]
 - [Grok Build tutorial](./grok-cli.md) — install, auth, TUI, permissions, sandbox
 - [Cheatsheet](./grok-cheatsheet.md) — full commands / flags / config keys / env vars
 - [Glossary](./grok-glossary.md) — why the design looks like this
+- [Grok Bot](./grok-bot.md) — cloud-computer teammates, not this CLI

--- a/docs/products/ai-coding/grok/grok-cookbook.md
+++ b/docs/products/ai-coding/grok/grok-cookbook.md
@@ -44,13 +44,25 @@ The same shape exists for `[compat.cursor]` (Cursor's `.cursor/rules`, `.cursor/
 
 ## 2. Adding external tools with MCP
 
+Three transports, from [mcp-servers](https://docs.x.ai/build/features/mcp-servers):
+
 ```bash
-grok mcp add
+# Local stdio server; everything after -- is the server command
+grok mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /path/to/dir
+
+# Remote HTTP server (OAuth handled automatically)
+grok mcp add --transport http linear https://mcp.linear.app/mcp
+
+# Remote + static auth header (--header is repeatable)
+grok mcp add --transport http api https://mcp.example.com/mcp --header "Authorization: Bearer ${API_TOKEN}"
+
 grok mcp list
 grok mcp doctor            # diagnose all servers
 grok mcp doctor <name>     # diagnose one
 grok mcp remove <name>
 ```
+
+`list` and `doctor` take `--json`. Pass `--scope project` to write the server into the repo `.grok/config.toml`.
 
 Or configure it in TOML — this is one of the three sections a **project-level** `.grok/config.toml` supports, so it can be committed for the team ([mcp-servers](https://docs.x.ai/build/features/mcp-servers)):
 
@@ -74,6 +86,21 @@ OAuth-based MCP servers store their tokens in `~/.grok/mcp_credentials.json`.
 ## 3. Blocking dangerous commands with hooks
 
 Hooks are **JSON** files (not TOML). Personal hooks live in `~/.grok/hooks/*.json`, project hooks in `<project>/.grok/hooks/*.json` ([hooks](https://docs.x.ai/build/features/hooks)).
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "bin/safety-check.sh", "timeout": 10 }]
+      }
+    ]
+  }
+}
+```
+
+`matcher` is a regular expression on the tool name (Claude names such as `Bash` / `Read` / `Edit` are mapped automatically); omit it to match everything. `type` is `"command"` or `"http"` (the latter needs `url`; the event is POSTed). `timeout` is seconds, default 5.
 
 `PreToolUse` is the **only blocking event**. The contract:
 
@@ -149,19 +176,22 @@ grok -r "$SESSION" -p "Now write the findings to REPORT.md"
 ## 6. Parallel development: worktrees plus the Dashboard
 
 ```bash
-grok -w feature-a                 # new session in a fresh git worktree
-grok -w feature-b --ref main      # base the worktree on a specific ref
+grok -w
+grok --worktree=feat "refactor module X"   # = keeps the prompt out of the name
+grok -w --ref main "fix the flaky test"    # clean checkout of the ref
+grok -w -r <session-id>                    # resume in a fresh worktree
 ```
 
-Worktrees live under `~/.grok/worktrees/<repo>/<name>` ([worktrees](https://docs.x.ai/build/features/worktrees)). Inside a session, `/fork --worktree` branches the conversation *and* isolates the files.
+Worktrees live under `~/.grok/worktrees/<repo>/<name>`, start from current HEAD **including uncommitted changes**, and require a git repository ([worktrees](https://docs.x.ai/build/features/worktrees)). Inside a session, `/fork --worktree` branches the conversation *and* isolates the files.
 
 Management:
 
 ```bash
 grok worktree list
-grok worktree show <name>
-grok worktree rm <name>
-grok worktree gc            # cleanup is manual, by design
+grok worktree show <id>
+grok worktree rm <ids...>          # --dry-run to preview
+grok worktree gc                   # cleanup is manual, by design
+grok worktree gc --max-age 7d      # also expire idle worktrees
 ```
 
 `gc` never runs automatically — deleting work an agent produced before you have looked at it would be worse than leaving stale directories around. So remember to run it.
@@ -172,7 +202,9 @@ Watch several sessions at once with the Agent Dashboard: `grok dashboard`, `/das
 
 Three different things that are easy to confuse ([subagents](https://docs.x.ai/build/features/subagents)):
 
-- **Subagent** — a unit of execution with its own context window that hands a summary back to the parent. Built-in types: `general-purpose`, `explore`, `plan`. `explore` is read-only with no shell and cannot edit files; `plan` also does not touch files. Custom types go in `~/.grok/agents/` or `.grok/agents/`, managed with `/config-agents` (alias `/agents`).
+- **Subagent** — a unit of execution with its own context window that hands a summary back to the parent. Built-in types: `general-purpose`, `explore`, `plan`. `explore` is read-only with no shell and cannot edit files; `plan` also does not touch files. Custom types go in `~/.grok/agents/` or `.grok/agents/`, managed with `/config-agents` (alias `/agents`). [subagents](https://docs.x.ai/build/features/subagents) says they are "Enabled by default when the setting is unset." [settings/reference](https://docs.x.ai/build/settings/reference) lists `GROK_SUBAGENTS` default `0`. Those two official sentences disagree — do not guess which wins; check `grok inspect`.
+
+<!-- TODO: 待核实 —— `[subagents] enabled` / `GROK_SUBAGENTS` when unset: feature page vs env-var table contradict each other -->
 - **Persona** — a behavioral overlay (tone, focus, contract). It changes **how** the agent talks, not **what tools** it can call. Defined in `~/.grok/personas/*.toml` or `.grok/personas/*.toml`, managed with `/personas`.
 - **Workflow** — orchestration written in `.rhai`, living in `~/.grok/workflows/*.rhai` or `.grok/workflows/*.rhai`. It fans out to subagents, validates, and aggregates; it runs in the background.
 
@@ -200,13 +232,15 @@ Subagents inherit the parent's permission mode but are **not** bound by the pare
 ## 8. Background tasks and scheduled checks
 
 ```text
-/loop [interval] <prompt>     # repeat a prompt on an interval
+/loop 5m Check if the test suite passes and report any failures
 /tasks                        # background tasks, subagents, scheduled jobs
 /btw <question>               # ask a side question without derailing the main thread
 /queue                        # prompts queued behind the current turn
 ```
 
-`Ctrl+B` pushes a running command into the background; `Ctrl+G` toggles the task panel.
+The interval accepts `Ns` (minimum 60), `Nm`, `Nh`, and `Nd`. The prompt **fires immediately**, then repeats; each firing is a new agent turn. Hard limits from [background-tasks](https://docs.x.ai/build/features/background-tasks): loops expire after 7 days, and at most 50 scheduled tasks can be active at once.
+
+`Ctrl+B` pushes a running command into the background; `Ctrl+G` toggles the task panel. For a real-time event stream rather than a periodic check, let the agent attach a monitor to a script — **every output line becomes a notification and interrupts the conversation**.
 
 Long-running bash is handled for you: `[toolset.bash] timeout_secs` defaults to 120, and `auto_background_on_timeout` defaults to `true`, so a command that exceeds the timeout moves to the background instead of dying. Raise the ceiling with `max_timeout_secs` (default 36000) and the output cap with `output_byte_limit` (default 20000 bytes).
 

--- a/docs/products/ai-coding/grok/grok-cookbook.md
+++ b/docs/products/ai-coding/grok/grok-cookbook.md
@@ -1,0 +1,287 @@
+# Grok Build Cookbook
+
+Task-oriented recipes. Concepts are in the [glossary](./grok-glossary.md); parameter lists are in the [cheatsheet](./grok-cheatsheet.md).
+
+## 1. Migrating from Claude Code
+
+Grok Build advertises zero-config compatibility, so the fastest path is: install, then just run it in an existing Claude Code project.
+
+What it picks up automatically:
+
+- Instruction files: `CLAUDE.md`, `Claude.md`, `CLAUDE.local.md`, `.claude/rules/*.md`
+- Skills, agents, MCP configs, hooks from `.claude/` (including `.claude/settings.json` hook definitions)
+- Marketplaces and plugins registered for Claude Code
+- Claude Code CLI flag aliases: `--allowedTools`, `--disallowedTools`, `--append-system-prompt`, `--system-prompt`, `--dangerously-skip-permissions`
+
+Two migration commands:
+
+```bash
+grok import              # import Claude Code sessions
+```
+
+Inside the TUI, `/import-claude` opens the settings-import dialog.
+
+Verify what actually loaded:
+
+```bash
+grok inspect
+```
+
+Turn compatibility scanning off per source if you do not want it ([settings/reference](https://docs.x.ai/build/settings/reference)):
+
+```toml
+[compat.claude]
+skills = false
+rules  = false
+agents = false
+mcps   = false
+hooks  = false
+```
+
+The same shape exists for `[compat.cursor]` (Cursor's `.cursor/rules`, `.cursor/hooks.json`, including its camelCase event names).
+
+**One deliberate exception**: Claude's `managed-settings.json` key `disableBypassPermissionsMode: "disable"` does **not** apply to Grok's always-approve mode. If you need that lock on the Grok side, write it in Grok's own `requirements.toml` (see recipe 4).
+
+## 2. Adding external tools with MCP
+
+```bash
+grok mcp add
+grok mcp list
+grok mcp doctor            # diagnose all servers
+grok mcp doctor <name>     # diagnose one
+grok mcp remove <name>
+```
+
+Or configure it in TOML — this is one of the three sections a **project-level** `.grok/config.toml` supports, so it can be committed for the team ([mcp-servers](https://docs.x.ai/build/features/mcp-servers)):
+
+```toml
+[mcp_servers.my-server]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
+startup_timeout_sec = 30
+tool_timeout_sec = 6000
+```
+
+Four things to know:
+
+1. **Tool names are namespaced** as `<server>__<tool>` (double underscore). Permission rules and `--tools` lists must use the namespaced name.
+2. Timeouts: `startup_timeout_sec` defaults to 30 and `tool_timeout_sec` to 6000 (both in **seconds**). The Claude-compatible `MCP_TIMEOUT` env var is in **milliseconds** and is checked *before* `GROK_MCP_STARTUP_TIMEOUT_SECS`.
+3. stdio server stderr goes to `~/.grok/logs/mcp/<server>.stderr.log` — the first place to look when a server will not start.
+4. Project-level MCP servers require trust: `--trust` at launch or `/hooks-trust` in the TUI; trusted directories are recorded in `~/.grok/trusted_folders.toml`.
+
+OAuth-based MCP servers store their tokens in `~/.grok/mcp_credentials.json`.
+
+## 3. Blocking dangerous commands with hooks
+
+Hooks are **JSON** files (not TOML). Personal hooks live in `~/.grok/hooks/*.json`, project hooks in `<project>/.grok/hooks/*.json` ([hooks](https://docs.x.ai/build/features/hooks)).
+
+`PreToolUse` is the **only blocking event**. The contract:
+
+- exit code `0` → allow
+- exit code `2` → block
+- anything else (timeout, crash, malformed output) → **fail-open**, i.e. the call proceeds
+
+That last rule matters: hooks are a guardrail, not a security boundary. If a hook must not be bypassable, pair it with the sandbox.
+
+Available events: `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionDenied`, `Stop`, `StopFailure`, `Notification`, `SubagentStart`, `SubagentStop`, `PreCompact`, `PostCompact`.
+
+Manage them from the TUI with `/hooks`. Project hooks also require trust (`--trust` or `/hooks-trust`).
+
+## 4. Tightening permissions
+
+Start from the rule that matters most: **`deny` beats `ask` beats `allow`** — it is a precedence ladder, not last-one-wins.
+
+Team-shareable, in a project `.grok/config.toml`:
+
+```toml
+[permission]
+rules = [
+  { action = "allow", tool = "read" },
+  { action = "allow", tool = "bash", pattern = "git status" },
+  { action = "allow", tool = "bash", pattern = "npm test" },
+  { action = "deny",  tool = "bash", pattern = "rm -rf *" },
+  { action = "deny",  tool = "bash", pattern = "git push *" },
+]
+```
+
+Filters: `Bash`, `Edit`, `Read`, `Grep`, `MCPTool`, `WebFetch`, `WebSearch`.
+
+Note the asymmetry: `[permission]` rules work at project level, but `[ui] permission_mode` (the default mode) **only** takes effect in user-level config. A repo you cloned cannot silently switch you into always-approve.
+
+To lock always-approve off org-wide, put it in a root-owned source ([enterprise](https://docs.x.ai/build/enterprise)):
+
+```toml
+# /etc/grok/requirements.toml  — must be root-owned to be honored
+[ui]
+disable_bypass_permissions_mode = true
+```
+
+Writing the same key into a user-writable `~/.grok/requirements.toml` does **not** create a tamper-resistant lock: a user who can add it can remove it.
+
+## 5. Running headless in CI and scripts
+
+```bash
+grok -p "Review the diff and list any risks" \
+  --output-format json \
+  --permission-mode dontAsk \
+  --no-auto-update
+```
+
+CI-specific choices worth making deliberately:
+
+| Concern | What to do |
+|---------|-----------|
+| Auth | `export XAI_API_KEY=...` (a secret in your CI settings, never committed) |
+| Permissions | `--permission-mode dontAsk` silently denies anything not explicitly allowed; `acceptEdits` auto-approves edits but still asks for shell |
+| Auto-update | `--no-auto-update`, or `GROK_DISABLE_AUTOUPDATER`, or `[cli] auto_update = false` |
+| Output parsing | `--output-format json` for one final object, `streaming-json` for line-delimited events |
+| Runaway loops | `--max-turns <N>` |
+| Network egress | Allow `cli-chat-proxy.grok.com` and `auth.x.ai` |
+| Isolation | Add `--sandbox read-only` for review-only jobs |
+
+Extract the session ID so a later step can continue the same session:
+
+```bash
+SESSION=$(grok -p "Start the audit" --output-format json | jq -r '.sessionId')
+grok -r "$SESSION" -p "Now write the findings to REPORT.md"
+```
+
+## 6. Parallel development: worktrees plus the Dashboard
+
+```bash
+grok -w feature-a                 # new session in a fresh git worktree
+grok -w feature-b --ref main      # base the worktree on a specific ref
+```
+
+Worktrees live under `~/.grok/worktrees/<repo>/<name>` ([worktrees](https://docs.x.ai/build/features/worktrees)). Inside a session, `/fork --worktree` branches the conversation *and* isolates the files.
+
+Management:
+
+```bash
+grok worktree list
+grok worktree show <name>
+grok worktree rm <name>
+grok worktree gc            # cleanup is manual, by design
+```
+
+`gc` never runs automatically — deleting work an agent produced before you have looked at it would be worse than leaving stale directories around. So remember to run it.
+
+Watch several sessions at once with the Agent Dashboard: `grok dashboard`, `/dashboard`, or `Ctrl+\`. Disable it with `[dashboard] enabled = false` or `GROK_AGENT_DASHBOARD=0`.
+
+## 7. Subagents, personas, and workflows
+
+Three different things that are easy to confuse ([subagents](https://docs.x.ai/build/features/subagents)):
+
+- **Subagent** — a unit of execution with its own context window that hands a summary back to the parent. Built-in types: `general-purpose`, `explore`, `plan`. `explore` is read-only with no shell and cannot edit files; `plan` also does not touch files. Custom types go in `~/.grok/agents/` or `.grok/agents/`, managed with `/config-agents` (alias `/agents`).
+- **Persona** — a behavioral overlay (tone, focus, contract). It changes **how** the agent talks, not **what tools** it can call. Defined in `~/.grok/personas/*.toml` or `.grok/personas/*.toml`, managed with `/personas`.
+- **Workflow** — orchestration written in `.rhai`, living in `~/.grok/workflows/*.rhai` or `.grok/workflows/*.rhai`. It fans out to subagents, validates, and aggregates; it runs in the background.
+
+```text
+/create-workflow [description]
+/workflow <name> [args]      # also pause / resume / stop / save
+/workflows                   # full-screen run board
+/deep-research <query>       # built-in research workflow
+```
+
+Routing and switches:
+
+```toml
+[subagents]
+enabled = true
+# per-type toggle and per-type model routing
+# toggle = { explore = true, plan = false }
+# models = { explore = "grok-build-0.1" }
+```
+
+The point of subagents is **context economy**: exploring a large repo generates a lot of intermediate output that is pure waste in the main session. Let `explore` compress a pile of search results into one conclusion.
+
+Subagents inherit the parent's permission mode but are **not** bound by the parent's plan-mode edit gate.
+
+## 8. Background tasks and scheduled checks
+
+```text
+/loop [interval] <prompt>     # repeat a prompt on an interval
+/tasks                        # background tasks, subagents, scheduled jobs
+/btw <question>               # ask a side question without derailing the main thread
+/queue                        # prompts queued behind the current turn
+```
+
+`Ctrl+B` pushes a running command into the background; `Ctrl+G` toggles the task panel.
+
+Long-running bash is handled for you: `[toolset.bash] timeout_secs` defaults to 120, and `auto_background_on_timeout` defaults to `true`, so a command that exceeds the timeout moves to the background instead of dying. Raise the ceiling with `max_timeout_secs` (default 36000) and the output cap with `output_byte_limit` (default 20000 bytes).
+
+See [background-tasks](https://docs.x.ai/build/features/background-tasks).
+
+## 9. Sessions and cross-session memory
+
+Session operations are covered in the [tutorial](./grok-cli.md#8-session-management). Two habits worth forming:
+
+- `/context` before a long task, to see how much budget is left; `/compact [focus]` to reclaim it while keeping what matters.
+- `/rewind` (or `Esc Esc` on an empty input) rolls back **both the conversation and the files on disk**. It is not "undo the last message" — uncommitted changes will be gone. Commit before you rewind.
+
+Cross-session memory is **off by default**:
+
+```bash
+grok --experimental-memory
+# or
+export GROK_MEMORY=1
+```
+
+```toml
+[memory]
+enabled = true
+```
+
+Once enabled, extra commands appear: `/remember <note>`, `/memory` (alias `/mem`), `/flush` (write memory to disk now), `/dream` (run memory consolidation). Clear it with:
+
+```bash
+grok memory clear --workspace   # this workspace only
+grok memory clear --global
+grok memory clear --all
+```
+
+## 10. Skills and plugins
+
+A **skill** adds knowledge and procedure; it does not change the tool set. A **plugin** is a distribution container that can bundle skills, commands, agents, hooks, MCP servers, and LSP config ([skills-plugins-marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces)).
+
+Locations: `~/.grok/skills/` and `./.grok/skills/`; `~/.grok/plugins/` and `./.grok/plugins/`.
+
+```bash
+grok plugin list
+grok plugin install <name>
+grok plugin uninstall <name>
+grok plugin update <name>
+grok plugin enable <name>
+grok plugin disable <name>
+grok plugin details <name>
+grok plugin validate <path>
+
+grok plugin marketplace list
+grok plugin marketplace add <source>
+grok plugin marketplace remove <name>
+grok plugin marketplace update
+```
+
+The official catalog is [xai-org/plugin-marketplace](https://github.com/xai-org/plugin-marketplace). TUI tabs: `/skills`, `/plugins`, `/marketplace`, `/mcps`, `/hooks` (all the same dialog).
+
+**A trap worth naming**: `allowed-tools` in a `SKILL.md` frontmatter sounds like an allowlist, but xAI states explicitly that it neither grants nor restricts tools. To actually control tools, use `[permission]` rules or `--tools` / `--disallowed-tools`.
+
+A user-invocable skill also becomes a slash command `/<skill-name>`. When names collide, use the qualified form such as `/local:commit`.
+
+Extra discovery paths and opt-outs:
+
+```toml
+[skills]
+paths = ["/path/to/extra/skills"]
+disabled = ["noisy-skill"]
+
+[plugins]
+paths = ["/path/to/extra/plugins"]
+```
+
+## Related pages
+
+- [Grok learning map](./index.md)
+- [Grok Build tutorial](./grok-cli.md) — install, auth, TUI, permissions, sandbox
+- [Cheatsheet](./grok-cheatsheet.md) — full commands / flags / config keys / env vars
+- [Glossary](./grok-glossary.md) — why the design looks like this

--- a/docs/products/ai-coding/grok/grok-cookbook.md
+++ b/docs/products/ai-coding/grok/grok-cookbook.md
@@ -214,7 +214,7 @@ See [background-tasks](https://docs.x.ai/build/features/background-tasks).
 
 ## 9. Sessions and cross-session memory
 
-Session operations are covered in the [tutorial](./grok-cli.md#8-session-management). Two habits worth forming:
+Session operations are covered in the [tutorial](./grok-cli.md#_8-session-management). Two habits worth forming:
 
 - `/context` before a long task, to see how much budget is left; `/compact [focus]` to reclaim it while keeping what matters.
 - `/rewind` (or `Esc Esc` on an empty input) rolls back **both the conversation and the files on disk**. It is not "undo the last message" — uncommitted changes will be gone. Commit before you rewind.

--- a/docs/products/ai-coding/grok/grok-glossary.md
+++ b/docs/products/ai-coding/grok/grok-glossary.md
@@ -1,0 +1,151 @@
+# Grok Build Glossary
+
+Concepts, not commands. Read this when something in Grok Build seems arbitrary — usually there is a reason, and it is usually about safety boundaries or context economy.
+
+## Five things called Grok
+
+The name collides constantly. Sorting it out first saves a lot of confusion:
+
+| Name | What it actually is |
+| --- | --- |
+| **Grok Build** | The terminal coding agent — the subject of these docs. Executable `grok`. |
+| Grok (the chat product) | The general-purpose assistant on [grok.com](https://grok.com) and inside X. Not a coding tool. |
+| `grok-4.6` | A model. The one currently driving Grok Build. |
+| `grok-build-0.1` | A different model, trained specifically for agentic coding. Cheaper, smaller context. |
+| xAI API | The model API at `api.x.ai`. Grok Build is a *client* of it, not the same thing. |
+
+"Grok Code" and "Grok CLI" are **not** official names. The official name is Grok Build, and the source repository is [xai-org/grok-build](https://github.com/xai-org/grok-build).
+
+## One agent, three faces
+
+Grok Build is a single agent exposed through three surfaces, not three products:
+
+- **TUI** (`grok`) — a full-screen terminal UI. Human in the loop.
+- **Headless** (`grok -p "..."`) — one prompt, structured output, exit. No human.
+- **ACP** (`grok agent stdio`) — JSON-RPC over stdin/stdout so a host application drives it.
+
+They share sessions, configuration, permission rules, hooks, and MCP servers. A session started in the TUI can be resumed headlessly and vice versa, because sessions are stored on disk under `~/.grok/sessions/`, keyed by working directory.
+
+The practical consequence: there is no "IDE version" to learn. Editor integration means an editor speaking ACP to the same binary.
+
+## Permissions and the sandbox are two orthogonal axes
+
+The single most common misunderstanding. xAI states it plainly:
+
+> Permissions decide which tool calls may run. The sandbox is separate: it limits what an approved call can do on the filesystem and network.
+
+Think of it as two gates in series:
+
+1. **Permission gate** — may this tool call happen at all? Answered by `allow` / `ask` / `deny` rules and the current permission mode.
+2. **Sandbox** — now that it is running, what can it reach? Answered by the OS (Landlock on Linux, Seatbelt on macOS).
+
+Always-approve mode opens the first gate wide. It does **not** touch the second. That is why `grok --always-approve --sandbox read-only` is a coherent combination and a genuinely useful one: let the agent work uninterrupted, but make it physically unable to write.
+
+Conversely, a permissive sandbox with strict `deny` rules is the opposite trade: the agent asks less often about safe things but is hard-blocked on the patterns you named.
+
+The sandbox is off by default, so out of the box you only have the first gate.
+
+## Five config layers: why the highest priority lives in /etc
+
+Configuration precedence runs, from lowest to highest:
+
+| Layer | Path | Who controls it |
+| --- | --- | --- |
+| 1 | `/etc/grok/managed_config.toml` | Admin — **defaults** |
+| 2 | `~/.grok/managed_config.toml` | MDM-delivered user defaults |
+| 3 | `~/.grok/config.toml` | The user |
+| 4 | `~/.grok/requirements.toml` | User-level hard requirements |
+| 5 | `/etc/grok/requirements.toml` | Admin — **mandates** |
+
+Note the shape: the admin appears twice, at the bottom *and* the top. `managed_config.toml` sets defaults the user may override; `requirements.toml` sets constraints the user may not. That is why "managed" and "required" are separate files rather than one file with a priority flag — they express different intents.
+
+One detail that turns this from theory into practice: the tamper-resistance lock is honored **only when the source file is root-owned**. Writing `disable_bypass_permissions_mode = true` into a user-writable `~/.grok/requirements.toml` is not a lock, because whoever wrote it can also delete it.
+
+A project-level `.grok/config.toml` is deliberately not in this ladder. It only supports `[mcp_servers]`, `[plugins]`, and `[permission]`. A repository you clone cannot change your default permission mode, your model, or your sandbox profile. That restriction is the security property, not an oversight.
+
+## Authentication: four paths and one resolution order
+
+Four ways in — browser OIDC, device code, API key, external auth provider — but only one order of resolution:
+
+`model.api_key` > `model.env_key` > active session token > `XAI_API_KEY`
+
+Read it as "most specific wins". A per-model key beats an environment variable, which is what you want when one model in your config points at a third-party endpoint: that model's key should not be shadowed by the global `XAI_API_KEY`.
+
+The order also explains a confusing symptom. If you `grok login` and *also* export `XAI_API_KEY`, the session token wins, and usage lands on your subscription rather than your API credit. Which is usually right, and occasionally surprising.
+
+## AGENTS.md: why deeper files win
+
+Rules load global-first, then from the repository root downward to the current directory. Later files take precedence, so the deepest `AGENTS.md` wins.
+
+This is the inverse of how CSS specificity feels but the same as how you'd reason about it in person: repository-wide conventions are the backdrop, and the conventions of the specific package you are standing in are the foreground. `packages/legacy-widget/AGENTS.md` saying "this directory is CommonJS, do not convert it" must beat the root file saying "we use ESM".
+
+Grok Build also reads the Claude family (`CLAUDE.md`, `CLAUDE.local.md`, `.claude/rules/`) and Cursor's `.cursor/rules/` in the same walk. Gitignored files are skipped — so a personal `CLAUDE.local.md` that you gitignored is *not* loaded, which is worth knowing before you spend an hour wondering why your rule has no effect. `grok inspect` prints exactly which rules files loaded, with token counts.
+
+## Plan mode gates edits, not the shell
+
+In plan mode only the session plan file is editable. It sounds like a read-only mode. It is not.
+
+xAI is explicit that bash can still write through shell redirection. `echo x > file.txt` is a bash call, not an edit call, and the plan-mode gate is on the edit tools. So plan mode prevents *accidental* edits and preserves the review step; it is not an isolation boundary.
+
+If you want an actual boundary, that is what the sandbox is for. This is the same distinction as the two gates above, showing up in a different place.
+
+Plan mode is also independent of permission mode: always-approve does not skip the plan review screen. The two systems compose rather than override.
+
+## A session is branchable state, not a chat log
+
+Four operations make sense only if you stop thinking of a session as a transcript:
+
+- **fork** (`/fork`) — branch the conversation. Optionally `--worktree`, which branches the *files* too. Two agents, two states, from a shared prefix.
+- **rewind** (`/rewind`, or `Esc Esc` on an empty input) — roll back to an earlier turn. **This reverts files on disk as well.** It is not "delete the last message"; uncommitted work disappears. Commit first.
+- **compact** (`/compact [focus]`) — rewrite history into a summary to reclaim context. Also happens automatically.
+- **resume** (`grok -c`, `grok -r <id>`) — pick a stored state back up, from any of the three surfaces.
+
+Once files are part of the state, fork plus worktree becomes the natural way to try two approaches to the same problem, and the Agent Dashboard (`Ctrl+\`) becomes necessary rather than decorative — you now have several live states to watch.
+
+Worktree cleanup (`grok worktree gc`) never runs automatically. Automatic cleanup would eventually delete agent output nobody has reviewed yet, which is a worse failure than leaving stale directories on disk.
+
+## Five extension mechanisms and their division of labor
+
+They overlap enough to be confusing, so here is what each one actually changes:
+
+| Mechanism | Changes | Lives in |
+| --- | --- | --- |
+| **Skill** | Knowledge and procedure — *how* to do a thing | `~/.grok/skills/`, `./.grok/skills/` |
+| **MCP server** | The tool set — *what* the agent can call | `[mcp_servers]` in config |
+| **Plugin** | Distribution — packages skills, commands, agents, hooks, MCP, LSP together | `~/.grok/plugins/`, `./.grok/plugins/` |
+| **Subagent** | Execution — a separate context window that reports a summary back | `~/.grok/agents/`, `.grok/agents/` |
+| **Workflow** | Orchestration — `.rhai` scripts that fan out and aggregate | `~/.grok/workflows/*.rhai` |
+| **Persona** | Behavior — tone, focus, output contract | `~/.grok/personas/*.toml` |
+
+Two misconceptions worth naming:
+
+**`allowed-tools` in a skill's frontmatter is not permission control.** xAI states that it neither grants nor restricts tools. It is a hint. Real control is `[permission]` rules, `--tools`, and `--disallowed-tools`. Treating a skill's frontmatter as a security boundary is a mistake with real consequences.
+
+**A persona is not a kind of subagent.** A persona changes how the agent writes; a subagent changes where the work runs and whose context window pays for it. You can apply a persona to a subagent, which is exactly why they are separate concepts.
+
+Subagents exist for **context economy**. Exploring a large repository produces a lot of intermediate output — file listings, search hits, dead ends — that is pure noise in the main conversation. The `explore` subagent burns its own context window on that and hands back a conclusion. It is read-only, cannot run shell commands, and cannot edit files, which is what makes it safe to run without supervision.
+
+## Why it goes out of its way to be Claude Code compatible
+
+Grok Build reads `CLAUDE.md`, `.claude/settings.json` hooks, Claude skills and agents and MCP configs, accepts Claude Code's CLI flag names as aliases, and ships `grok import` for Claude Code sessions. The README's phrasing: "Grok is fully compatible with Claude Code with zero configuration needed."
+
+The strategic reading is obvious — it removes the switching cost for the incumbent's users. The practical reading matters more to you: **a repository configured for Claude Code is already configured for Grok Build**, which makes a genuine side-by-side comparison cheap. Run both on the same task, same rules, same tools.
+
+There is one deliberate gap in the compatibility, and it is instructive. Claude's `disableBypassPermissionsMode: "disable"` is *not* applied to Grok's always-approve mode, and Grok's own `/etc/grok/requirements.toml` always takes precedence over Claude's `managed-settings.json`. Compatibility extends to convenience, not to security policy — Grok will not let another vendor's config file decide its safety boundaries.
+
+## Why this document will go out of date
+
+Grok Build entered early beta on 2026-05-25. The npm package has shipped 552 versions since 2025-10-22, recently at roughly one every one to three days. External pull requests are not accepted; feedback goes through `/feedback`.
+
+So treat every table here as a snapshot, and prefer these habits over memorizing values:
+
+- `grok --help` and `grok <subcommand> --help` are the authoritative command surface.
+- `grok inspect --json` answers "what is actually loaded on this machine" better than any document can.
+- [x.ai/build/changelog](https://x.ai/build/changelog) is usually ahead of the docs site. When behavior does not match documentation, check it first.
+
+## Related pages
+
+- [Grok learning map](./index.md)
+- [Grok Build tutorial](./grok-cli.md)
+- [Grok Build cookbook](./grok-cookbook.md)
+- [Grok Build cheatsheet](./grok-cheatsheet.md)

--- a/docs/products/ai-coding/grok/grok-glossary.md
+++ b/docs/products/ai-coding/grok/grok-glossary.md
@@ -135,13 +135,13 @@ There is one deliberate gap in the compatibility, and it is instructive. Claude'
 
 ## Why this document will go out of date
 
-Grok Build entered early beta on 2026-05-25. The npm package has shipped 552 versions since 2025-10-22, recently at roughly one every one to three days. External pull requests are not accepted; feedback goes through `/feedback`.
+Grok Build entered early beta on 2026-05-25. npm `@xai-official/grok` `latest` moved 1.0.3 → 1.0.5 between 2026-08-12 and 2026-08-16. External pull requests are not accepted; feedback goes through `/feedback`.
 
 So treat every table here as a snapshot, and prefer these habits over memorizing values:
 
 - `grok --help` and `grok <subcommand> --help` are the authoritative command surface.
 - `grok inspect --json` answers "what is actually loaded on this machine" better than any document can.
-- [x.ai/build/changelog](https://x.ai/build/changelog) is usually ahead of the docs site. When behavior does not match documentation, check it first.
+- [x.ai/build/changelog](https://x.ai/build/changelog) can list commands before [CLI Reference](https://docs.x.ai/build/cli/reference) does. When behavior does not match documentation, check the changelog first.
 
 ## Related pages
 

--- a/docs/products/ai-coding/grok/grok-glossary.md
+++ b/docs/products/ai-coding/grok/grok-glossary.md
@@ -9,11 +9,14 @@ The name collides constantly. Sorting it out first saves a lot of confusion:
 | Name | What it actually is |
 | --- | --- |
 | **Grok Build** | The terminal coding agent — the subject of these docs. Executable `grok`. Docs live under `docs.x.ai/build/*`. |
-| Grok (the chat product) | The general-purpose assistant on [grok.com](https://grok.com), the Grok apps, and inside X. Chat, search, voice, files. |
-| Imagine | Image and video generation / editing. Consumer entry: [grok.com/imagine](https://grok.com/imagine). Programmatic entry: the [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine). |
-| Build Mode | A grok.com / Grok-app **chat mode** (mode switcher → **Build**). Early Beta for SuperGrok Heavy. Builds a working preview in the conversation and publishes it. **Not** Grok Build. |
+| [Grok (the chat product)](./grok-chat.md) | The general-purpose assistant on [grok.com](https://grok.com), the Grok apps, and inside X. Chat, search, voice, files. |
+| [Imagine](./grok-imagine.md) | Image and video generation / editing. Consumer entry: [grok.com/imagine](https://grok.com/imagine). Programmatic entry: the [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine). |
+| [Voice](./grok-voice.md) | Two boxes: **product** Voice ("Talk to Grok hands-free") on grok.com / apps, and the **Voice API** (TTS / STT / Speech to Speech). |
+| [Connectors](./grok-connectors.md) | Chat-side links to email, files, calendar, catalog OAuth, or a public MCP server. Not Grok Build `grok mcp add`. |
+| Build Mode | A grok.com / Grok-app **chat mode** (mode switcher → **Build**). Early Beta for SuperGrok Heavy on web, iOS, and Android ([x.ai/grok/build-mode](https://x.ai/grok/build-mode), [news](https://x.ai/news/grok-build-mode)). "Tell Grok an idea, and it builds a working version live in your chat." Publish to grok.me or a custom domain. Websites, apps, games, dashboards (dashboards can use Connectors). Nothing to install. **Not** Grok Build. Official density is a marketing page + one news post, so no standalone tutorial. |
 | grok.me | The **publish host** for Build Mode ("Publish to a grok.me link or a custom domain you own"). Not a product, not the CLI. |
-| Grok Bot | Named AI teammates on one persistent cloud computer. Desktop + iOS. Docs: [docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview). **Not** Grok Build headless. |
+| [Grok Bot](./grok-bot.md) | Named AI teammates on one persistent cloud computer. Desktop + iOS. Docs: [docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview). **Not** Grok Build headless. |
+| [Grok Business](./grok-business.md) | Team workspaces, SuperGrok / SuperGrok Heavy licenses, org sharing. Docs: [docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide). |
 | `grok-4.6` | A model. The one currently driving Grok Build. |
 | `grok-build-0.1` | A different model, trained specifically for agentic coding. Cheaper, smaller context. |
 | xAI API | The model API at `api.x.ai`. Grok Build is a *client* of it, not the same thing. |
@@ -25,7 +28,7 @@ The name collides constantly. Sorting it out first saves a lot of confusion:
 - grok.me as a separate "Build product" — it is only the publish URL for Build Mode.
 - Third-party posts about "Grok 4.3", "2 million token context", "Arena Mode", or "8 parallel agents" as product specs — this set only records slugs and limits that appear on [docs.x.ai](https://docs.x.ai/developers/models) or [x.ai](https://x.ai).
 
-The decision tree for picking a surface is on the [learning map](./index.md). Grok Bot has its own page: [Grok Bot](./grok-bot.md).
+The decision tree for picking a surface is on the [learning map](./index.md). Product maps: [Chat](./grok-chat.md), [Imagine](./grok-imagine.md), [Voice](./grok-voice.md), [Connectors](./grok-connectors.md), [Grok Bot](./grok-bot.md), [Business](./grok-business.md).
 
 ## One agent, three faces
 
@@ -160,4 +163,9 @@ So treat every table here as a snapshot, and prefer these habits over memorizing
 - [Grok Build tutorial](./grok-cli.md)
 - [Grok Build cookbook](./grok-cookbook.md)
 - [Grok Build cheatsheet](./grok-cheatsheet.md)
+- [Grok Chat](./grok-chat.md)
+- [Imagine](./grok-imagine.md)
+- [Voice](./grok-voice.md)
+- [Connectors](./grok-connectors.md)
 - [Grok Bot](./grok-bot.md)
+- [Grok Business](./grok-business.md)

--- a/docs/products/ai-coding/grok/grok-glossary.md
+++ b/docs/products/ai-coding/grok/grok-glossary.md
@@ -2,19 +2,30 @@
 
 Concepts, not commands. Read this when something in Grok Build seems arbitrary — usually there is a reason, and it is usually about safety boundaries or context economy.
 
-## Five things called Grok
+## Things called Grok
 
 The name collides constantly. Sorting it out first saves a lot of confusion:
 
 | Name | What it actually is |
 | --- | --- |
-| **Grok Build** | The terminal coding agent — the subject of these docs. Executable `grok`. |
-| Grok (the chat product) | The general-purpose assistant on [grok.com](https://grok.com) and inside X. Not a coding tool. |
+| **Grok Build** | The terminal coding agent — the subject of these docs. Executable `grok`. Docs live under `docs.x.ai/build/*`. |
+| Grok (the chat product) | The general-purpose assistant on [grok.com](https://grok.com), the Grok apps, and inside X. Chat, search, voice, files. |
+| Imagine | Image and video generation / editing. Consumer entry: [grok.com/imagine](https://grok.com/imagine). Programmatic entry: the [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine). |
+| Build Mode | A grok.com / Grok-app **chat mode** (mode switcher → **Build**). Early Beta for SuperGrok Heavy. Builds a working preview in the conversation and publishes it. **Not** Grok Build. |
+| grok.me | The **publish host** for Build Mode ("Publish to a grok.me link or a custom domain you own"). Not a product, not the CLI. |
+| Grok Bot | Named AI teammates on one persistent cloud computer. Desktop + iOS. Docs: [docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview). **Not** Grok Build headless. |
 | `grok-4.6` | A model. The one currently driving Grok Build. |
 | `grok-build-0.1` | A different model, trained specifically for agentic coding. Cheaper, smaller context. |
 | xAI API | The model API at `api.x.ai`. Grok Build is a *client* of it, not the same thing. |
 
-"Grok Code" and "Grok CLI" are **not** official names. The official name is Grok Build, and the source repository is [xai-org/grok-build](https://github.com/xai-org/grok-build).
+**Not official names or products (do not write them as facts):**
+
+- "Grok Code" and "Grok CLI" — the official product name is Grok Build; the binary is `grok`; the repo is [xai-org/grok-build](https://github.com/xai-org/grok-build).
+- An official VS Code / JetBrains plugin — editor integration is ACP (`grok agent stdio`).
+- grok.me as a separate "Build product" — it is only the publish URL for Build Mode.
+- Third-party posts about "Grok 4.3", "2 million token context", "Arena Mode", or "8 parallel agents" as product specs — this set only records slugs and limits that appear on [docs.x.ai](https://docs.x.ai/developers/models) or [x.ai](https://x.ai).
+
+The decision tree for picking a surface is on the [learning map](./index.md). Grok Bot has its own page: [Grok Bot](./grok-bot.md).
 
 ## One agent, three faces
 
@@ -149,3 +160,4 @@ So treat every table here as a snapshot, and prefer these habits over memorizing
 - [Grok Build tutorial](./grok-cli.md)
 - [Grok Build cookbook](./grok-cookbook.md)
 - [Grok Build cheatsheet](./grok-cheatsheet.md)
+- [Grok Bot](./grok-bot.md)

--- a/docs/products/ai-coding/grok/grok-imagine.md
+++ b/docs/products/ai-coding/grok/grok-imagine.md
@@ -1,0 +1,155 @@
+# Grok Imagine
+
+> **Imagine** is xAI's image and video surface. Official consumer entry is [grok.com/imagine](https://grok.com/imagine). Official API entry is the [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine):
+> "The Imagine API lets you generate and edit images and videos with Grok Imagine models."
+>
+> This page maps the **product** (chat + grok.com/imagine + iOS/Android) and the **API**. Analog: Claude Design / Gemini Flow — a creative surface, **not** a coding agent.
+
+## Goals and non-goals
+
+**Audience:** people who want images or short video from Grok, either in the app or from `api.x.ai`.
+
+**Goals:** separate product Imagine from the Imagine API, list official models and workflows, point at docs.
+
+**Non-goals:** a second copy of the full REST reference, invented quotas, or third-party "Grok 4.3 / 2M token" claims. Do not treat Imagine as Grok Build.
+
+## Two doors
+
+| Door | Who it is for | Entry |
+|------|---------------|-------|
+| **Product Imagine** | Chat users on grok.com / iOS / Android | [grok.com/imagine](https://grok.com/imagine), or generate inside a [Grok Chat](./grok-chat.md) thread |
+| **Imagine API** | Your own app | [docs.x.ai/developers/model-capabilities/imagine](https://docs.x.ai/developers/model-capabilities/imagine), playground on [console.x.ai](https://console.x.ai) |
+
+[x.ai/grok](https://x.ai/grok) describes the product in one line: generate images and video from text or reference photos; restyle, edit, and iterate without leaving the conversation. Marketing numbers on that page: **up to 2K** stills and **15-second** videos (video also listed as "up to 15 seconds at 720p" in the feature grid — resolution caps also depend on plan, see FAQ).
+
+Paid usage draws from the **same weekly SuperGrok pool** as Chat / Voice / Build ([FAQ](https://docs.x.ai/grok/faq)). This page does not invent how many images a plan includes.
+
+## Product Imagine
+
+Official consumer facts:
+
+- [overview](https://docs.x.ai/grok/overview): "Create images and video with Grok Imagine."
+- [x.ai/news/grok-imagine-image-2](https://x.ai/news/grok-imagine-image-2) (2026-08-07): **Imagine Image 2.0** is generally available as **Quality Mode** on grok.com/imagine and the iOS / Android apps.
+- Same post: product tools include a **magic wand** (edit the region you point at), **segmentation**, **background removal**, **multi-ref editing (up to 5 input images)**, **smart resize** to another aspect ratio, and **templates** (photo edit, product shots, headshots, icons, game assets, and more).
+- [x.ai/news/grok-imagine-video-1-5-references](https://x.ai/news/grok-imagine-video-1-5-references) (2026-07-31): **text-to-video** and **native 1080p** (text-to-video and image-to-video) are generally available on grok.com/imagine, iOS, and Android. Image + voice references started in the US for SuperGrok Heavy and SuperGrok Plus, then rolled out. Up to **seven** image references per generation.
+
+### Product rules you will hit ([FAQ](https://docs.x.ai/grok/faq))
+
+- Generated images and videos include a **Grok watermark**. There is no setting to remove it. Removing, altering, or obscuring the watermark is prohibited under the Acceptable Use Policy.
+- Enabling **NSFW** does **not** turn off moderation. CSAM and non-consensual intimate imagery are never permitted.
+- **720p videos automatically fall back to 480p** once you hit the 720p cap for your tier.
+
+## Imagine API
+
+Official overview ([imagine](https://docs.x.ai/developers/model-capabilities/imagine)): image generation, image editing with up to **3** reference images, video from text or stills, video editing, reference-to-video, video extension, and Files API integration.
+
+That **3-image API edit cap** is not the same number as the product's "up to 5 input images" on Image 2.0. Quote the page you are on.
+
+### Models (official slugs)
+
+| Job | Official pick ([developers/models](https://docs.x.ai/developers/models), [imagine](https://docs.x.ai/developers/model-capabilities/imagine)) |
+|-----|------------------------------------------------------------------------------------------------------------------------------------------|
+| Images | `grok-imagine-image-2.0` |
+| Videos | `grok-imagine-video-1.5` |
+
+[x.ai/api/imagine](https://x.ai/api/imagine): up to **2K** resolution, **10 images per request**, video **up to 15s**. Image generation is **flat per-image**. Image edits bill **input + output**. Video is **per-second**, duration and resolution both affect cost. Prices live on [developers/models](https://docs.x.ai/developers/models) / [pricing](https://docs.x.ai/developers/pricing#imagine-api-pricing) — do not copy a third-party table.
+
+### Image generation
+
+Endpoint: `POST https://api.x.ai/v1/images/generations`. Official knobs ([images/generation](https://docs.x.ai/developers/model-capabilities/images/generation)):
+
+- `n` — multiple images in one request (overview: up to 10).
+- `aspect_ratio` — `1:1`, `16:9` / `9:16`, `4:3` / `3:4`, `3:2` / `2:3`, `2:1` / `1:2`, `19.5:9` / `9:19.5`, `20:9` / `9:20`, `auto`.
+- `resolution` — `1k` or `2k`.
+- `quality` — `low` or `medium` (default `medium`). **Only** on `grok-imagine-image-2.0`.
+- Default return is a **temporary URL**. Download promptly, or request base64.
+
+```bash
+curl -X POST https://api.x.ai/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -d '{
+    "model": "grok-imagine-image-2.0",
+    "prompt": "A collage of London landmarks in a stenciled street-art style",
+    "aspect_ratio": "16:9",
+    "resolution": "2k"
+  }'
+```
+
+Edit path: `POST https://api.x.ai/v1/images/edits` with a public URL or `data:` URI ([imagine](https://docs.x.ai/developers/model-capabilities/imagine)).
+
+### Video generation
+
+Endpoint: `POST https://api.x.ai/v1/videos/generations`, then poll `GET https://api.x.ai/v1/videos/{request_id}` ([video/generation](https://docs.x.ai/developers/model-capabilities/video/generation)).
+
+Official constraints:
+
+| Knob | Official range |
+|------|----------------|
+| `duration` | 1–15 seconds |
+| `aspect_ratio` | `1:1`, `16:9` / `9:16` (default `16:9`), `4:3` / `3:4`, `3:2` / `2:3` |
+| `resolution` | `480p` (default), `720p`, `1080p` on `grok-imagine-video-1.5` for text-to-video and image-to-video. Reference-to-video is capped at 720p |
+| Status | `pending` → `done` / `expired` / `failed` |
+| Modes (one per request) | text-to-video, image-to-video, reference-to-video, edit-video, extend-video |
+
+Do **not** send `image` and `reference_images` together (400). Video URLs are temporary.
+
+```bash
+REQUEST_ID=$(curl -s -X POST https://api.x.ai/v1/videos/generations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -d '{
+    "model": "grok-imagine-video-1.5",
+    "prompt": "A glowing crystal-powered rocket launching from Mars",
+    "duration": 10,
+    "aspect_ratio": "16:9",
+    "resolution": "720p"
+  }' | jq -r '.request_id')
+
+curl -s "https://api.x.ai/v1/videos/$REQUEST_ID" \
+  -H "Authorization: Bearer $XAI_API_KEY"
+```
+
+The xAI SDK's `generate()` polls for you. REST users must poll.
+
+Voice on video: preset `voice_id` values (same roster as TTS) are generally available on reference-to-video. **Voice references from your own audio files** are trusted-partner only, [on request](https://x.ai/contact-sales?interest=imagine) ([video/generation](https://docs.x.ai/developers/model-capabilities/video/generation), [news](https://x.ai/news/grok-imagine-video-1-5-references)).
+
+Generated media is subject to content-policy review and is **not used for training** ([imagine](https://docs.x.ai/developers/model-capabilities/imagine)). Enterprise bullets on that page: SOC 2 Type II, HIPAA eligible, GDPR, data residency, SSO & RBAC.
+
+## When to use which
+
+| You want | Use |
+|----------|-----|
+| A poster / clip inside Grok | Product Imagine on grok.com/imagine or in chat |
+| Images or video inside your product | Imagine API |
+| A working website / game with a `*.grok.me` link | **Build Mode** on grok.com, not Imagine ([x.ai/grok/build-mode](https://x.ai/grok/build-mode)) |
+| Edits in a real git repo | [Grok Build](./grok-cli.md) |
+
+## Common pitfalls
+
+- Mixing the product **5-image** editor with the API **3-image** edit cap.
+- Assuming API 1080p works on every mode — reference-to-video is 720p; editing keeps the input resolution, capped at 720p.
+- Leaving Imagine output on the temporary URL.
+- Treating Imagine as "Grok 4.3 with 2M context". Image/video slugs are `grok-imagine-*`. The coding flagship is `grok-4.6`.
+- Removing the product watermark. Officially forbidden.
+
+## Official docs
+
+| Page | Use |
+|------|-----|
+| [grok.com/imagine](https://grok.com/imagine) | Consumer studio |
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | Imagine as a chat capability |
+| [docs.x.ai/grok/faq](https://docs.x.ai/grok/faq) | Watermark, NSFW, 720p fallback, weekly pool |
+| [docs.x.ai/developers/model-capabilities/imagine](https://docs.x.ai/developers/model-capabilities/imagine) | API overview |
+| [images/generation](https://docs.x.ai/developers/model-capabilities/images/generation) | Still images |
+| [video/generation](https://docs.x.ai/developers/model-capabilities/video/generation) | Video |
+| [x.ai/api/imagine](https://x.ai/api/imagine) | API marketing |
+| [x.ai/news/grok-imagine-image-2](https://x.ai/news/grok-imagine-image-2) | Image 2.0 / Quality Mode |
+| [x.ai/news/grok-imagine-video-1-5-references](https://x.ai/news/grok-imagine-video-1-5-references) | 1080p, references |
+
+## Related pages
+
+- [Grok Chat](./grok-chat.md) — Imagine also lives inside a thread
+- [Voice](./grok-voice.md) — TTS roster reused as video preset voices
+- [Grok learning map](./index.md)
+- [Glossary](./grok-glossary.md)

--- a/docs/products/ai-coding/grok/grok-voice.md
+++ b/docs/products/ai-coding/grok/grok-voice.md
@@ -1,0 +1,184 @@
+# Grok Voice
+
+> Two different things share the word **Voice**.
+>
+> **Product Voice** is "Talk to Grok hands-free with voice" on grok.com and the iOS / Android apps ([docs.x.ai/grok/overview](https://docs.x.ai/grok/overview)).
+>
+> **Voice API** is the developer stack at [docs.x.ai/developers/model-capabilities/audio/voice](https://docs.x.ai/developers/model-capabilities/audio/voice): Speech to Speech, Text to Speech, Speech to Text, and custom voices.
+>
+> This page maps both. It is **not** Grok Build.
+
+## Goals and non-goals
+
+**Audience:** people who want to *talk* to Grok, or ship voice in their own app.
+
+**Goals:** keep product Voice and the Voice API in separate boxes; list official endpoints; mark missing product-UI detail as TODO.
+
+**Non-goals:** a full realtime event reference, invented app-button paths, or third-party voice-arena rankings as product specs.
+
+## Product Voice (grok.com / apps)
+
+What official pages actually say:
+
+| Fact | Source |
+|------|--------|
+| Hands-free voice is a first-class Grok capability | [overview](https://docs.x.ai/grok/overview) |
+| "Natural voice conversations with low-latency back and forth" / "sub-second latency" | [x.ai/grok](https://x.ai/grok) |
+| Available on web, iOS, and Android with synced history | [overview](https://docs.x.ai/grok/overview), [x.ai/grok](https://x.ai/grok) |
+| Voice is one slice of the **weekly SuperGrok usage pool** (with Chat, Imagine, Build, API) | [FAQ](https://docs.x.ai/grok/faq) |
+| After the paid weekly cap, **free-tier Chat and Voice limits still work** and reset on their own schedule | [FAQ](https://docs.x.ai/grok/faq) |
+
+**TODO — product Voice UI (not on docs.x.ai / x.ai / grok.com as a walkthrough):**
+
+- Which control starts Voice on grok.com vs iOS vs Android (mic button, mode switcher, lock-screen, etc.).
+- Whether product Voice exposes the API voice roster (`eve`, `ara`, …) or a shorter in-app set.
+- Whether product Voice can call [Connectors](./grok-connectors.md) mid-call.
+- Barge-in, transcripts, language picker, and Companion overlap (Companions are **iOS-only** per the [FAQ](https://docs.x.ai/grok/faq); that is not the same feature as Voice).
+
+Until those pages exist, do not invent a click-path. Open grok.com or the Grok app and use the in-product Voice control you actually see.
+
+Product Voice is a chat capability. For a teammate that keeps working on a cloud VM, use [Grok Bot](./grok-bot.md).
+
+## Voice API
+
+Official stack ([voice overview](https://docs.x.ai/developers/model-capabilities/audio/voice), [x.ai/api/voice](https://x.ai/api/voice)):
+
+| Surface | Job | Official entry |
+|---------|-----|----------------|
+| **Speech to Speech** (Realtime) | Full-duplex voice agent, tools, barge-in | `wss://api.x.ai/v1/realtime?model=grok-voice-latest` |
+| **Text to Speech** | Text → audio | `POST https://api.x.ai/v1/tts` and `wss://api.x.ai/v1/tts` |
+| **Speech to Text** | Audio → text | `POST https://api.x.ai/v1/stt` and `wss://api.x.ai/v1/stt` |
+| **Custom voices** | Clone from a short clip, then pass `voice_id` | `POST https://api.x.ai/v1/custom-voices` |
+
+Audio is processed in real time and **never stored or used for training** ([voice overview](https://docs.x.ai/developers/model-capabilities/audio/voice)). Same enterprise bullets as Imagine: SOC 2 Type II, HIPAA eligible, GDPR, data residency, SSO & RBAC.
+
+Official prices live on [developers/models](https://docs.x.ai/developers/models) (Speech to Speech, TTS per 1M characters, STT REST vs streaming). [x.ai/api/voice](https://x.ai/api/voice) also lists marketing numbers — when they disagree with `docs.x.ai`, **trust docs.x.ai**.
+
+### Text to Speech
+
+Convert text to spoken audio ([text-to-speech](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech)). Default voice is **`eve`**. Voice IDs are case-insensitive.
+
+```bash
+curl -X POST https://api.x.ai/v1/tts \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Hello! Welcome to the xAI Text to Speech API.",
+    "voice_id": "eve",
+    "language": "en"
+  }' \
+  --output hello.mp3
+```
+
+Official knobs worth knowing:
+
+- `text` — required, max **15,000** characters on unary `POST /v1/tts`. WebSocket has no total cap (each `text.delta` still ≤ 15,000).
+- `language` — required. BCP-47 or `auto`. Table on the TTS page lists 20 codes (`en`, `zh`, `pt-BR`, …).
+- `output_format` — default **MP3 24 kHz / 128 kbps**. Codecs: `mp3`, `wav`, `pcm`, `mulaw`, `alaw`.
+- `speed` — `0.7`–`1.5`.
+- Speech tags — inline `[pause]` / `[laugh]`, wrapping `<whisper>…</whisper>`.
+- `replace` — pronunciation map (respelling or IPA), applied before synthesis. Billing stays on the text you sent.
+- `with_timestamps` — JSON envelope with base64 audio + per-character timings.
+- List voices: `GET https://api.x.ai/v1/tts/voices`.
+- **Never call TTS from the browser with your API key.** Proxy it.
+
+Streaming: `wss://api.x.ai/v1/tts`, up to **50 concurrent sessions per team**.
+
+Playground: [console.x.ai text-to-speech](https://console.x.ai/team/default/voice/text-to-speech).
+
+### Speech to Text
+
+Transcribe a file or a stream ([speech-to-text](https://docs.x.ai/developers/model-capabilities/audio/speech-to-text)).
+
+```bash
+curl -X POST https://api.x.ai/v1/stt \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -F format=true \
+  -F language=en \
+  -F file=@audio.mp3
+```
+
+Official limits: file or `url` required; file last in the multipart body; max **500 MB**. Optional: word timestamps, `diarize`, `multichannel` (up to 8 channels), `keyterm`, `filler_words`, Inverse Text Normalization (`format=true` + `language`). Streaming: `wss://api.x.ai/v1/stt` with Smart Turn end-of-turn detection.
+
+The Voice overview says **25 languages** for STT; the STT page lists a concrete formatting-language table. Do not collapse those two sentences into one number in a table you invent — link the page.
+
+### Speech to Speech (Realtime)
+
+Build a voice agent over WebSocket ([speech-to-speech](https://docs.x.ai/developers/model-capabilities/audio/speech-to-speech)).
+
+```javascript
+import WebSocket from "ws";
+
+const ws = new WebSocket("wss://api.x.ai/v1/realtime?model=grok-voice-latest", {
+  headers: { Authorization: `Bearer ${process.env.XAI_API_KEY}` },
+});
+
+ws.on("open", () => {
+  ws.send(JSON.stringify({
+    type: "session.update",
+    session: {
+      voice: "eve",
+      instructions: "You are a helpful customer support agent.",
+      turn_detection: { type: "server_vad" },
+      tools: [{ type: "web_search" }],
+    },
+  }));
+});
+```
+
+Official model slugs:
+
+| Slug | Meaning |
+|------|---------|
+| `grok-voice-latest` | Alias for `grok-voice-think-fast-2.0` |
+| `grok-voice-think-fast-2.0` | Flagship voice model |
+| `grok-voice-think-fast-1.0` | Previous generation |
+
+Client-side apps should use **[ephemeral tokens](https://docs.x.ai/developers/model-capabilities/audio/ephemeral-tokens)** so the API key never hits the browser. Browsers cannot set WebSocket headers; pass `xai-client-secret.<token>` as the protocol.
+
+Server-side tools on the session: `file_search`, `web_search`, `x_search`, `mcp`. Client-side: custom `function` tools. Session resumption is opt-in (`resumption.enabled`), keyed by `conversation_id`, dropped after **30 minutes** of inactivity.
+
+Demo apps from the docs: [Web Agent](https://github.com/xai-org/xai-cookbook/tree/main/voice-examples/agent/web), [WebRTC](https://github.com/xai-org/xai-cookbook/tree/main/voice-examples/agent/webrtc), [Twilio](https://github.com/xai-org/xai-cookbook/tree/main/voice-examples/agent/telephony), [iOS tester](https://github.com/xai-org/xai-cookbook/tree/main/iOS/VoiceTesterApp).
+
+### Custom voices
+
+Clone from a reference clip (**max 120s** on the Voice overview; [x.ai/api/voice](https://x.ai/api/voice) says "two minutes"). The resulting `voice_id` works on TTS, streaming TTS, and Speech to Speech.
+
+## When to use which
+
+| You want | Use |
+|----------|-----|
+| Talk to Grok with your hands free | Product Voice on grok.com / the Grok app |
+| Narrate text, captions, telephony prompts | TTS API |
+| Transcribe a meeting or a live stream | STT API |
+| A voice agent that searches / calls tools | Speech to Speech API |
+| A named teammate on a cloud computer | [Grok Bot](./grok-bot.md), not Voice |
+
+## Common pitfalls
+
+- Shipping the API key in a browser Voice widget. Use ephemeral tokens or a backend proxy.
+- Mixing product Voice (subscription weekly pool) with Voice API (API credits / team billing).
+- Sending `response.create` before playback finishes after a tool call — official Speech-to-Speech docs warn this overlaps audio.
+- Inventing an in-app settings path for choosing `eve` vs `ara`. **TODO** until xAI documents product Voice UI.
+
+## Official docs
+
+| Page | Use |
+|------|-----|
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | Product Voice one-liner |
+| [docs.x.ai/grok/faq](https://docs.x.ai/grok/faq) | Weekly pool, free-tier Voice after cap |
+| [docs.x.ai/developers/model-capabilities/audio/voice](https://docs.x.ai/developers/model-capabilities/audio/voice) | API stack |
+| [text-to-speech](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech) | TTS |
+| [speech-to-text](https://docs.x.ai/developers/model-capabilities/audio/speech-to-text) | STT |
+| [speech-to-speech](https://docs.x.ai/developers/model-capabilities/audio/speech-to-speech) | Realtime |
+| [custom-voices](https://docs.x.ai/developers/model-capabilities/audio/custom-voices) | Clone a voice |
+| [x.ai/api/voice](https://x.ai/api/voice) | API marketing + live demos |
+| [x.ai/grok](https://x.ai/grok) | Product marketing |
+
+## Related pages
+
+- [Grok Chat](./grok-chat.md) — Voice lives next to Chat
+- [Imagine](./grok-imagine.md) — video preset voices share the TTS roster
+- [Connectors](./grok-connectors.md)
+- [Grok learning map](./index.md)
+- [Glossary](./grok-glossary.md)

--- a/docs/products/ai-coding/grok/index.md
+++ b/docs/products/ai-coding/grok/index.md
@@ -5,19 +5,70 @@
 > Official definition ([docs.x.ai/build/overview](https://docs.x.ai/build/overview)):
 > "**Grok Build** is a powerful and extensible coding agent. Use it via an interactive TUI, headlessly in scripts or bots, or through the Agent Client Protocol (ACP) in other apps."
 
-## Tell the products apart in one minute
+## Product landscape
 
-Several xAI products share the "Grok" name. Sort them out first:
+Several xAI products share the word "Grok" or "Build". They are **not** one product with four skins. The set of pages under this directory is about **Grok Build** (the terminal coding agent). The other official surfaces belong in the decision tree so you do not pick the wrong door.
 
-| Product | What it is | Entry point |
-|---------|-----------|-------------|
-| **Grok Build** | Terminal coding agent (the subject of these docs) | the `grok` command |
-| Grok (chat) | General-purpose conversational product | [grok.com](https://grok.com), built into X |
-| xAI API | Model API (`grok-4.6` and others) | [api.x.ai](https://docs.x.ai/developers/quickstart) |
+```
+xAI / Grok family
+├── Grok (chat) — grok.com, iOS, Android, and X
+│   ├── Chat / search / voice / file upload
+│   ├── Imagine — images and video (also grok.com/imagine)
+│   └── Build Mode — chat-native sites / apps / games, publish to grok.me
+├── Grok Build — terminal coding agent (the `grok` command)
+│   ├── Interactive TUI
+│   ├── Headless (`grok -p`)
+│   └── ACP (`grok agent stdio`)
+├── Grok Bot — named teammates on a persistent cloud computer
+└── xAI API — model HTTP API, including the Imagine API
+```
 
-All three share the same account and models, but **only Grok Build is a coding tool**. There is no official IDE plugin — to use it inside an editor you go through the ACP protocol (see below).
+| Product | What it is | Entry point | Analog in the Claude family |
+|---------|-----------|-------------|-----------------------------|
+| **Grok Build** | Terminal coding agent for a real repo | the `grok` command | Claude Code CLI |
+| Grok (chat) | General-purpose assistant | [grok.com](https://grok.com), Grok apps, X | Claude.ai |
+| Imagine | Image and video generation / editing | [grok.com/imagine](https://grok.com/imagine), or the [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine) | Claude Design (creative surface, not a coding agent) |
+| Build Mode | Chat-native builder; publish a live link | Mode switcher **Build** on grok.com / Grok apps | Claude.ai Artifacts-style creation, **not** Claude Code |
+| Grok Bot | Always-on teammates on a shared cloud VM | [x.ai/bot](https://x.ai/bot) desktop + iOS apps | Cowork (task agent, not a repo CLI) |
+| xAI API | Model / Imagine / Voice HTTP API | [docs.x.ai/developers/quickstart](https://docs.x.ai/developers/quickstart) | Anthropic API |
 
-## Three surfaces
+**Names that collide:**
+
+- **Grok Build** ≠ **Build Mode**. Grok Build is the terminal agent (`docs.x.ai/build/*`). Build Mode is a grok.com chat mode that writes a working preview in the conversation and publishes it ([x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode)).
+- **grok.me** is the **publish host** for Build Mode ("Publish to a grok.me link or a custom domain you own"). It is not a separate product and not the Grok Build CLI.
+- **Grok Bot** ≠ Grok Build headless "bots". Grok Bot is a desktop / iOS product with its own docs tree at [docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview).
+- There is **no official IDE plugin**. Editor use of Grok Build is ACP (`grok agent stdio`). [terminal-support](https://docs.x.ai/build/cli/terminal-support) only documents key-binding differences inside VS Code / Cursor / Windsurf / Zed terminals.
+
+Accounts are **not** one pool. Grok Build accepts a SuperGrok / X Premium Plus login or `XAI_API_KEY`. Grok Bot authenticates with a **Cursor** account and is gated to SuperGrok Heavy, Cursor Ultra, and Cursor Teams Premium ([get-started](https://docs.x.ai/grok-bot/get-started)). Build Mode's Early Beta is SuperGrok Heavy only.
+
+### Quick decision: which surface?
+
+```
+What do I want to do?
+├── Write / debug / refactor / open a PR in a real repository
+│   └── → Grok Build (`grok`)
+│       ├── In the terminal? → TUI (`grok`)
+│       ├── In CI / scripts? → headless (`grok -p`)
+│       └── Inside an editor? → ACP (`grok agent stdio`) — no official VS Code plugin
+├── Chat / write / research / voice / upload files
+│   └── → grok.com or the Grok iOS / Android apps
+├── Generate or edit images / video
+│   └── → Imagine
+│       ├── In the product? → grok.com/imagine (also inside grok.com chat)
+│       └── From my own app? → Imagine API
+├── Build a website / app / game in chat and share a link
+│   └── → Build Mode (grok.com mode switcher → Build)
+│       └── SuperGrok Heavy Early Beta; publish to grok.me or a custom domain
+├── Hand real work to a teammate that keeps going when the laptop is closed
+│   └── → Grok Bot (desktop + iOS)
+│       └── SuperGrok Heavy / Cursor Ultra / Cursor Teams Premium
+└── Call models from my own software
+    └── → xAI API
+```
+
+Sources: [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview), [docs.x.ai/build/overview](https://docs.x.ai/build/overview), [docs.x.ai/grok-bot/overview](https://docs.x.ai/grok-bot/overview), [x.ai/grok](https://x.ai/grok), [x.ai/grok/build-mode](https://x.ai/grok/build-mode), [x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode), [docs.x.ai/developers/model-capabilities/imagine](https://docs.x.ai/developers/model-capabilities/imagine), [x.ai/bot](https://x.ai/bot).
+
+## Three Grok Build surfaces
 
 | Surface | Entry point | Where it fits |
 |---------|-------------|---------------|
@@ -27,18 +78,20 @@ All three share the same account and models, but **only Grok Build is a coding t
 
 Sources: [docs.x.ai/build/overview](https://docs.x.ai/build/overview), [docs.x.ai/build/cli/reference](https://docs.x.ai/build/cli/reference)
 
-## Quick decision
+## When Grok Build is worth trying
 
-**When it is worth trying**
+**Try it when**
 
 - You already use Claude Code and want a cheap side-by-side comparison. xAI explicitly claims zero-configuration compatibility (it reads `CLAUDE.md` and `.claude/settings.json`, accepts Claude Code flag aliases, and `grok import` pulls in Claude Code sessions), so migration cost is close to zero.
 - You need long-running orchestration in the terminal: background tasks, scheduled loops, parallel subagents, and worktree isolation are all built in.
 - You already subscribe to SuperGrok or X Premium Plus (the [launch announcement](https://x.ai/news/grok-build-cli) says: Available now to all SuperGrok and X Premium Plus subscribers), or you have an `XAI_API_KEY`.
 
-**When to hold off**
+**Hold off when**
 
 - You want inline IDE completion — Grok Build is a terminal agent with no completion feature and no official IDE plugin.
-- You need a stable long-term surface — it is still beta. npm `@xai-official/grok` moved `latest` from 1.0.3 (2026-08-12) to 1.0.5 (2026-08-16); commands and config keys are still moving. Check `grok version` and the [changelog](https://x.ai/build/changelog) before pinning anything.
+- You need a teammate that keeps working after you close the laptop — that is [Grok Bot](./grok-bot.md), not Grok Build.
+- You want a no-install chat builder that publishes a `*.grok.me` link — that is Build Mode on grok.com, SuperGrok Heavy Early Beta.
+- You need a stable long-term surface — Grok Build is still beta. npm `@xai-official/grok` moved `latest` from 1.0.3 (2026-08-12) to 1.0.5 (2026-08-16); commands and config keys are still moving. Check `grok version` and the [changelog](https://x.ai/build/changelog) before pinning anything.
 
 ## Learning path
 
@@ -100,4 +153,5 @@ Sources: [developers/models](https://docs.x.ai/developers/models), [developers/r
 - [Cookbook](./grok-cookbook.md) — task-oriented recipes
 - [Cheatsheet](./grok-cheatsheet.md) — commands / config / env vars / pricing / sources
 - [Glossary](./grok-glossary.md) — what the concepts are and why
+- [Grok Bot](./grok-bot.md) — cloud-computer teammates (not the CLI)
 - [AI coding tools overview](../index.md)

--- a/docs/products/ai-coding/grok/index.md
+++ b/docs/products/ai-coding/grok/index.md
@@ -7,7 +7,7 @@
 
 ## Product landscape
 
-Several xAI products share the word "Grok" or "Build". They are **not** one product with four skins. The set of pages under this directory is about **Grok Build** (the terminal coding agent). The other official surfaces belong in the decision tree so you do not pick the wrong door.
+Several xAI products share the word "Grok" or "Build". They are **not** one product with four skins. The **core learning path** in this directory is **Grok Build** (the terminal coding agent). The other official surfaces now have their own pages so you do not pick the wrong door.
 
 ```
 xAI / Grok family
@@ -26,16 +26,19 @@ xAI / Grok family
 | Product | What it is | Entry point | Analog in the Claude family |
 |---------|-----------|-------------|-----------------------------|
 | **Grok Build** | Terminal coding agent for a real repo | the `grok` command | Claude Code CLI |
-| Grok (chat) | General-purpose assistant | [grok.com](https://grok.com), Grok apps, X | Claude.ai |
-| Imagine | Image and video generation / editing | [grok.com/imagine](https://grok.com/imagine), or the [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine) | Claude Design (creative surface, not a coding agent) |
+| [Grok (chat)](./grok-chat.md) | General-purpose assistant | [grok.com](https://grok.com), Grok apps, X | Claude.ai |
+| [Imagine](./grok-imagine.md) | Image and video generation / editing | [grok.com/imagine](https://grok.com/imagine), or the [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine) | Claude Design (creative surface, not a coding agent) |
+| [Voice](./grok-voice.md) | Hands-free talk in the app + Voice API | grok.com / apps; [Voice API](https://docs.x.ai/developers/model-capabilities/audio/voice) | Claude voice / realtime API |
+| [Connectors](./grok-connectors.md) | Email / files / calendar / custom MCP inside chat | [grok.com/connectors](https://grok.com/connectors) | Claude Connectors |
 | Build Mode | Chat-native builder; publish a live link | Mode switcher **Build** on grok.com / Grok apps | Claude.ai Artifacts-style creation, **not** Claude Code |
-| Grok Bot | Always-on teammates on a shared cloud VM | [x.ai/bot](https://x.ai/bot) desktop + iOS apps | Cowork (task agent, not a repo CLI) |
+| [Grok Bot](./grok-bot.md) | Always-on teammates on a shared cloud VM | [x.ai/bot](https://x.ai/bot) desktop + iOS apps | Cowork (task agent, not a repo CLI) |
+| [Grok Business](./grok-business.md) | Team workspaces, licenses, org controls | [docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide) | Claude Team / Enterprise |
 | xAI API | Model / Imagine / Voice HTTP API | [docs.x.ai/developers/quickstart](https://docs.x.ai/developers/quickstart) | Anthropic API |
 
 **Names that collide:**
 
-- **Grok Build** ≠ **Build Mode**. Grok Build is the terminal agent (`docs.x.ai/build/*`). Build Mode is a grok.com chat mode that writes a working preview in the conversation and publishes it ([x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode)).
-- **grok.me** is the **publish host** for Build Mode ("Publish to a grok.me link or a custom domain you own"). It is not a separate product and not the Grok Build CLI.
+- **Grok Build** ≠ **Build Mode**. Grok Build is the terminal agent (`docs.x.ai/build/*`). Build Mode is a grok.com chat mode: "Tell Grok an idea, and it builds a working version live in your chat" and you "Publish to a grok.me link or a custom domain you own" ([x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode), [x.ai/grok/build-mode](https://x.ai/grok/build-mode)). Early Beta for **SuperGrok Heavy** on web, iOS, and Android. Official density is still a marketing page + one news post, so it stays on this map instead of a standalone tutorial.
+- **grok.me** is the **publish host** for Build Mode. It is not a separate product and not the Grok Build CLI.
 - **Grok Bot** ≠ Grok Build headless "bots". Grok Bot is a desktop / iOS product with its own docs tree at [docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview).
 - There is **no official IDE plugin**. Editor use of Grok Build is ACP (`grok agent stdio`). [terminal-support](https://docs.x.ai/build/cli/terminal-support) only documents key-binding differences inside VS Code / Cursor / Windsurf / Zed terminals.
 
@@ -51,17 +54,21 @@ What do I want to do?
 │       ├── In CI / scripts? → headless (`grok -p`)
 │       └── Inside an editor? → ACP (`grok agent stdio`) — no official VS Code plugin
 ├── Chat / write / research / voice / upload files
-│   └── → grok.com or the Grok iOS / Android apps
+│   └── → [Grok Chat](./grok-chat.md) on grok.com or the Grok iOS / Android apps
+│       ├── Hands-free talk → [Voice](./grok-voice.md) (product; Voice API is separate)
+│       └── Email / Drive / calendar in-thread → [Connectors](./grok-connectors.md)
 ├── Generate or edit images / video
-│   └── → Imagine
+│   └── → [Imagine](./grok-imagine.md)
 │       ├── In the product? → grok.com/imagine (also inside grok.com chat)
 │       └── From my own app? → Imagine API
 ├── Build a website / app / game in chat and share a link
 │   └── → Build Mode (grok.com mode switcher → Build)
 │       └── SuperGrok Heavy Early Beta; publish to grok.me or a custom domain
 ├── Hand real work to a teammate that keeps going when the laptop is closed
-│   └── → Grok Bot (desktop + iOS)
+│   └── → [Grok Bot](./grok-bot.md) (desktop + iOS)
 │       └── SuperGrok Heavy / Cursor Ultra / Cursor Teams Premium
+├── Team workspaces / licenses / org sharing
+│   └── → [Grok Business](./grok-business.md)
 └── Call models from my own software
     └── → xAI API
 ```
@@ -153,5 +160,10 @@ Sources: [developers/models](https://docs.x.ai/developers/models), [developers/r
 - [Cookbook](./grok-cookbook.md) — task-oriented recipes
 - [Cheatsheet](./grok-cheatsheet.md) — commands / config / env vars / pricing / sources
 - [Glossary](./grok-glossary.md) — what the concepts are and why
+- [Grok Chat](./grok-chat.md) — grok.com / iOS / Android
+- [Imagine](./grok-imagine.md) — images and video
+- [Voice](./grok-voice.md) — product Voice + Voice API
+- [Connectors](./grok-connectors.md) — email / files / calendar in chat
 - [Grok Bot](./grok-bot.md) — cloud-computer teammates (not the CLI)
+- [Grok Business](./grok-business.md) — team workspaces
 - [AI coding tools overview](../index.md)

--- a/docs/products/ai-coding/grok/index.md
+++ b/docs/products/ai-coding/grok/index.md
@@ -1,0 +1,103 @@
+# Grok Learning Map
+
+> **Grok Build** is xAI's first-party terminal coding agent. The executable is named `grok`, and the source is open at [xai-org/grok-build](https://github.com/xai-org/grok-build).
+>
+> Official definition ([docs.x.ai/build/overview](https://docs.x.ai/build/overview)):
+> "**Grok Build** is a powerful and extensible coding agent. Use it via an interactive TUI, headlessly in scripts or bots, or through the Agent Client Protocol (ACP) in other apps."
+
+## Tell the products apart in one minute
+
+Several xAI products share the "Grok" name. Sort them out first:
+
+| Product | What it is | Entry point |
+|---------|-----------|-------------|
+| **Grok Build** | Terminal coding agent (the subject of these docs) | the `grok` command |
+| Grok (chat) | General-purpose conversational product | [grok.com](https://grok.com), built into X |
+| xAI API | Model API (`grok-4.6` and others) | [api.x.ai](https://docs.x.ai/developers/quickstart) |
+
+All three share the same account and models, but **only Grok Build is a coding tool**. There is no official IDE plugin — to use it inside an editor you go through the ACP protocol (see below).
+
+## Three surfaces
+
+| Surface | Entry point | Where it fits |
+|---------|-------------|---------------|
+| Interactive TUI | `grok` | Day-to-day development, full-screen terminal UI |
+| Headless | `grok -p "<prompt>"` | Scripts, CI, batch jobs |
+| ACP | `grok agent stdio` | Embedded by editors or your own orchestrator (JSON-RPC over stdin/stdout) |
+
+Sources: [docs.x.ai/build/overview](https://docs.x.ai/build/overview), [docs.x.ai/build/cli/reference](https://docs.x.ai/build/cli/reference)
+
+## Quick decision
+
+**When it is worth trying**
+
+- You already use Claude Code and want a cheap side-by-side comparison. xAI explicitly claims zero-configuration compatibility (it reads `CLAUDE.md` and `.claude/settings.json`, accepts Claude Code flag aliases, and `grok import` pulls in Claude Code sessions), so migration cost is close to zero.
+- You need long-running orchestration in the terminal: background tasks, scheduled loops, parallel subagents, and worktree isolation are all built in.
+- You already subscribe to SuperGrok or X Premium Plus (the [launch announcement](https://x.ai/news/grok-build-cli) says: Available now to all SuperGrok and X Premium Plus subscribers), or you have an `XAI_API_KEY`.
+
+**When to hold off**
+
+- You want inline IDE completion — Grok Build is a terminal agent with no completion feature and no official IDE plugin.
+- You need a stable long-term surface — it is still beta. npm has shipped 552 versions since 2025-10-22 (recently roughly one every one to three days), and commands and config keys are still moving.
+
+## Learning path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Get it running | Install and auth in the [Grok Build tutorial](./grok-cli.md) | First conversation within 15 minutes |
+| 2. Learn the core | TUI / plan mode / permissions in the [tutorial](./grok-cli.md) | Confident enough to let it edit code |
+| 3. Wire it into your workflow | [Cookbook](./grok-cookbook.md) | headless, CI, hooks, MCP, subagents |
+| 4. Look up parameters | [Cheatsheet](./grok-cheatsheet.md) | Commands, flags, config keys, env vars, pricing |
+| 5. Understand the concepts | [Glossary](./grok-glossary.md) | Permission mode vs. sandbox, skill vs. plugin, memory vs. session |
+
+## Feature index
+
+Only capabilities that have an official documentation page are listed. Each row links to the primary source.
+
+| Capability | In one line | Official docs |
+|------------|-------------|---------------|
+| Plan mode | Draft a plan, get approval, then act | [plan-mode](https://docs.x.ai/build/features/plan-mode) |
+| Permission rules | `allow` / `ask` / `deny` rules matched against tool calls | [permissions](https://docs.x.ai/build/features/permissions) |
+| Sandbox | OS-level isolation via Landlock / Seatbelt, five profiles | [sandbox](https://docs.x.ai/build/features/sandbox) |
+| Project rules | Reads `AGENTS.md`, and also `CLAUDE.md` / `.cursor/rules` | [project-rules](https://docs.x.ai/build/features/project-rules) |
+| Skills | `SKILL.md` defines reusable capability, callable as `/<name>` | [skills-plugins-marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces) |
+| Plugins / Marketplace | Package skills + commands + agents + hooks + MCP for distribution | [skills-plugins-marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces) |
+| Hooks | Lifecycle events trigger external commands; can block tool calls | [hooks](https://docs.x.ai/build/features/hooks) |
+| MCP | `grok mcp add`; tools are namespaced as `<server>__<tool>` | [mcp-servers](https://docs.x.ai/build/features/mcp-servers) |
+| Subagents / Personas | Built-in `general-purpose` / `explore` / `plan`, plus custom types | [subagents](https://docs.x.ai/build/features/subagents) |
+| Sessions | Indexed by working directory; resume / fork / rewind / compact | [sessions](https://docs.x.ai/build/features/sessions) |
+| Worktrees | Work in an isolated checkout under `~/.grok/worktrees/` | [worktrees](https://docs.x.ai/build/features/worktrees) |
+| Background tasks | Task panel plus `/loop` scheduled repeats | [background-tasks](https://docs.x.ai/build/features/background-tasks) |
+| Dashboard | Multi-session status overview | [dashboard](https://docs.x.ai/build/features/dashboard) |
+| Headless | `-p` for one-shot prompts, `--output-format` for JSON | [headless-scripting](https://docs.x.ai/build/cli/headless-scripting) |
+| ACP | `grok agent stdio` runs as an ACP agent for a host app | [headless-scripting](https://docs.x.ai/build/cli/headless-scripting) |
+| Enterprise policy | Five config layers, OIDC, MDM-managed policy | [enterprise](https://docs.x.ai/build/enterprise) |
+| Theming | Built-in GrokNight / GrokDay and others, can follow the system | [theming](https://docs.x.ai/build/features/theming) |
+
+## Model reference
+
+| Model slug | Positioning (official wording) | Context |
+|------------|-------------------------------|---------|
+| `grok-4.6` | "For everything else, including code, use Grok 4.6. It is the most intelligent and fastest model we've built." | 500k |
+| `grok-build-0.1` | "xAI's coding model, trained specifically for agentic coding workflows." | 256k |
+
+The current banner on [x.ai/build](https://x.ai/build) reads "Meet Grok 4.6 • Now powering Grok Build", so the default driving model is `grok-4.6`. Pricing and limits are in the [cheatsheet](./grok-cheatsheet.md#models-and-pricing).
+
+Sources: [developers/models](https://docs.x.ai/developers/models), [developers/release-notes](https://docs.x.ai/developers/release-notes)
+
+## Resources
+
+- Official CLI docs: <https://docs.x.ai/build/overview>
+- Official API docs: <https://docs.x.ai/developers/quickstart>
+- CLI changelog: <https://x.ai/build/changelog>
+- Source repository: <https://github.com/xai-org/grok-build>
+- Official plugin marketplace: <https://github.com/xai-org/plugin-marketplace>
+- A fuller source list (with access notes) lives in the [cheatsheet's "High-quality sources" section](./grok-cheatsheet.md#high-quality-sources)
+
+## Related pages
+
+- [Grok Build tutorial](./grok-cli.md) — install, auth, TUI, headless, ACP
+- [Cookbook](./grok-cookbook.md) — task-oriented recipes
+- [Cheatsheet](./grok-cheatsheet.md) — commands / config / env vars / pricing / sources
+- [Glossary](./grok-glossary.md) — what the concepts are and why
+- [AI coding tools overview](../index.md)

--- a/docs/products/ai-coding/grok/index.md
+++ b/docs/products/ai-coding/grok/index.md
@@ -38,7 +38,7 @@ Sources: [docs.x.ai/build/overview](https://docs.x.ai/build/overview), [docs.x.a
 **When to hold off**
 
 - You want inline IDE completion — Grok Build is a terminal agent with no completion feature and no official IDE plugin.
-- You need a stable long-term surface — it is still beta. npm has shipped 552 versions since 2025-10-22 (recently roughly one every one to three days), and commands and config keys are still moving.
+- You need a stable long-term surface — it is still beta. npm `@xai-official/grok` moved `latest` from 1.0.3 (2026-08-12) to 1.0.5 (2026-08-16); commands and config keys are still moving. Check `grok version` and the [changelog](https://x.ai/build/changelog) before pinning anything.
 
 ## Learning path
 

--- a/docs/products/ai-coding/index.md
+++ b/docs/products/ai-coding/index.md
@@ -21,6 +21,7 @@
 - [Claude](./claude/) - Claude ecosystem: Claude.ai, Claude Code, Claude Design, Cowork
 - [Pi Agent](./pi-agent.md) - 极简主义 coding agent harness
 - [Gemini CLI](./gemini-cli.md) - Google's AI coding assistant
+- [Grok](./grok/) - xAI's first-party terminal coding agent (Grok Build)
 - [Other Tools](./othertools.md) - Explore more AI coding tools
 
 ## Getting Started

--- a/docs/zh/products/ai-coding/grok/grok-bot.md
+++ b/docs/zh/products/ai-coding/grok/grok-bot.md
@@ -1,0 +1,135 @@
+# Grok Bot
+
+> **Grok Bot** 是 xAI 的常驻同事产品。官方定义（[docs.x.ai/grok-bot/overview](https://docs.x.ai/grok-bot/overview)）：
+> "Bots are AI teammates you can give real work to. Bots can sign and use apps and websites just like you do on a persistent cloud computer."
+>
+> 本页只根据 [docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview)、[x.ai/bot](https://x.ai/bot)、[x.ai/news/introducing-grok-bot](https://x.ai/news/introducing-grok-bot) 画产品地图。它**不是** Grok Build CLI 教程——CLI 在 [grok-cli.md](./grok-cli.md)。
+
+## 目标与非目标
+
+**目标：** 把 Grok Bot 和 Grok Build / grok.com 聊天 / Imagine / Build Mode 分开，并指向官方文档里的安装、共享电脑和审批。
+
+**非目标：** 再抄一遍官方 get-started、臆造配额，或把三方博客里 docs.x.ai / x.ai / grok.com 没有的说法写成事实。
+
+## 它是什么
+
+文档和 App 里，**一个 Bot = 一个持久的、有名字的 agent**（[overview](https://docs.x.ai/grok-bot/overview)）。你像给同事发消息那样派活。合上笔记本之后，云电脑上的工作继续跑（[faq](https://docs.x.ai/grok-bot/faq)）。
+
+官方相对聊天助手的差异（[overview](https://docs.x.ai/grok-bot/overview)、[faq](https://docs.x.ai/grok-bot/faq)）：
+
+- 每个 Bot 跑在一台带浏览器、文件系统和终端的**持久云 VM** 上。
+- 有 connector / MCP 就用；没有干净 API 的网站走 computer use。
+- 多个 Bot **共用一台按用户划分的电脑**，可以并行、互相发消息、交接。
+- 可以跟着你演示一遍工作流，存成 **routine**。
+- 具名 Bot 跨轮次保留记忆、文件、浏览器会话和偏好。
+
+| | Grok（聊天） | Grok Build | Grok Bot |
+|---|-------------|------------|----------|
+| 干什么 | 对话、搜索、语音、Imagine | 改本地 / CI 里的真实仓库 | 在 App 和网站里把活干完 |
+| 电脑 | 没有自己的电脑 | 你的机器（可选沙箱） | 每个用户一台持久**云**电脑 |
+| 合上笔记本就停？ | 是（它是聊天） | 是（进程在本地） | 否——云上继续 |
+| 官方入口 | [grok.com](https://grok.com) | `grok` | 桌面 + iOS（[x.ai/bot](https://x.ai/bot)） |
+
+发布公告（[2026-08-11](https://x.ai/news/introducing-grok-bot)）写明 Grok Bot 处于 **beta**。
+
+## 谁能用
+
+[get-started](https://docs.x.ai/grok-bot/get-started) 列出的资格：
+
+- SuperGrok Heavy
+- Cursor Ultra
+- Cursor Teams Premium（用 Cursor 账号登录）
+
+[x.ai/bot](https://x.ai/bot) 补充："Already on Cursor Ultra or SuperGrok Heavy? Grok Bot is included." [发布公告](https://x.ai/news/introducing-grok-bot) 里企业用户走 waitlist；[faq](https://docs.x.ai/grok-bot/faq) 说团队 / 企业放量因组织而异。
+
+**认证走 Cursor**，不是 `grok login`。Grok Bot 要求云端数据存储，不支持 Legacy Privacy Mode（[get-started](https://docs.x.ai/grok-bot/get-started)、[faq](https://docs.x.ai/grok-bot/faq)）。
+
+### 平台（[faq](https://docs.x.ai/grok-bot/faq)）
+
+| 发布时支持 | 发布时不支持 |
+|------------|--------------|
+| macOS（Apple silicon 与 Intel） | Linux 桌面 |
+| Windows（x64 与 Arm64） | Android |
+| iOS 18 及以上的 iPhone | iPad |
+
+同一套 Bot 和对话在已登录设备之间同步。
+
+## 共享的云电脑
+
+账号下每个 Bot 用的是**同一台**电脑（[computer-and-apps](https://docs.x.ai/grok-bot/computer-and-apps)）：
+
+- 浏览器 cookie 和登录会话共享
+- 文件对每个 Bot 可见
+- 命令行凭证共享
+- 一个 Bot 可以从另一个 Bot 留下的工作接着做
+
+电脑挂在**用户账号**上，不挂在单个 Bot 上。官方警告写了两遍：**不要把不同 Bot 当成安全边界**。
+
+每个 Bot 在这台共享电脑上有自己的屏幕，所以多个 Bot 可以并行用浏览器和桌面工具。一个 Bot 在自己的屏幕上同一时刻只能跑一个 computer-use 任务。屏幕是工作面，**不是**独立安全域。
+
+持久项目文件放在共享工作区 `/workspace`。临时目录、手工装的包、未提交的应用状态都按可丢弃处理。
+
+云电脑和你面前的 Mac / Windows **是分开的**。本机命令策略在 **Settings → General → Agent → Execution on Local Computer**，默认 **Ask every time**（[approvals](https://docs.x.ai/grok-bot/approvals-security-and-privacy)）。这些设置挡不住 Bot 用它自己的云电脑。
+
+## 上手（官方顺序）
+
+按 [get-started](https://docs.x.ai/grok-bot/get-started) 走。压缩如下：
+
+1. 从 [Grok Bot 入口页](https://x.ai/bot) 装桌面 App（macOS：拖进 Applications；Windows：跑安装器）。
+2. 在 App 打开的浏览器窗口里用 Cursor 账号登录。
+3. 创建一个 Bot：短名字、一个主职、它该怎么干活。官方建议：职责收窄的 Bot 好过一个万能 Bot。
+4. 第一次派活要写清结果、来源、约束、交付物、何时停下来给你看。
+5. 网站要密码、passkey、二次验证或 CAPTCHA 时，打开 **Agent Computer**，自己接管、只做这一步，再交还控制权。**不要把密码或一次性验证码贴进聊天。**
+
+当前 App 里 connector 显示为 **Plugins**： **Settings → Plugins**。聊天里用 `@` 挂上 connector，用 `/` 引用已存 skill。有 connector 优先用 connector；没有的服务再用浏览器。
+
+## Skill 和 routine
+
+官方分法（[faq](https://docs.x.ai/grok-bot/faq)）：
+
+- **skill** 描述「这件事怎么做」。
+- **routine** 把一条工作流派给某个 Bot，并告诉它何时跑——按日程，或（若支持）按事件。
+
+先在一次性真实任务上试过 skill，再做成 routine。
+
+**Teach a task**（若该账号已开放）从电脑视图录一段浏览器流程，上限十分钟。放量可能是逐步的。
+
+删除 Bot 会去掉它的档案、对话和 routine。共享电脑上的文件和登录可能还在。
+
+## 该设的审批
+
+[approvals-security-and-privacy](https://docs.x.ai/grok-bot/approvals-security-and-privacy) 要求把常驻边界写进 Bot 描述，并把这些动作留在审批后面：
+
+- 发消息或邀请
+- 发布内容
+- 购买和资金划转
+- 删除或覆盖数据
+- 改权限
+- 改生产
+- 接受法律条款
+
+Auto Review 可用时：**Require Approval** 永远压过 **Always Allow**。不要写「浏览器里什么都允许」这种宽规则。
+
+## 费用（只写官方页上的话）
+
+[faq](https://docs.x.ai/grok-bot/faq) 说能否用、怎么计费取决于账号和套餐；Grok Bot 订阅含每周用量，符合条件的账号可以按模型和 token 成本加购按需用量。[x.ai/bot](https://x.ai/bot) 当前列出 Cursor Ultra $200 / 月、Cursor Premium Teams $120 / 席 / 月，并写 SuperGrok Heavy / Cursor Ultra 已包含 Grok Bot。本页**不**臆造 SuperGrok Heavy 的价格或 token 配额。
+
+## 官方文档
+
+| 页面 | 用来干什么 |
+|------|------------|
+| [docs.x.ai/grok-bot/overview](https://docs.x.ai/grok-bot/overview) | Bot 是什么 |
+| [docs.x.ai/grok-bot/get-started](https://docs.x.ai/grok-bot/get-started) | 安装、登录、第一次派活 |
+| [docs.x.ai/grok-bot/files-and-results](https://docs.x.ai/grok-bot/files-and-results) | 附件与结果 |
+| [docs.x.ai/grok-bot/computer-and-apps](https://docs.x.ai/grok-bot/computer-and-apps) | 共享电脑、connector、`/workspace` |
+| [docs.x.ai/grok-bot/approvals-security-and-privacy](https://docs.x.ai/grok-bot/approvals-security-and-privacy) | 审批、本机、隐私 |
+| [docs.x.ai/grok-bot/faq](https://docs.x.ai/grok-bot/faq) | 平台、记忆、费用、删除 |
+| [docs.x.ai/grok-bot/teams-and-enterprises](https://docs.x.ai/grok-bot/teams-and-enterprises) | 每人一台电脑、组织控制 |
+| [x.ai/bot](https://x.ai/bot) | 营销页和下载 |
+| [x.ai/news/introducing-grok-bot](https://x.ai/news/introducing-grok-bot) | 发布公告（2026-08-11，beta） |
+
+## 相关页面
+
+- [Grok 学习地图](./index.md) — 家族决策树
+- [Grok Build 教程](./grok-cli.md) — 终端编程 Agent
+- [术语表](./grok-glossary.md) — 名字怎么撞车

--- a/docs/zh/products/ai-coding/grok/grok-business.md
+++ b/docs/zh/products/ai-coding/grok/grok-business.md
@@ -1,0 +1,118 @@
+# Grok Business & Enterprise
+
+> 官方定位（[docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide)）：
+> "**Grok Business provides dedicated workspaces for personal and team use, with enhanced privacy and sharing controls.**"
+>
+> [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) 把 **Business & Enterprise** 列为一级下一步："team workspaces, licenses, and organization controls."
+>
+> 本页给这个官方入口画产品地图。在本站复杂度轴上它比 Grok Build 靠后。仍然立页，因为 xAI 把它放在 Grok 文档首页。
+
+## 目标与非目标
+
+**写给谁：** 公司已经有（或正在买）Grok Business / Enterprise 的人，不是个人 SuperGrok 订阅者。
+
+**目标：** 讲清个人 / 团队工作区、许可证、分享、管理控制台。指向官方页。
+
+**非目标：** 臆造席位价格、再抄一遍企业法律条款，或 Grok Build 的 `/etc/grok/requirements.toml` 策略（那是 [CLI 企业策略](https://docs.x.ai/build/enterprise)，另一个产品）。
+
+## 你得到什么
+
+一个**团队工作区**（[user-guide](https://docs.x.ai/grok/user-guide)）：
+
+- 隐私保证见 xAI 的 [企业条款](https://x.ai/legal/terms-of-service-enterprise)。
+- 完整 **SuperGrok** 能力（升级许可证则是 **SuperGrok Heavy**）。
+- 对话只能安全分享给**有有效许可证**的团队成员。
+
+两种工作区：
+
+| 工作区 | 给谁 | 门槛 |
+|--------|------|------|
+| **Personal** | 个人使用 | 默认有；组织可在 Enterprise 许可证上关掉 |
+| **Team** | 团队协作 | 必须有**有效许可证** |
+
+在 grok.com **左下角**导航切换工作区。开新对话前先确认你在正确的工作区。
+
+打不开团队工作区 = 没有有效许可证，找团队管理员。**看不见个人工作区** = 组织关掉了；开关这件事走 Enterprise / 销售（[user-guide](https://docs.x.ai/grok/user-guide)）。
+
+Enterprise 另有自定义保留策略。本页不转述法律条文——读 [x.ai/legal/terms-of-service-enterprise](https://x.ai/legal/terms-of-service-enterprise)。
+
+## 许可证与用户
+
+枢纽： [console.x.ai](https://console.x.ai) 的 Grok Business 总览（[management](https://docs.x.ai/grok/management)、[user-guide](https://docs.x.ai/grok/user-guide)）。
+
+官方许可证类型（[management](https://docs.x.ai/grok/management)）：
+
+- **SuperGrok** — 标准商务访问，更高配额与功能。
+- **SuperGrok Heavy** — 面向更重负载的升级性能。
+
+本页**不**臆造每席美元价。
+
+管理员流程（压缩自 [management](https://docs.x.ai/grok/management) 与 [user-guide](https://docs.x.ai/grok/user-guide)）：
+
+1. 在总览页购买许可证（类型 + 数量）。需要 **Billing Read-Write**。
+2. 用邮箱邀请用户；可选在接受时自动配发许可证。需要 **Team Read-Write**。被邀请者获得团队工作区访问与基础 team read（这样才能分享对话）。
+3. 在用户列表里分配 / 收回许可证。收回后许可证回池，**团队**工作区权限取消；**个人**工作区仍在。
+4. 在总览页取消未用许可证。取消可能要几天；符合条件的退款回到原支付方式。
+
+终端用户开通（[user-guide](https://docs.x.ai/grok/user-guide)）：console.x.ai → **Assign license** → 选类型。然后 grok.com 上会出现团队工作区。
+
+## 分享
+
+团队对话分享（[user-guide](https://docs.x.ai/grok/user-guide)）：
+
+1. 在**团队工作区**打开对话。
+2. 分享按钮 → 选择团队成员 → 生成链接。
+3. 链接只对**有许可证**的团队成员可开。非成员、未授权队友打不开。
+4. 收件箱：[grok.com/history?tab=shared-with-me](https://grok.com/history?tab=shared-with-me)。
+
+组织级分享策略是**上限**，不是默认全员分享（[management](https://docs.x.ai/grok/management)）。管理员在 console.x.ai → **Sharing & Retention** → **Product Sharing** 设置。每种资源单独一条：conversations、projects、skills。
+
+| 级别 | 成员能做什么 |
+|------|----------------|
+| **Private** | 该资源关闭分享 |
+| **Team** | 个别队友与成员自己的团队。不能全组织 / 跨团队 |
+| **Organization** | Team，再加上其他团队和全组织 |
+| **Public** | Organization，再加上任何人都能打开的公开链接 |
+
+公开链接**只适用于对话**。projects 与 skills 最高到 Organization。默认：对话和项目可组织范围分享；**skills 默认 Private**。收紧策略立即生效，已经超出新上限的旧分享也会被压下来。
+
+## 团队里的 Connectors
+
+Business / Enterprise 成员**不能**自己先加 connector。必须由团队管理员在控制台开通，然后成员在 [grok.com/connectors](https://grok.com/connectors) 连接自己的账号。细节见 [Connectors](./grok-connectors.md) 与 [connector-management](https://docs.x.ai/grok/connector-management)。
+
+## 不是本页
+
+| 产品 | 为什么不同 |
+|------|------------|
+| grok.com 上的个人 SuperGrok | 没有团队工作区，没有许可证池。见 [Grok 聊天](./grok-chat.md) |
+| 消费端 [FAQ](https://docs.x.ai/grok/faq) 里的 xAI API「teams」 | 控制台里给 **API 用量 / 发票** 用的团队，不是 Grok Business 工作区 |
+| Grok Build 企业策略 | CLI 上的五层配置、OIDC、MDM（[docs.x.ai/build/enterprise](https://docs.x.ai/build/enterprise)） |
+| Grok Bot 团队 | 每人一台云电脑（[docs.x.ai/grok-bot/teams-and-enterprises](https://docs.x.ai/grok-bot/teams-and-enterprises)） |
+
+## 常见陷阱
+
+- 机密对话开在**个人**工作区，然后奇怪团队分享链接不生效。
+- 指望没许可证的队友能打开分享链接。官方写明不能。
+- 把 Grok Business 许可证和 `XAI_API_KEY` 的 API credit 当成同一口池。
+- 在本页找席位价格。官方文档列的是**许可证类型**，没有消费级美元数字。
+
+## 官方文档
+
+| 页面 | 用来干什么 |
+|------|------------|
+| [docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide) | 工作区、隐私、对话分享、激活许可证 |
+| [docs.x.ai/grok/management](https://docs.x.ai/grok/management) | 购买 / 邀请 / 分配 / 收回 / 取消，分享策略 |
+| [docs.x.ai/grok/connector-management](https://docs.x.ai/grok/connector-management) | 管理员开通 connectors |
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | 一级「Business & Enterprise」入口 |
+| [console.x.ai](https://console.x.ai) | 管理枢纽 |
+| [企业条款](https://x.ai/legal/terms-of-service-enterprise) | 隐私 / 数据处理 |
+
+白手套 / Enterprise 升级：联系 xAI 销售（文档页把地址做成站点控件）。
+
+## 相关页面
+
+- [Grok 聊天](./grok-chat.md) — 成员在工作区里用的东西
+- [Connectors](./grok-connectors.md) — 管理员开通 + 成员 OAuth
+- [Grok Bot](./grok-bot.md) — 另一套团队产品
+- [Grok Build 教程](./grok-cli.md) — CLI 企业策略在别处
+- [Grok 学习地图](./index.md)

--- a/docs/zh/products/ai-coding/grok/grok-chat.md
+++ b/docs/zh/products/ai-coding/grok/grok-chat.md
@@ -1,0 +1,145 @@
+# Grok 聊天
+
+> **Grok** 是 xAI 的助手。官方定义（[docs.x.ai/grok/overview](https://docs.x.ai/grok/overview)）：
+> "Grok is xAI's assistant, available on the web at [grok.com](https://grok.com) and in the iOS and Android apps. Sign in once and your conversations, settings, and subscription stay in sync across every platform."
+>
+> 本页只根据 [docs.x.ai/grok](https://docs.x.ai/grok/overview)、[x.ai/grok](https://x.ai/grok)、[grok.com](https://grok.com) 画产品地图。对位 Claude.ai。它**不是** Grok Build——CLI 在 [grok-cli.md](./grok-cli.md)。
+
+## 目标与非目标
+
+**写给谁：** 在选 Grok 产品面的前端工程师。你需要浏览器或 Grok App，不需要仓库。
+
+**目标：** 写清 grok.com / iOS / Android 实际能做什么、账号如何同步、文件 / Voice / Imagine / Connectors 分别在哪。
+
+**非目标：** Grok Build 教程、臆造 SuperGrok 价格、三方 Arena Mode / 8 路并行，或把 Grok 4.3 写成现行旗舰。编码模型以 [developers/models](https://docs.x.ai/developers/models) 为准：`grok-4.6` 与 `grok-build-0.1`。
+
+## 它是什么
+
+一个助手，三个官方客户端（[overview](https://docs.x.ai/grok/overview)、[x.ai/grok](https://x.ai/grok)）：
+
+| 客户端 | 官方入口 |
+|--------|----------|
+| Web | [grok.com](https://grok.com)——[FAQ](https://docs.x.ai/grok/faq) 要求用这个地址、Chrome/Chromium；`grok.x.ai` 会缺功能（例如 Projects） |
+| iOS | App Store 上的 Grok（[x.ai/grok](https://x.ai/grok)） |
+| Android | Google Play 上的 Grok（[x.ai/grok](https://x.ai/grok)） |
+| X 内 | X.com / X App 里的 Grok（[FAQ](https://docs.x.ai/grok/faq) 把 X 产品问题转给 X Help，不是 xAI） |
+
+这些页面上**没有**官方 Grok 桌面聊天 App。带云电脑的桌面 + iOS 产品是 [Grok Bot](./grok-bot.md)。
+
+官方 "What you can do"（[overview](https://docs.x.ai/grok/overview)）：
+
+- **Chat** — 提问、头脑风暴、写作、来回解决问题。
+- **Create images and video** with Grok Imagine。产品页：[grok-imagine.md](./grok-imagine.md)。
+- **Talk to Grok** hands-free with voice。产品 + API：[grok-voice.md](./grok-voice.md)。
+- **Upload files** — PDF、图片、表格、代码、音频等，做分析、抽取、摘要。
+- **Connect your tools** — 在对话里连邮箱、文件、日历。见 [Connectors](./grok-connectors.md)。
+
+[x.ai/grok](https://x.ai/grok) 还写了实时 web + 𝕏 搜索、深度推理、SuperGrok 的 multi-agent、**对话里**写代码、跨会话记忆、长文 Canvas、自定义指令、可分享链接。这仍是聊天，不是仓库 Agent。
+
+## 账号与订阅同步
+
+登录一次。对话、设置、订阅在 Web 与 App 之间同步（[overview](https://docs.x.ai/grok/overview)）。
+
+[FAQ](https://docs.x.ai/grok/faq) 写明的常见坑：
+
+- 订阅绑在**购买时的那个账号**上。Web 上有 SuperGrok、手机 App 里没有，多半是登录身份不同，不一定是重复扣款。X Premium+ 只作用于绑了该 X 账号的那个身份。
+- 在 grok.com 的 **Settings → Account → Connect your X Account** 绑定 X。登录方式在 [accounts.x.ai](https://accounts.x.ai) 管理。
+- 用 Apple「隐藏邮件地址」买的订阅，必须用 **Apple 登录**，不能拿中转邮箱走 Google/邮箱登录。
+- 删除 xAI 账号走 [accounts.x.ai/account](https://accounts.x.ai/account)。30 天内可恢复。同一账号上的 API 权限一并撤掉。
+
+计费入口取决于在哪买的（[FAQ](https://docs.x.ai/grok/faq)）：
+
+| 购买渠道 | 管理入口 |
+|----------|----------|
+| Web（grok.com） | [grok.com/?_s=billing](https://grok.com/?_s=billing) 或 Settings → Billing |
+| Apple App Store | Apple 订阅 / 退款页 |
+| Google Play | Google Play 取消；退款走 [xAI 退款表](https://accounts.x.ai/refund) |
+| X Premium | X，不是 xAI（[X Help](https://help.x.com/using-x/x-premium)） |
+
+**API credits 不可退**（[FAQ](https://docs.x.ai/grok/faq)）。
+
+## 套餐与每周用量池
+
+[overview](https://docs.x.ai/grok/overview)：Grok **可以免费开始**。付费 SuperGrok 提高限额、解锁更多产品，从一个**每周用量额度**里花，花在哪个产品上由你决定。
+
+[FAQ](https://docs.x.ai/grok/faq)（2026 年 6 月起滚动上线）用每周共享池替换「每个产品各有每日上限」：
+
+- Chat、Imagine、Voice、Build 等共用一个每周池。
+- 不同产品消耗不同。一条聊天几乎不吃算力；高质量视频或长编码任务吃得多。
+- 查 **Settings → Usage**（Web 与手机）：已用百分比、按产品拆分（API、Build、Chat、Imagine、Voice）、每周重置时间、Extra Usage Credits。
+- 撞上每周上限后，**付费能力**暂停。免费档的 Chat 与 Voice 限额仍在，按自己的周期重置。
+- Extra Usage Credits **目前只能在 Web 买**，最低 $5，默认购买后一年过期，单价高于套餐内含用量。
+- Auto Top Up 是 Web 设置（金额 + 每月上限）。
+
+本页**不**臆造 SuperGrok 美元价或 token 配额。以 Usage 页为准。
+
+团队 / 企业工作区是另一张产品面：[Grok Business](./grok-business.md)。
+
+## 上传文件
+
+官方路径（[FAQ](https://docs.x.ai/grok/faq)）：任意对话里点输入框旁的 **+**（Web 也可拖放）。一条消息可多文件。Grok 确认上传成功后再回答。
+
+| 限额 | 官方数字 |
+|------|----------|
+| 一次多少个 | Web：约 100。Android：最多 20。iOS：支持多个 |
+| 大小 | 多数文件（文档、图片、代码、音频）：每个 **150 MB** |
+| 文档 | PDF、DOCX、TXT、CSV、XLSX、PPTX、HTML、XML、JSON、MD、LaTeX、ODT、RTF、代码（`.py`、`.cpp`、`.java`、`.html`、`.css`） |
+| 图片 | JPEG/JPG、PNG、WebP、HEIC、BMP。GIF / SVG 因平台而异 |
+| 音频 | MP3、WAV、M4A、OGG、FLAC、AAC |
+| 视频 | MP4、MOV |
+
+Grok 能做的事（[FAQ](https://docs.x.ai/grok/faq)）：跨文件综合、改写 / 摘要、抽取表格与引文、分析图表 / 代码 / 音视频、多模态推理。
+
+官方限制：
+
+- 极长文件可能被摘要或分段处理。
+- **非 PDF** 里嵌的图不一定会做视觉理解。
+- 音视频转写质量不稳定。
+- 已存资产在 [grok.com/files](https://grok.com/files) 管理。数据控制：**Profile → Settings → Data Controls**。
+
+## 旁边那些面（别混）
+
+| 产品面 | 是什么 | 页面 |
+|--------|--------|------|
+| **Grok 聊天** | 本页。对话、搜索、文件、Voice、对话里的 Imagine | grok.com / App |
+| **Imagine** | 独立生图 / 视频工作室 + Imagine API | [grok-imagine.md](./grok-imagine.md) |
+| **Voice** | App 里免提说话 + Voice API | [grok-voice.md](./grok-voice.md) |
+| **Connectors** | 对话里连邮箱 / 文件 / 日历 / MCP | [grok-connectors.md](./grok-connectors.md) |
+| **Build Mode** | 聊天模式：做出可运行预览并发布到 grok.me。SuperGrok Heavy Early Beta | [x.ai/grok/build-mode](https://x.ai/grok/build-mode)——不是 Grok Build |
+| **Grok Build** | 终端编程 Agent（`grok`） | [grok-cli.md](./grok-cli.md) |
+| **Grok Bot** | 持久云电脑上的具名同事 | [grok-bot.md](./grok-bot.md) |
+| **Grok Business** | 团队工作区与许可证 | [grok-business.md](./grok-business.md) |
+
+[FAQ](https://docs.x.ai/grok/faq) 还值得记住：
+
+- **Grok Studio 已不再支持。** 改用 **Grok Build**。
+- **Companions 仅 iOS。** 官方原文：没有计划做 Web / Android。
+
+## 常见陷阱
+
+- 手机用另一套 Google / Apple / X 身份登录，然后以为订阅丢了。
+- 用 `grok.x.ai` 却奇怪 Projects 不见了——官方地址是 **grok.com**。
+- 把对话里写代码当成仓库 Agent。真要改 checkout，用 [Grok Build](./grok-cli.md)。
+- 每轮粘贴同一批文件，而不是用 [Connectors](./grok-connectors.md) 连邮箱 / Drive / 日历。
+- 把三方「Grok 4.3 / 200 万上下文」写成聊天旗舰。[developers/models](https://docs.x.ai/developers/models) 的编码建议是 **Grok 4.6**。
+
+## 官方文档
+
+| 页面 | 用来干什么 |
+|------|------------|
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | Grok 是什么、平台、下一步 |
+| [docs.x.ai/grok/faq](https://docs.x.ai/grok/faq) | 计费、每周用量、文件、Imagine、账号 |
+| [docs.x.ai/grok/connectors](https://docs.x.ai/grok/connectors) | 对话里连应用 |
+| [docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide) | Business & Enterprise 工作区 |
+| [x.ai/grok](https://x.ai/grok) | 营销页与商店链接 |
+| [grok.com](https://grok.com) | 产品本身 |
+
+## 相关页面
+
+- [Grok 学习地图](./index.md) — 家族决策树
+- [Imagine](./grok-imagine.md) — 生图与视频
+- [Voice](./grok-voice.md) — 产品 Voice + Voice API
+- [Connectors](./grok-connectors.md)
+- [Grok Business](./grok-business.md)
+- [Grok Build 教程](./grok-cli.md)
+- [术语表](./grok-glossary.md)

--- a/docs/zh/products/ai-coding/grok/grok-cheatsheet.md
+++ b/docs/zh/products/ai-coding/grok/grok-cheatsheet.md
@@ -1,0 +1,455 @@
+# Grok Build 速查表
+
+只查不学。所有条目来自 xAI 官方文档，页面链接在每节标题旁。命令的完整集合永远以 `grok --help` / `grok <subcommand> --help` 为准。
+
+覆盖版本 v1.0.4（2026-08-13 的 npm latest）。Grok Build 处于 beta，迭代非常快，看到差异先跑 `grok --version` 再对 [changelog](https://x.ai/build/changelog)。
+
+## 安装与更新
+
+| 场景 | 命令 |
+| --- | --- |
+| macOS / Linux | `curl -fsSL https://x.ai/cli/install.sh \| bash` |
+| Windows PowerShell | `irm https://x.ai/cli/install.ps1 \| iex` |
+| npm 渠道 | `npm install -g @xai-official/grok` |
+| 检查更新 | `grok update --check` |
+| 装指定版本 | `grok update --version <V>` |
+| 切通道 | `grok update --alpha` / `grok update --stable` |
+| 看版本 | `grok version` |
+
+npm 包要求 `node >= 20`，二进制名是 `grok`。
+
+## 子命令
+
+来源：[CLI Reference](https://docs.x.ai/build/cli/reference)
+
+| 命令 | 作用 |
+| --- | --- |
+| `grok` | 无参数启动交互式 TUI |
+| `grok login` | 登录；`--device-auth` 走设备码（无浏览器环境） |
+| `grok logout` | 登出并清除缓存凭证 |
+| `grok inspect [--json]` | 显示当前目录发现的配置：rules、skills、plugins、hooks、MCP servers |
+| `grok models` | 列出可用模型 |
+| `grok mcp <list\|add\|remove\|doctor>` | 管理 MCP server |
+| `grok plugin <list\|install\|uninstall\|update\|enable\|disable\|details\|validate>` | 管理 plugin |
+| `grok plugin marketplace <list\|add\|remove\|update>` | 管理 marketplace 源 |
+| `grok sessions <list\|search\|delete>` | 列出、搜索、删除会话 |
+| `grok export <session-id> [output]` | 导出会话为 Markdown |
+| `grok import [targets...]` | 从 Claude Code 导入会话 |
+| `grok memory clear [--workspace\|--global\|--all]` | 清除跨会话记忆文件 |
+| `grok worktree <list\|show\|rm\|gc>` | 管理会话创建的 git worktree |
+| `grok dashboard` | 打开 Agent Dashboard |
+| `grok agent stdio` | 以 ACP agent 身份在 stdin/stdout 上运行 |
+| `grok wrap <command...>` | 在本地 PTY 里跑命令并转发 OSC 52 剪贴板写入 |
+| `grok update` | 检查或安装更新 |
+| `grok version` | 打印版本信息 |
+| `grok completions <shell>` | 生成 shell 补全脚本 |
+| `grok setup` | 拉取并安装托管配置 |
+
+## 常用 flag
+
+| Flag | 作用 |
+| --- | --- |
+| `--cwd <PATH>` | 工作目录 |
+| `-r, --resume [<ID>]` | 恢复会话，省略 ID 则用最近一个 |
+| `-c, --continue` | 继续当前目录最近一个会话 |
+| `-s, --session-id <UUID>` | 给**新**会话指定 UUID（不是恢复） |
+| `--fork-session` | 恢复时分叉成新会话 ID |
+| `-w, --worktree [<NAME>]` | 在新 git worktree 里开会话 |
+| `--ref <REF>` | worktree 基于的分支/标签/提交 |
+| `-m, --model <MODEL>` | 模型 ID |
+| `--effort <LEVEL>` | 推理强度 |
+| `--always-approve` | 自动批准所有工具调用（别名 `--yolo`） |
+| `--allow <RULE>` / `--deny <RULE>` | 权限规则 |
+| `--sandbox <PROFILE>` | 沙箱 profile |
+| `--rules <TEXT>` | 追加到 system prompt 的额外规则 |
+| `--system-prompt-override <TEXT>` | 整体替换 system prompt |
+| `--tools <LIST>` / `--disallowed-tools <LIST>` | 开放或移除内置工具 |
+| `--max-turns <N>` | 最大 agent turn 数 |
+| `--no-plan` / `--no-subagents` / `--no-memory` / `--disable-web-search` | 本次会话关掉某特性 |
+| `--experimental-memory` | 开启跨会话记忆 |
+| `--oauth` | 欢迎页认证时走 OAuth |
+| `--trust` | 启动时信任项目级 hook / MCP / LSP |
+| `--plugin-dir <PATH>` | 额外的 plugin 目录 |
+
+Claude Code 的 flag 名作为别名被接受：`--allowedTools`、`--disallowedTools`、`--append-system-prompt`、`--system-prompt`、`--dangerously-skip-permissions`。
+
+### Headless 相关
+
+| Flag | 作用 |
+| --- | --- |
+| `-p <PROMPT>` | 非交互执行一个 prompt |
+| `--output-format plain\|json\|streaming-json` | 输出格式，默认 `plain` |
+| `--permission-mode dontAsk\|acceptEdits` | CI 用权限模式 |
+| `--no-alt-screen` | 不使用备用屏幕缓冲 |
+| `--no-auto-update` | 本次运行不自动更新 |
+
+## 权限与模式
+
+来源：[Permissions](https://docs.x.ai/build/features/permissions)、[Modes and Commands](https://docs.x.ai/build/modes-and-commands)
+
+| 模式 | 行为 | 进入方式 |
+| --- | --- | --- |
+| Ask（默认） | 任何未被 allow 的调用都询问 | 默认 |
+| Auto | 分类器自动批准安全工具，危险的仍可能询问 | `/auto`、`Shift+Tab`（特性开启时） |
+| Always-approve | 自动批准工具调用（`deny` 规则和 PreToolUse hook 仍生效） | `/always-approve`、`Ctrl+O`、`Shift+Tab`、`grok --always-approve` |
+| Plan | 只能编辑会话计划文件，直到你批准 | `/plan [description]`、`Shift+Tab` |
+| `dontAsk` | 静默拒绝一切没有显式 allow 的调用（headless / CI） | `--permission-mode dontAsk` |
+| `acceptEdits` | 自动批准文件编辑，shell 命令仍询问 | `--permission-mode acceptEdits` |
+
+`Shift+Tab` 的循环顺序：Normal → Plan → Auto（可用时）→ Always-approve。
+
+规则语法（`deny` 永远赢过 `allow`）：
+
+```toml
+[permission]
+rules = [
+  { action = "allow", tool = "bash", pattern = "git *" },
+  { action = "allow", tool = "read" },
+  { action = "deny",  tool = "bash", pattern = "rm -rf *" },
+]
+```
+
+支持的过滤器：`Bash`、`Edit`、`Read`、`Grep`、`MCPTool`、`WebFetch`、`WebSearch`。
+
+`[ui] permission_mode` 只在**用户配置**（`~/.grok/config.toml` 或 managed / requirements）里生效，项目 `.grok/config.toml` 里写了不算。旧键 `approval_mode` 和 `yolo = true` 仍可用，同时设置时 `permission_mode` 优先。
+
+## 沙箱 profile
+
+来源：[Sandbox](https://docs.x.ai/build/features/sandbox)
+
+默认关闭。Linux 用 Landlock，macOS 用 Seatbelt。
+
+| Profile | 读 | 写 | 网络 | 定位 |
+| --- | --- | --- | --- | --- |
+| `off` | 无限制 | 无限制 | 允许 | 无沙箱（默认） |
+| `workspace` | 任意位置 | CWD、`~/.grok/`、临时目录 | 允许 | 正常开发 |
+| `devbox` | 任意位置 | 除 `/data` 外的顶层目录 | 允许 | 云开发机 |
+| `read-only` | 任意位置 | 只有 `~/.grok/` 和临时目录 | 阻断 | 代码审查、审计 |
+| `strict` | CWD 和系统路径 | CWD、`~/.grok/`、临时目录 | 阻断 | 不可信仓库 |
+
+三条局限：子进程网络限制**只在 Linux 生效**，macOS 上 `read-only` / `strict` 是空操作；内置 profile **不会**永久保护 `~/.ssh` 之类路径，要自己写 `deny`；`~/.grok/` 在所有 profile 下保持可写。模型 API 和 web 工具不受子进程网络设置影响。
+
+自定义 profile 放 `~/.grok/sandbox.toml` 或 `.grok/sandbox.toml`，内置名字不能重定义：
+
+```toml
+[profiles.my-profile]
+extends = "workspace"
+restrict_network = true
+deny = ["/secrets", "**/.env", "**/*.pem"]
+```
+
+## 斜杠命令
+
+来源：[Modes and Commands](https://docs.x.ai/build/modes-and-commands)
+
+### 会话
+
+| 命令 | 作用 |
+| --- | --- |
+| `/quit`（别名 `/exit`） | 退出 |
+| `/help` | 浏览命令和键位 |
+| `/home` | 回欢迎页 |
+| `/new`（别名 `/clear`） | 新会话 |
+| `/resume` | 恢复历史会话 |
+| `/sessions` | 切换、重命名、关闭活动会话 |
+| `/fork` | 分叉当前会话成对等 agent |
+| `/rename <title>`（别名 `/title`） | 重命名当前会话 |
+| `/share` | 以 URL 分享当前会话 |
+| `/session-info` | 会话信息 |
+| `/context` | 上下文占用 |
+| `/compact [context]` | 压缩对话历史 |
+| `/rewind` | 回退到之前的 turn |
+| `/export` | 导出对话到文件或剪贴板 |
+| `/copy [N]` | 复制最后一条（或倒数第 N 条）响应 |
+| `/find` | 搜索滚动区 |
+| `/transcript` | 用 `$PAGER` 查看完整记录 |
+
+### 模型与模式
+
+| 命令 | 作用 |
+| --- | --- |
+| `/model <name>`（别名 `/m`） | 切换模型 |
+| `/effort` | 设置当前模型的推理强度 |
+| `/always-approve` | 切换 always-approve |
+| `/auto` | 切换 auto 模式 |
+| `/plan [description]` | 进入计划模式 |
+| `/view-plan` | 查看当前计划 |
+
+### 任务与编排
+
+| 命令 | 作用 |
+| --- | --- |
+| `/btw <question>` | 问个旁支问题不打断主线 |
+| `/loop [interval] <prompt>` | 按间隔重复跑一个 prompt |
+| `/tasks` | 列出后台任务、subagent、定时任务 |
+| `/queue` | 列出排在当前 turn 后面的 prompt |
+| `/create-workflow [description]` | 编写并保存新 workflow |
+| `/workflow <name> [args]` | 启动 workflow，或 `pause` / `resume` / `stop` / `save` |
+| `/workflows` | 全屏 workflow 运行看板 |
+| `/deep-research <query>` | 跑内置研究工作流 |
+| `/dashboard` | 打开 Agent Dashboard |
+| `/imagine <prompt>` | 文本生成图片 |
+| `/imagine-video <prompt>` | 文本生成视频 |
+
+### 扩展与配置
+
+| 命令 | 作用 |
+| --- | --- |
+| `/hooks` / `/plugins` / `/marketplace` / `/skills` / `/mcps` | 打开同一个扩展弹窗的不同标签页 |
+| `/config-agents`（别名 `/agents`） | 管理 agent 定义 |
+| `/personas` | 管理 persona |
+| `/settings`（别名 `/config`） | 设置弹窗 |
+| `/theme [name]`（别名 `/t`） | 切换主题 |
+| `/compact-mode` | 更紧凑的 UI |
+| `/multiline`（别名 `/ml`） | 切换多行输入 |
+| `/vim-mode` | 切换 vim 风格滚动区键位 |
+| `/timestamps` | 切换消息时间戳 |
+| `/terminal-setup` | 检查终端与剪贴板配置 |
+| `/hooks-trust` | 信任当前项目的 hook |
+| `/import-claude` | 打开 Claude 设置导入弹窗 |
+
+### 账号与记忆
+
+| 命令 | 作用 |
+| --- | --- |
+| `/login` / `/logout` | 登录 / 登出 |
+| `/usage` | 查看额度使用或管理账单 |
+| `/privacy` | 查看或切换隐私与数据保留状态 |
+| `/feedback [text]` | 反馈当前会话 |
+| `/release-notes`（别名 `/changelog`） | 当前版本的发布说明 |
+| `/remember <note>` | 存一条记忆 |
+| `/flush` | 立刻把对话记忆写盘 |
+| `/memory`（别名 `/mem`） | 浏览管理记忆 |
+| `/dream` | 跑记忆整合 |
+
+`/flush`、`/memory`、`/dream` 由 shell 提供，只在跨会话记忆开启时出现。user-invocable 的 skill 也会变成 `/<skill-name>`；名字冲突时用限定形式如 `/local:commit`。
+
+## 键位
+
+来源：[Keyboard Shortcuts](https://docs.x.ai/build/keyboard-shortcuts)。TUI 内按 `Ctrl+.`（Windows 或不支持 Kitty 键盘协议的终端用 `Ctrl+X`）看完整列表。
+
+### 必备
+
+| 键 | 作用 |
+| --- | --- |
+| `Enter` | 发送 |
+| `Tab` | 在输入框和滚动区之间切焦点 |
+| `Esc` | 取消运行中的 turn |
+| `Esc Esc` | 清空输入框；输入框为空时打开 rewind |
+| `Ctrl+C` | 取消 turn |
+| `Shift+Tab` | 循环模式 |
+| `Ctrl+P` 或 `?` | 命令面板 |
+| `F2` 或 `Ctrl+,` | 设置 |
+| `Ctrl+Q` / `Ctrl+D` | 退出（按两次） |
+
+### 输入
+
+| 键 | 作用 |
+| --- | --- |
+| `Ctrl+Enter` 或 `Ctrl+I` | turn 运行中插话 |
+| `Shift+Enter` | 换行；多行模式下是发送（不支持时用 `Alt+Enter`） |
+| `Ctrl+M` | 切换多行输入 |
+| `Ctrl+R` | 搜索 prompt 历史 |
+| `!` | 空输入框时进 shell 模式 |
+
+### 面板与会话
+
+| 键 | 作用 |
+| --- | --- |
+| `Ctrl+T` | 切换 todo 面板 |
+| `Ctrl+B` | 把运行中的命令丢到后台 |
+| `Ctrl+;` 或 `Ctrl+'` | 切换 prompt 队列面板 |
+| `Ctrl+S` | 打开会话列表 |
+| `Ctrl+L` | 打开扩展弹窗 |
+| `Ctrl+G` | 切换任务面板 |
+| `Ctrl+O` | 切换 always-approve |
+| `Ctrl+N` | 新会话（按两次） |
+| `Ctrl+M` | 输入框未聚焦时选模型 |
+| `Ctrl+\` | 打开 Agent Dashboard |
+
+### 终端差异（重要）
+
+- VS Code 系终端（VS Code、Cursor、Windsurf、Zed）：退出只有 `Ctrl+D`，插话是 `Ctrl+L`，半页滚动是 `Shift+D`，`Ctrl+L` **不**打开扩展弹窗（用 `/plugins`），换行用 `Alt+Enter`
+- Apple Terminal：`Ctrl+O` 也会插话
+- WezTerm：需要 `enable_kitty_keyboard = true` 才支持 `Ctrl+Enter` 和 `Shift+Enter`
+
+滚动区的字母键（`j`/`k`/`g`/`e`/`y`/`/` 等）需要 vim 模式（`/vim-mode` 或 `[ui] vim_mode = true`），方向键版本始终可用。
+
+## 配置文件
+
+| 路径 | 用途 |
+| --- | --- |
+| `~/.grok/config.toml` | 用户配置（Windows：`%USERPROFILE%\.grok\config.toml`） |
+| `<project>/.grok/config.toml` | 项目配置，**只认** `[mcp_servers]`、`[plugins]`、`[permission]` |
+| `~/.grok/sandbox.toml` / `.grok/sandbox.toml` | 自定义沙箱 profile |
+| `~/.grok/hooks/*.json` / `<project>/.grok/hooks/*.json` | hook 定义 |
+| `~/.grok/skills/` / `./.grok/skills/` | skill 目录 |
+| `~/.grok/plugins/` / `./.grok/plugins/` | plugin 目录 |
+| `~/.grok/agents/` / `.grok/agents/` | 自定义 subagent 类型 |
+| `~/.grok/personas/*.toml` / `.grok/personas/*.toml` | persona 定义 |
+| `~/.grok/workflows/*.rhai` / `.grok/workflows/*.rhai` | workflow |
+| `~/.grok/sessions/` | 会话历史（按工作目录索引） |
+| `~/.grok/worktrees/<repo>/<name>` | 会话 worktree |
+| `~/.grok/mcp_credentials.json` | MCP OAuth token |
+| `~/.grok/trusted_folders.toml` | 已信任的项目目录 |
+| `~/.grok/logs/mcp/<server>.stderr.log` | MCP stdio server 的 stderr |
+| `/etc/grok/requirements.toml` | 系统级托管策略（防篡改锁只认 root 拥有的来源） |
+
+指令文件：`AGENTS.md` 家族（`AGENTS.md` / `Agents.md` / `AGENT.md`）和 Claude 家族（`CLAUDE.md` / `Claude.md` / `CLAUDE.local.md` / `.claude/rules/`）都会从 cwd 向上读到仓库根。
+
+## 常用配置键
+
+来源：[Settings Reference](https://docs.x.ai/build/settings/reference)
+
+| 段 | 键 | 说明 |
+| --- | --- | --- |
+| `[models]` | `default` | 新会话使用的模型 |
+| `[models]` | `allowed_models` / `hidden_models` / `disabled_models` | 限制可选模型（glob 列表 / ID 列表） |
+| `[model.<id>]` | `model` / `base_url` / `name` / `env_key` / `api_backend` | 自定义或 BYOK 模型 |
+| `[model.<id>]` | `context_window` | 上下文窗口大小，影响自动压缩时机 |
+| `[tools]` | `respect_gitignore` | 默认 `false`；`true` 时搜索/读取工具跳过 gitignore 命中的文件 |
+| `[toolset]` | `file_toolset` | `standard`（默认）或 `hashline` |
+| `[toolset.bash]` | `timeout_secs` / `output_byte_limit` / `max_timeout_secs` | 默认 `120` 秒 / `20000` 字节 / `36000` 秒 |
+| `[toolset.bash]` | `auto_background_on_timeout` | 默认 `true`，超时自动转后台 |
+| `[toolset.web_fetch]` | `allowed_domains` / `proxy_endpoint` | `web_fetch` 域名白名单与出口代理 |
+| `[sandbox]` | `profile` / `auto_allow_bash` | 沙箱 profile；沙箱激活时跳过 bash 询问 |
+| `[permission]` | `rules` | allow / deny 规则 |
+| `[ui]` | `permission_mode` | `"ask"` / `"auto"` / `"always-approve"`，只在用户配置生效 |
+| `[ui]` | `disable_bypass_permissions_mode` | 全局锁掉 always-approve（只认 root 来源） |
+| `[ui]` | `vim_mode` | 滚动区 vim 键位 |
+| `[features]` | `web_fetch` / `lsp_tools` / `write_file` / `tool_search` | `lsp_tools` 默认关，`write_file` / `tool_search` 默认开 |
+| `[subagents]` | `enabled` / `toggle` / `models` | 总开关 / 逐类型开关 / 逐类型模型路由 |
+| `[memory]` | `enabled` | 跨会话记忆总开关，**默认关** |
+| `[skills]` / `[plugins]` | `paths` / `disabled` / `enabled` | 额外目录 / 发现但不激活 / 显式启用 |
+| `[compat.claude]` / `[compat.cursor]` | `skills` / `rules` / `agents` / `mcps` / `hooks` | 是否扫描对应目录，默认全 `true` |
+| `[dashboard]` | `enabled` | Agent Dashboard 总开关 |
+| `[workflows]` | `enabled` | workflow 总开关 |
+| `[mcp_servers.<name>]` | `startup_timeout_sec` / `tool_timeout_sec` | 默认 `30` / `6000` 秒 |
+
+## 环境变量
+
+| 变量 | 默认 | 说明 |
+| --- | --- | --- |
+| `GROK_HOME` | `~/.grok` | 配置、认证、会话、skill、plugin、日志的家目录 |
+| `XAI_API_KEY` | — | 不走浏览器登录时的 API key（CI / headless） |
+| `GROK_DEFAULT_MODEL` | 目录 / 配置 | 会话默认模型 |
+| `GROK_XAI_API_BASE_URL` | `https://api.x.ai/v1` | API key 认证时的 xAI API base |
+| `GROK_MODELS_BASE_URL` | — | 自定义推理 base URL |
+| `GROK_DISABLE_AUTOUPDATER` | 未设置 | 设了就关掉自动更新（CI / 容器） |
+| `GROK_SANDBOX` | `off` | 沙箱 profile，等同 `--sandbox` |
+| `GROK_SANDBOX_AUTO_ALLOW_BASH` | `0` | 沙箱激活时自动放行 bash |
+| `GROK_RESPECT_GITIGNORE` | 跟随配置 | 强制搜索/读取过滤 gitignore |
+| `GROK_WEB_FETCH` | `0` | 开启 `web_fetch` 工具，**默认关（安全考虑）** |
+| `GROK_WEB_FETCH_PROXY` | — | `web_fetch` 的出口代理 |
+| `GROK_MEMORY` | `0` | 跨会话记忆 |
+| `GROK_SUBAGENTS` | `0` | subagent / task 工具 |
+| `GROK_WRITE_FILE` | `1` | 设 `0` 关掉 `write` 工具（只读会话） |
+| `GROK_TOOL_SEARCH` | `1` | 大工具集的按需 MCP 工具发现 |
+| `GROK_LSP_TOOLS` | `0` | LSP 代码智能工具 |
+| `GROK_AGENT` | `grok-build` | 内置 agent 名、profile 或 agent 定义的绝对路径 |
+| `GROK_AGENT_DASHBOARD` | — | 设 `0` 关掉 Agent Dashboard |
+| `GROK_WORKFLOWS` | — | 设 `0` 关掉 workflow |
+| `GROK_THEME` | 内置 | 配色主题 |
+| `GROK_MCP_STARTUP_TIMEOUT_SECS` | `30` | 全局 MCP 启动握手超时，单位**秒** |
+| `MCP_TIMEOUT` | 同一套 | Claude 兼容的 MCP 启动超时，单位**毫秒**，比上一条先被检查 |
+| `GROK_LOG_FILE` | — | 日志写到这个路径 |
+| `RUST_LOG` | — | 日志过滤器（如 `debug`） |
+| `GROK_CRASH_HANDLER` | `0` | panic 时把报告写到 `$GROK_HOME/crash/` |
+| `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | 系统 | 标准代理变量 |
+
+兼容扫描器开关默认全开：`GROK_CURSOR_{SKILLS,RULES,AGENTS,MCPS,HOOKS}_ENABLED`、`GROK_CLAUDE_{SKILLS,RULES,AGENTS,MCPS,HOOKS}_ENABLED`。
+
+UI 类变量还有 `GROK_SHOW_THINKING_BLOCKS`、`GROK_GROUP_TOOL_VERBS`、`GROK_COLLAPSED_EDIT_BLOCKS`、`GROK_PROMPT_SUGGESTIONS`、`GROK_SCROLL_SPEED`、`GROK_SCROLL_MODE`、`GROK_SCROLL_LINES`、`GROK_INVERT_SCROLL`、`GROK_DEFAULT_SELECTED_PERMISSION`、`GROK_REMEMBER_TOOL_APPROVALS`、`GROK_MOUSE_REPORTING_TOGGLE`、`GROK_DISPLAY_REFRESH_AUTO_CADENCE`，完整默认值见官方 [Settings Reference](https://docs.x.ai/build/settings/reference)。
+
+## Hook 事件
+
+| 事件 | 触发时机 |
+| --- | --- |
+| `SessionStart` / `SessionEnd` | 会话开始 / 结束 |
+| `UserPromptSubmit` | 你提交 prompt |
+| `PreToolUse` | 工具即将运行 —— **唯一可阻塞的事件** |
+| `PostToolUse` / `PostToolUseFailure` | 工具完成 / 失败 |
+| `PermissionDenied` | 权限系统拒绝了一次调用 |
+| `Stop` / `StopFailure` | turn 结束 / 因 API 错误结束 |
+| `Notification` | agent 发通知 |
+| `SubagentStart` / `SubagentStop` | subagent 开始 / 结束 |
+| `PreCompact` / `PostCompact` | 对话压缩前 / 后 |
+
+退出码 0 放行，退出码 2 拦截，其余情况（超时、崩溃、格式错误）**全部 fail-open**。
+
+## 模型与计费
+
+来源：[Models](https://docs.x.ai/developers/models)。价格单位是每 100 万 token 的美元。
+
+| 模型 | 上下文 | Input | Cached input | Output |
+| --- | --- | --- | --- | --- |
+| `grok-4.6`（prompt < 200k） | 500k | $2.00 | $0.50 | $6.00 |
+| `grok-4.6`（prompt ≥ 200k） | 500k | $4.00 | $1.00 | $12.00 |
+| `grok-build-0.1`（prompt < 200k） | 256k | $1.00 | $0.20 | $2.00 |
+| `grok-build-0.1`（prompt ≥ 200k） | 256k | $2.00 | $0.40 | $4.00 |
+
+长上下文计费规则：**prompt 达到阈值时，该请求的全部 token 都按高档价算**，不是超出部分才涨价。
+
+官方选型建议：
+
+> For everything else, including code, use Grok 4.6. It is the most intelligent and fastest model we've built.
+
+`grok-4.6` 的知识截止日期是 2026 年 2 月 1 日。模型别名规则：`<modelname>` 指向最新稳定版，`<modelname>-latest` 指向最新版，`<modelname>-<date>` 锁死某次发布。
+
+其他模型（`grok-4.5`、`grok-4.3`、`grok-4.20-*` 系列、Imagine 图像视频、Voice）的价格见官方页面。
+
+## 高质量信息源
+
+按可信度和时效排序。**changelog 通常比文档站更新更快**，遇到文档没写的行为先查它。
+
+### 一手官方
+
+| 来源 | 用途 |
+| --- | --- |
+| [docs.x.ai/build/overview](https://docs.x.ai/build/overview) | Grok Build 文档入口 |
+| [docs.x.ai/build/cli/reference](https://docs.x.ai/build/cli/reference) | 子命令与 flag |
+| [docs.x.ai/build/cli/headless-scripting](https://docs.x.ai/build/cli/headless-scripting) | headless 与 ACP |
+| [docs.x.ai/build/cli/terminal-support](https://docs.x.ai/build/cli/terminal-support) | 终端兼容与诊断 |
+| [docs.x.ai/build/modes-and-commands](https://docs.x.ai/build/modes-and-commands) | 模式与斜杠命令全表 |
+| [docs.x.ai/build/keyboard-shortcuts](https://docs.x.ai/build/keyboard-shortcuts) | 键位全表 |
+| [docs.x.ai/build/settings](https://docs.x.ai/build/settings) | 配置层级与优先级 |
+| [docs.x.ai/build/settings/reference](https://docs.x.ai/build/settings/reference) | 环境变量与 TOML 键全表 |
+| [docs.x.ai/build/enterprise](https://docs.x.ai/build/enterprise) | 托管配置、SSO、ZDR、CI 权限模式 |
+| [docs.x.ai/build/features/permissions](https://docs.x.ai/build/features/permissions) | 权限模型 |
+| [docs.x.ai/build/features/sandbox](https://docs.x.ai/build/features/sandbox) | 沙箱 profile |
+| [docs.x.ai/build/features/hooks](https://docs.x.ai/build/features/hooks) | hook 事件与脚本契约 |
+| [docs.x.ai/build/features/mcp-servers](https://docs.x.ai/build/features/mcp-servers) | MCP 配置 |
+| [docs.x.ai/build/features/skills-plugins-marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces) | skill / plugin / marketplace |
+| [docs.x.ai/build/features/sessions](https://docs.x.ai/build/features/sessions) | 会话、fork、rewind、compact |
+| [docs.x.ai/build/features/worktrees](https://docs.x.ai/build/features/worktrees) | worktree |
+| [docs.x.ai/build/features/subagents](https://docs.x.ai/build/features/subagents) | subagent 与 persona |
+| [docs.x.ai/build/features/background-tasks](https://docs.x.ai/build/features/background-tasks) | 后台任务、`/loop`、monitor |
+| [docs.x.ai/build/features/dashboard](https://docs.x.ai/build/features/dashboard) | Agent Dashboard |
+| [docs.x.ai/developers/models](https://docs.x.ai/developers/models) | 模型列表与价格 |
+
+### 效率技巧
+
+| 技巧 | 说明 |
+| --- | --- |
+| [docs.x.ai/llms.txt](https://docs.x.ai/llms.txt) | 整个文档站的单文件全文镜像，适合本地 grep 或喂给模型（文件很大，别放进仓库） |
+| `https://docs.x.ai/api/mcp` | 官方文档 MCP 端点（Streamable HTTP、无状态），工具 `list_doc_pages` / `get_doc_page` |
+| `grok inspect --json` | 查"我这台机器上到底加载了什么"最快的手段 |
+
+### 版本与源码
+
+| 来源 | 用途 |
+| --- | --- |
+| [x.ai/build/changelog](https://x.ai/build/changelog) | 变更日志，比文档站更新快 |
+| [x.ai/news/grok-build-cli](https://x.ai/news/grok-build-cli) | 发布公告（2026-05-25 early beta） |
+| [github.com/xai-org/grok-build](https://github.com/xai-org/grok-build) | 源码（Rust，Apache-2.0）；**不接受外部 PR**，反馈走 `/feedback` |
+| [github.com/xai-org/plugin-marketplace](https://github.com/xai-org/plugin-marketplace) | 官方 plugin marketplace 目录 |
+| [npmjs.com/package/@xai-official/grok](https://www.npmjs.com/package/@xai-official/grok) | npm 发布节奏与历史版本 |
+
+**访问提示**：`x.ai` 及其子域（含 `status.x.ai`、`console.x.ai`）有 Cloudflare 防护，命令行 `curl` 会拿到 403；`docs.x.ai` 可以直接 `curl`。
+
+## 相关页面
+
+- [Grok Build 学习地图](./index.md)
+- [Grok Build 教程](./grok-cli.md)
+- [Grok Build 实战手册](./grok-cookbook.md)
+- [Grok Build 术语表](./grok-glossary.md)

--- a/docs/zh/products/ai-coding/grok/grok-cheatsheet.md
+++ b/docs/zh/products/ai-coding/grok/grok-cheatsheet.md
@@ -2,7 +2,7 @@
 
 只查不学。所有条目来自 xAI 官方文档，页面链接在每节标题旁。命令的完整集合永远以 `grok --help` / `grok <subcommand> --help` 为准。
 
-覆盖版本 v1.0.4（2026-08-13 的 npm latest）。Grok Build 处于 beta，迭代非常快，看到差异先跑 `grok --version` 再对 [changelog](https://x.ai/build/changelog)。
+覆盖 npm `@xai-official/grok` `1.0.5`（2026-08-16 的 `dist-tags.latest` 与 `alpha`）。2026-08-18 复核时 [changelog](https://x.ai/build/changelog) 头部仍显示 v1.0.3 / Aug 12, 2026。看到差异先跑 `grok version` 再对 changelog。
 
 ## 安装与更新
 
@@ -342,7 +342,7 @@ deny = ["/secrets", "**/.env", "**/*.pem"]
 | `GROK_WEB_FETCH` | `0` | 开启 `web_fetch` 工具，**默认关（安全考虑）** |
 | `GROK_WEB_FETCH_PROXY` | — | `web_fetch` 的出口代理 |
 | `GROK_MEMORY` | `0` | 跨会话记忆 |
-| `GROK_SUBAGENTS` | `0` | subagent / task 工具 |
+| `GROK_SUBAGENTS` | `0` | 开启 subagent / task 工具（`1`/`0`）。[subagents](https://docs.x.ai/build/features/subagents) 页同时写 “Enabled by default when the setting is unset.” 两处官方说法不一致——不要猜哪个赢，以本机 `grok inspect` 为准。 |
 | `GROK_WRITE_FILE` | `1` | 设 `0` 关掉 `write` 工具（只读会话） |
 | `GROK_TOOL_SEARCH` | `1` | 大工具集的按需 MCP 工具发现 |
 | `GROK_LSP_TOOLS` | `0` | LSP 代码智能工具 |
@@ -400,7 +400,7 @@ UI 类变量还有 `GROK_SHOW_THINKING_BLOCKS`、`GROK_GROUP_TOOL_VERBS`、`GROK
 
 ## 高质量信息源
 
-按可信度和时效排序。**changelog 通常比文档站更新更快**，遇到文档没写的行为先查它。
+最后核实：2026-08-18。按可信度和时效排序。**changelog 可以比 [CLI Reference](https://docs.x.ai/build/cli/reference) 更早上新命令**（调研记录里 `grok du`、`grok trace` 就是先出现在 changelog），遇到文档没写的行为先查它。
 
 ### 一手官方
 
@@ -431,8 +431,8 @@ UI 类变量还有 `GROK_SHOW_THINKING_BLOCKS`、`GROK_GROUP_TOOL_VERBS`、`GROK
 
 | 技巧 | 说明 |
 | --- | --- |
-| [docs.x.ai/llms.txt](https://docs.x.ai/llms.txt) | 整个文档站的单文件全文镜像，适合本地 grep 或喂给模型（文件很大，别放进仓库） |
-| `https://docs.x.ai/api/mcp` | 官方文档 MCP 端点（Streamable HTTP、无状态），工具 `list_doc_pages` / `get_doc_page` |
+| [docs.x.ai/llms.txt](https://docs.x.ai/llms.txt) | 整个文档站的单文件全文镜像，适合本地 grep 或喂给模型（文件很大，别放进仓库）。最后核实 2026-08-18，HTTP 200。 |
+| `https://docs.x.ai/api/mcp` | 官方文档 MCP 端点（Streamable HTTP、无状态），工具 `list_doc_pages` / `get_doc_page`。浏览器 GET/HEAD 不是文档页——2026-08-18：HEAD 405、GET/POST 406、OPTIONS 204。要用 MCP 客户端，不要当网页打开。 |
 | `grok inspect --json` | 查"我这台机器上到底加载了什么"最快的手段 |
 
 ### 版本与源码
@@ -441,11 +441,12 @@ UI 类变量还有 `GROK_SHOW_THINKING_BLOCKS`、`GROK_GROUP_TOOL_VERBS`、`GROK
 | --- | --- |
 | [x.ai/build/changelog](https://x.ai/build/changelog) | 变更日志，比文档站更新快 |
 | [x.ai/news/grok-build-cli](https://x.ai/news/grok-build-cli) | 发布公告（2026-05-25 early beta） |
+| [x.ai/news/grok-4-6](https://x.ai/news/grok-4-6) | Grok 4.6 公告（提到 Grok Build 限时 2x included usage；没有长期配额数字） |
 | [github.com/xai-org/grok-build](https://github.com/xai-org/grok-build) | 源码（Rust，Apache-2.0）；**不接受外部 PR**，反馈走 `/feedback` |
 | [github.com/xai-org/plugin-marketplace](https://github.com/xai-org/plugin-marketplace) | 官方 plugin marketplace 目录 |
 | [npmjs.com/package/@xai-official/grok](https://www.npmjs.com/package/@xai-official/grok) | npm 发布节奏与历史版本 |
 
-**访问提示**：`x.ai` 及其子域（含 `status.x.ai`、`console.x.ai`）有 Cloudflare 防护，命令行 `curl` 会拿到 403；`docs.x.ai` 可以直接 `curl`。
+**访问提示**（2026-08-18 复核）：`x.ai/build` 与 `x.ai/build/changelog` 对命令行 `curl` 返回 403（Cloudflare）。`x.ai/news/grok-build-cli` 与 `x.ai/cli/install.sh` 返回 200。上表 `docs.x.ai` 页面返回 200。npmjs.com HTML 返回 403；registry JSON `https://registry.npmjs.org/@xai-official/grok` 可读。
 
 ## 相关页面
 

--- a/docs/zh/products/ai-coding/grok/grok-cheatsheet.md
+++ b/docs/zh/products/ai-coding/grok/grok-cheatsheet.md
@@ -426,6 +426,12 @@ UI 类变量还有 `GROK_SHOW_THINKING_BLOCKS`、`GROK_GROUP_TOOL_VERBS`、`GROK
 | [docs.x.ai/build/features/background-tasks](https://docs.x.ai/build/features/background-tasks) | 后台任务、`/loop`、monitor |
 | [docs.x.ai/build/features/dashboard](https://docs.x.ai/build/features/dashboard) | Agent Dashboard |
 | [docs.x.ai/developers/models](https://docs.x.ai/developers/models) | 模型列表与价格 |
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | grok.com / App 消费端总览 |
+| [docs.x.ai/developers/model-capabilities/imagine](https://docs.x.ai/developers/model-capabilities/imagine) | Imagine API（图像与视频） |
+| [docs.x.ai/grok-bot/overview](https://docs.x.ai/grok-bot/overview) | Grok Bot 产品入口 |
+| [docs.x.ai/grok-bot/get-started](https://docs.x.ai/grok-bot/get-started) | Grok Bot 安装与第一次派活 |
+| [docs.x.ai/grok-bot/computer-and-apps](https://docs.x.ai/grok-bot/computer-and-apps) | 共享云电脑 |
+| [docs.x.ai/grok-bot/faq](https://docs.x.ai/grok-bot/faq) | Grok Bot 平台、费用、记忆 |
 
 ### 效率技巧
 
@@ -442,6 +448,12 @@ UI 类变量还有 `GROK_SHOW_THINKING_BLOCKS`、`GROK_GROUP_TOOL_VERBS`、`GROK
 | [x.ai/build/changelog](https://x.ai/build/changelog) | 变更日志，比文档站更新快 |
 | [x.ai/news/grok-build-cli](https://x.ai/news/grok-build-cli) | 发布公告（2026-05-25 early beta） |
 | [x.ai/news/grok-4-6](https://x.ai/news/grok-4-6) | Grok 4.6 公告（提到 Grok Build 限时 2x included usage；没有长期配额数字） |
+| [x.ai/grok](https://x.ai/grok) | 消费端 Grok（聊天 / Imagine / 语音） |
+| [grok.com/imagine](https://grok.com/imagine) | 消费端 Imagine |
+| [x.ai/grok/build-mode](https://x.ai/grok/build-mode) | Build Mode 营销页（不是 Grok Build CLI） |
+| [x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode) | Build Mode 发布；SuperGrok Heavy Early Beta；grok.me 发布域名 |
+| [x.ai/bot](https://x.ai/bot) | Grok Bot 营销页与下载 |
+| [x.ai/news/introducing-grok-bot](https://x.ai/news/introducing-grok-bot) | Grok Bot 发布（2026-08-11，beta） |
 | [github.com/xai-org/grok-build](https://github.com/xai-org/grok-build) | 源码（Rust，Apache-2.0）；**不接受外部 PR**，反馈走 `/feedback` |
 | [github.com/xai-org/plugin-marketplace](https://github.com/xai-org/plugin-marketplace) | 官方 plugin marketplace 目录 |
 | [npmjs.com/package/@xai-official/grok](https://www.npmjs.com/package/@xai-official/grok) | npm 发布节奏与历史版本 |
@@ -454,3 +466,4 @@ UI 类变量还有 `GROK_SHOW_THINKING_BLOCKS`、`GROK_GROUP_TOOL_VERBS`、`GROK
 - [Grok Build 教程](./grok-cli.md)
 - [Grok Build 实战手册](./grok-cookbook.md)
 - [Grok Build 术语表](./grok-glossary.md)
+- [Grok Bot](./grok-bot.md)

--- a/docs/zh/products/ai-coding/grok/grok-cli.md
+++ b/docs/zh/products/ai-coding/grok/grok-cli.md
@@ -1,0 +1,312 @@
+# Grok Build 教程
+
+> 本页覆盖 Grok Build（可执行文件 `grok`）从安装到日常使用的完整链路。参数清单见 [速查表](./grok-cheatsheet.md)，概念辨析见 [术语表](./grok-glossary.md)，场景化配方见 [Cookbook](./grok-cookbook.md)。
+>
+> Grok Build 处于 beta 阶段且发版极快（npm 上近期约 1-3 天一个版本），本页刻意不写具体版本号；命令与配置若与你机器上的实际行为不符，先看 [x.ai/build/changelog](https://x.ai/build/changelog)。
+
+## 1. 安装
+
+官方提供三条安装通道。
+
+::: code-group
+
+```bash [macOS / Linux]
+curl -fsSL https://x.ai/cli/install.sh | bash
+```
+
+```powershell [Windows PowerShell]
+irm https://x.ai/cli/install.ps1 | iex
+```
+
+```bash [npm（跨平台）]
+npm install -g @xai-official/grok
+```
+
+:::
+
+- 前两条来自 [docs.x.ai/build/overview](https://docs.x.ai/build/overview) 与 [仓库 README](https://github.com/xai-org/grok-build)。
+- npm 通道由 [docs.x.ai/build/enterprise](https://docs.x.ai/build/enterprise) 给出，原文把它列为在网络策略禁止 `curl | bash` 时的替代方案。npm 包要求 Node.js `>= 20`，支持 macOS / Linux / Windows 的 x64 与 arm64。
+
+验证安装：
+
+```bash
+grok --version
+```
+
+> **命名提示**：从源码自行编译得到的二进制叫 `xai-grok-pager`，官方安装包把它作为 `grok` 分发（[README](https://github.com/xai-org/grok-build) 原文："The binary artifact is named `xai-grok-pager`; official installs ship it as `grok`."）。
+
+## 2. 认证
+
+四种方式，来自 [docs.x.ai/build/enterprise](https://docs.x.ai/build/enterprise)：
+
+| 方式 | 怎么做 | 适用场景 |
+|------|--------|----------|
+| 浏览器 OIDC | `grok login`（首次启动会自动打开浏览器） | 本机开发 |
+| 设备码 | `grok login --device-auth`（RFC 8628） | SSH / 远程机器 / 无浏览器 |
+| API Key | `export XAI_API_KEY="xai-..."` 后再运行 `grok` | CI、容器 |
+| 外部认证提供方 | 配置 `auth_provider_command` | 企业统一身份 |
+
+凭证解析优先级（高 → 低）：`model.api_key` > `model.env_key` > 当前会话 token > `XAI_API_KEY`。
+
+订阅要求：[发布公告](https://x.ai/news/grok-build-cli)（2026-05-25）写的是 "Available now to all SuperGrok and X Premium Plus subscribers."，而营销页 [x.ai/build](https://x.ai/build) 当前挂着 "Available to try for Free"。两处口径不同，以你账号登录后实际看到的额度为准；官方没有给出免费额度的具体数值。
+
+<!-- TODO: 待核实 —— 免费额度的具体数值、SuperGrok/X Premium Plus 与 Grok Build 用量的换算关系，官方文档与营销页均未给出说明 -->
+
+退出登录：`grok logout`。
+
+## 3. 第一次运行
+
+```bash
+cd your-project
+grok
+```
+
+无参数启动即进入交互式 TUI（[cli/reference](https://docs.x.ai/build/cli/reference) 原文："Running `grok` with no arguments starts the interactive TUI."）。
+
+官方建议的第一批提示词（[overview](https://docs.x.ai/build/overview)）：
+
+```text
+Explain this repo.
+@src/main.rs Walk me through this file.
+```
+
+`@` 引用文件。**装完先跑一次 `grok inspect`**——它会打印 Grok 在当前目录发现的一切：配置来源、指令文件（含 token 数）、skills、plugins、hooks、MCP 服务器。配置没生效时这是第一诊断命令。
+
+```bash
+grok inspect
+grok inspect --json
+```
+
+## 4. TUI 必备键位
+
+完整键位表在 TUI 里按 `Ctrl+.`（Windows 或不支持 Kitty 键盘协议的终端用 `Ctrl+X`）查看。下表是入门够用的一组，来自 [keyboard-shortcuts](https://docs.x.ai/build/keyboard-shortcuts)：
+
+| 键位 | 作用 |
+|------|------|
+| `Enter` | 发送 |
+| `Shift+Enter` | 换行（VS Code / Cursor / Windsurf / Zed 的内置终端识别不了，改用 `Alt+Enter`） |
+| `Shift+Tab` | 循环切换 Normal → Plan → Auto → Always-approve |
+| `Esc` | 中断当前动作 |
+| `Esc Esc` | 触发 `/rewind`（回退会话） |
+| `Ctrl+Enter` / `Ctrl+I` | 插话（interject，在 VS Code 系终端里是 `Ctrl+L`） |
+| `Ctrl+P` 或 `?` | 命令面板 |
+| `Ctrl+T` | 待办面板 |
+| `Ctrl+B` | 后台任务面板 |
+| `Ctrl+G` | 任务面板 |
+| `Ctrl+S` | 会话面板 |
+| `Ctrl+M` | 模型选择器 |
+| `Ctrl+\` | Dashboard |
+| `Ctrl+O` | 切到 always-approve |
+| `F2` / `Ctrl+,` | 设置 |
+| `Ctrl+Q` / `Ctrl+D` | 退出（VS Code 系终端里只有 `Ctrl+D`） |
+
+终端不兼容时（复制粘贴失效、按键错乱），先在 TUI 里跑 `/terminal-setup` 自检，详见 [terminal-support](https://docs.x.ai/build/cli/terminal-support)。
+
+## 5. 权限：先搞懂这两件事是分开的
+
+这是 Grok Build 最容易用错的地方。官方 [permissions](https://docs.x.ai/build/features/permissions) 原文：
+
+> "Permissions decide which tool calls may run. The sandbox is separate: it limits what an approved call can do on the filesystem and network."
+
+**权限决定「这次工具调用能不能跑」，沙箱决定「跑起来能碰到什么」**，两者正交，可以同时开。
+
+三档权限模式：
+
+| 模式 | 行为 | 怎么进 |
+|------|------|--------|
+| Ask（默认） | 未被 allow 规则覆盖的一律弹确认 | — |
+| Auto | 分类器自动放行安全工具，危险的仍可能弹确认（`deny` 规则与 hooks 依然生效） | `/auto`、`Shift+Tab`（该特性开启时） |
+| Always-approve | 自动放行工具调用（`deny` 规则与 `PreToolUse` hooks 依然生效） | `/always-approve`、`Ctrl+O`、`Shift+Tab`、`grok --always-approve` |
+
+默认模式只能写在**用户级** `~/.grok/config.toml`（项目级 `.grok/config.toml` 不生效）：
+
+```toml
+[ui]
+permission_mode = "auto"  # 或 "ask" | "always-approve"
+```
+
+规则写法（`--allow` / `--deny` 接受同样的 pattern）：
+
+```toml
+[permission]
+rules = [
+  { action = "allow", tool = "bash", pattern = "git *" },
+  { action = "allow", tool = "read" },
+  { action = "deny",  tool = "bash", pattern = "rm -rf *" },
+]
+```
+
+三条必须记住的规则：
+
+1. **`deny` 永远赢过 `allow`**，完整优先级是 deny > ask > allow（[settings/reference](https://docs.x.ai/build/settings/reference)），不是「后写覆盖先写」。
+2. 支持的过滤器：`Bash`、`Edit`、`Read`、`Grep`、`MCPTool`、`WebFetch`、`WebSearch`。
+3. 交互里点的「always allow」对 `rm`、`git push` 这类危险 pattern 仍会再次弹确认；只有配置文件或 CLI 里的显式 allow 规则才会真正自动放行。
+
+## 6. 沙箱：默认是关的
+
+[sandbox](https://docs.x.ai/build/features/sandbox)：Linux 用 Landlock，macOS 用 Seatbelt，**默认 `off`**。
+
+| Profile | 可读 | 可写 | 子进程联网 | 场景 |
+|---------|------|------|-----------|------|
+| `off` | 不限 | 不限 | 允许 | 默认，无沙箱 |
+| `workspace` | 全部 | CWD、`~/.grok/`、临时目录 | 允许 | 常规开发 |
+| `devbox` | 全部 | 除 `/data` 外的顶层目录 | 允许 | 云端 devbox |
+| `read-only` | 全部 | 仅 `~/.grok/` 与临时目录 | 阻止 | 代码审查、审计 |
+| `strict` | CWD 与系统路径 | CWD、`~/.grok/`、临时目录 | 阻止 | 不可信仓库 |
+
+三种开启方式：`grok --sandbox workspace`、`[sandbox] profile = "workspace"`、`GROK_SANDBOX=workspace`。
+
+两个必须知道的限制（官方明确列出）：
+
+- **子进程网络限制只在 Linux 生效**，macOS 上 `read-only` / `strict` 的网络阻断是 no-op。
+- 内置 profile **不会**永久保护 `~/.ssh` 这类敏感路径，要自己写 deny 列表：
+
+```toml
+# ~/.grok/sandbox.toml
+[profiles.my-profile]
+extends = "workspace"
+restrict_network = true
+deny = ["/secrets", "**/.env", "**/*.pem"]
+```
+
+Linux 上要用「可读但拒绝某些路径」的能力需要系统装 `bubblewrap`。
+
+## 7. 计划模式
+
+`/plan [描述]` 进入计划模式，`/view-plan`（别名 `/show-plan`、`/plan-view`）查看。计划评审界面里的按键：`a` 批准、`s` 要求修改、`c` 评论、`q` 退出、`Tab` 切换焦点。
+
+两个要点（[plan-mode](https://docs.x.ai/build/features/plan-mode)）：
+
+- 计划模式与权限模式**互相独立**：即使处于 auto 或 always-approve，计划评审界面也不会被跳过。
+- 计划模式下只有会话计划文件可编辑，但 **bash 仍可通过重定向写文件**——它不是硬隔离，需要硬隔离请配沙箱。
+
+## 8. 会话管理
+
+会话按工作目录存放在 `~/.grok/sessions/`（[sessions](https://docs.x.ai/build/features/sessions)）。
+
+| 目的 | 做法 |
+|------|------|
+| 恢复上一个会话 | `grok -c`（或 `--continue`） |
+| 选择恢复 | `grok --resume`（不带 ID 时列出可选） |
+| 恢复指定会话 | `grok --resume <id>` |
+| TUI 内恢复 | `/resume` |
+| 从当前会话分叉 | `/fork [指令]`，可加 `--worktree` / `--no-worktree` |
+| 回退历史 | `/rewind` 或 `Esc Esc` |
+| 压缩上下文 | `/compact [重点]`；也会自动压缩 |
+| 看上下文占用 | `/context`、`/session-info` |
+| 列出 / 搜索 / 删除 | `grok sessions list` / `search` / `delete` |
+| 导出 | `grok export <session-id> [output]`，`--clipboard` 进剪贴板 |
+| 改标题 | `/rename`（别名 `/title`） |
+
+headless 里拿会话 ID：
+
+```bash
+grok -p "Start the refactor" --output-format json | jq -r '.sessionId'
+```
+
+## 9. 项目规则：AGENTS.md
+
+Grok Build 的项目规则主文件是 `AGENTS.md`。加载顺序是先 `~/.grok/` 全局，再从仓库根目录逐级向下到当前目录（[project-rules](https://docs.x.ai/build/features/project-rules)）。
+
+它会读的文件：
+
+- `AGENTS.md`、`Agents.md`、`AGENT.md`
+- `CLAUDE.md`、`Claude.md`、`CLAUDE.local.md`
+- `.grok/rules/` 下的 `*.md`，以及 `.claude/rules/`、`.cursor/rules/`
+
+被 gitignore 的文件会跳过。单次覆盖用 `--rules <TEXT>`，整体替换系统提示词用 `--system-prompt-override <TEXT>`。`grok inspect` 会列出实际加载了哪些规则文件以及各自的 token 数——规则没生效时先看这里。
+
+## 10. 切换模型
+
+```bash
+grok -m grok-build-0.1 -p "重构这个模块"
+```
+
+TUI 内用 `/model`（别名 `/m`）或 `Ctrl+M`。推理强度用 `/effort` 或 `--effort <LEVEL>`。
+
+接自建 / 第三方 OpenAI 兼容端点（[overview](https://docs.x.ai/build/overview)）：
+
+```toml
+# ~/.grok/config.toml（Windows: %USERPROFILE%\.grok\config.toml）
+[model.my-model]
+model = "model-id"
+base_url = "https://api.example.com/v1"
+name = "Display Name"
+env_key = "API_KEY"
+
+[models]
+default = "my-model"
+```
+
+改完用 `grok inspect` 确认被识别，再 `grok -p "Hello" -m my-model` 验证。
+
+## 11. Headless 模式
+
+```bash
+grok -p "Explain this codebase"
+grok -p "Explain the architecture" --output-format streaming-json
+```
+
+常用参数（[headless-scripting](https://docs.x.ai/build/cli/headless-scripting)）：
+
+| 参数 | 作用 |
+|------|------|
+| `-p, --single <PROMPT>` | 发送单次提示 |
+| `-s, --session-id <ID>` | 创建或复用一个命名的 headless 会话 |
+| `-r, --resume <ID>` / `-c, --continue` | 恢复会话 |
+| `--cwd <PATH>` | 指定工作目录 |
+| `--output-format <FMT>` | `plain`（人读）/ `json`（结束时一个对象）/ `streaming-json`（逐行 JSON 事件） |
+| `--always-approve` | 免确认 |
+| `--no-alt-screen` | 内联输出，不接管整屏 |
+
+headless 会话存在 `~/.grok/sessions`。
+
+**CI 里务必禁用自动更新**：加 `--no-auto-update`，或在 `~/.grok/config.toml` 里持久化：
+
+```toml
+[cli]
+auto_update = false
+```
+
+## 12. ACP：嵌进编辑器或自建编排器
+
+```bash
+grok agent stdio
+```
+
+以 ACP（Agent Client Protocol）agent 身份在 stdin/stdout 上跑 JSON-RPC。官方示例的握手顺序（[headless-scripting](https://docs.x.ai/build/cli/headless-scripting)）：
+
+1. `initialize`，传 `protocolVersion: 1` 和 `clientCapabilities`（`fs.readTextFile` / `fs.writeTextFile` / `terminal`）
+2. `authenticate`：设了 `XAI_API_KEY` 就选 `xai.api_key`，否则用 `cached_token`（都没有时官方报错文案是 "Run `grok login` first, or set XAI_API_KEY."）
+3. `session/new`，传 `{ cwd, mcpServers: [] }`
+4. `session/prompt`，传 `prompt: [{ type: "text", text: "..." }]`
+
+关键细节：**`session/prompt` 的返回值只是完成元数据，助手正文是通过 `session/update` 的 `agent_message_chunk` 事件流式送达的**——只看返回值会以为没输出。
+
+## 13. 更新与排错
+
+```bash
+grok update --check        # 只检查
+grok update                # 更新
+grok update --version <V>  # 指定版本
+grok update --alpha        # 切 alpha 通道
+grok update --stable       # 切回 stable
+```
+
+| 症状 | 先查什么 |
+|------|----------|
+| 配置 / 规则 / MCP 没生效 | `grok inspect`（看它到底读到了什么） |
+| 项目级配置项没生效 | 项目 `.grok/config.toml` **只支持 `[mcp_servers]`、`[plugins]`、`[permission]` 三段**，其余键必须写在 `~/.grok/config.toml` |
+| MCP 服务器起不来 | `grok mcp doctor [name]`，日志在 `~/.grok/logs/mcp/<server>.stderr.log` |
+| 复制粘贴 / 按键异常 | `/terminal-setup` |
+| 网页抓取工具不工作 | `GROK_WEB_FETCH` 默认是 `0`（官方出于安全默认关闭），需显式开启 |
+| 企业网络连不上 | 必须放行 `cli-chat-proxy.grok.com` 与 `auth.x.ai`（[enterprise](https://docs.x.ai/build/enterprise)） |
+
+反馈渠道是 TUI 里的 `/feedback`。**不要给 [xai-org/grok-build](https://github.com/xai-org/grok-build) 提 PR**——README 明确写了 "External contributions are not accepted."
+
+## 相关页面
+
+- [Grok 学习地图](./index.md)
+- [实战 Cookbook](./grok-cookbook.md) — hooks、MCP、skills、subagent、CI 配方
+- [速查表](./grok-cheatsheet.md) — 完整命令 / flag / 配置键 / 环境变量
+- [术语表](./grok-glossary.md) — 权限 vs 沙箱、skill vs plugin 等概念辨析

--- a/docs/zh/products/ai-coding/grok/grok-cli.md
+++ b/docs/zh/products/ai-coding/grok/grok-cli.md
@@ -314,3 +314,4 @@ grok update --stable       # 切回 stable
 - [实战 Cookbook](./grok-cookbook.md) — hooks、MCP、skills、subagent、CI 配方
 - [速查表](./grok-cheatsheet.md) — 完整命令 / flag / 配置键 / 环境变量
 - [术语表](./grok-glossary.md) — 权限 vs 沙箱、skill vs plugin 等概念辨析
+- [Grok Bot](./grok-bot.md) — 云电脑同事，不是这个 CLI

--- a/docs/zh/products/ai-coding/grok/grok-cli.md
+++ b/docs/zh/products/ai-coding/grok/grok-cli.md
@@ -2,7 +2,7 @@
 
 > 本页覆盖 Grok Build（可执行文件 `grok`）从安装到日常使用的完整链路。参数清单见 [速查表](./grok-cheatsheet.md)，概念辨析见 [术语表](./grok-glossary.md)，场景化配方见 [Cookbook](./grok-cookbook.md)。
 >
-> Grok Build 处于 beta 阶段且发版极快（npm 上近期约 1-3 天一个版本），本页刻意不写具体版本号；命令与配置若与你机器上的实际行为不符，先看 [x.ai/build/changelog](https://x.ai/build/changelog)。
+> Grok Build 处于 beta 阶段且发版极快（`latest` 在 2026-08-12 到 2026-08-16 之间从 1.0.3 到 1.0.5），本页刻意不写死版本号；命令与配置若与你机器上的实际行为不符，先看 [x.ai/build/changelog](https://x.ai/build/changelog)。
 
 ## 1. 安装
 
@@ -30,8 +30,10 @@ npm install -g @xai-official/grok
 验证安装：
 
 ```bash
-grok --version
+grok version
 ```
+
+[仓库 README](https://github.com/xai-org/grok-build) 的安装片段写的是 `grok --version`。[CLI Reference](https://docs.x.ai/build/cli/reference) 列出的命令是 `grok version`。
 
 > **命名提示**：从源码自行编译得到的二进制叫 `xai-grok-pager`，官方安装包把它作为 `grok` 分发（[README](https://github.com/xai-org/grok-build) 原文："The binary artifact is named `xai-grok-pager`; official installs ship it as `grok`."）。
 
@@ -48,9 +50,9 @@ grok --version
 
 凭证解析优先级（高 → 低）：`model.api_key` > `model.env_key` > 当前会话 token > `XAI_API_KEY`。
 
-订阅要求：[发布公告](https://x.ai/news/grok-build-cli)（2026-05-25）写的是 "Available now to all SuperGrok and X Premium Plus subscribers."，而营销页 [x.ai/build](https://x.ai/build) 当前挂着 "Available to try for Free"。两处口径不同，以你账号登录后实际看到的额度为准；官方没有给出免费额度的具体数值。
+订阅要求：[发布公告](https://x.ai/news/grok-build-cli)（2026-05-25）写的是 "Available now to all SuperGrok and X Premium Plus subscribers."，营销页 [x.ai/build](https://x.ai/build) 当前挂着 "Available to try for Free"，[Grok 4.6 公告](https://x.ai/news/grok-4-6) 又写过限时 "2x included usage inside Grok Build … for the first week"。三处口径不同，且都没有给出可引用的免费额度数字。以你账号登录后实际看到的额度为准，不要猜数字。
 
-<!-- TODO: 待核实 —— 免费额度的具体数值、SuperGrok/X Premium Plus 与 Grok Build 用量的换算关系，官方文档与营销页均未给出说明 -->
+<!-- TODO: 待核实 —— 免费额度的具体数值、SuperGrok/X Premium Plus 与 Grok Build 用量的换算关系；发布公告、营销页、Grok 4.6 公告三处口径不同，且都没有给出可引用的配额数字。console.x.ai 对非浏览器客户端 403，无法代查。 -->
 
 退出登录：`grok logout`。
 
@@ -85,16 +87,16 @@ grok inspect --json
 |------|------|
 | `Enter` | 发送 |
 | `Shift+Enter` | 换行（VS Code / Cursor / Windsurf / Zed 的内置终端识别不了，改用 `Alt+Enter`） |
-| `Shift+Tab` | 循环切换 Normal → Plan → Auto → Always-approve |
+| `Shift+Tab` | 循环切换 Normal → Plan → Auto（可用时）→ Always-approve |
 | `Esc` | 中断当前动作 |
-| `Esc Esc` | 触发 `/rewind`（回退会话） |
+| `Esc Esc` | 清空输入框；输入框为空时打开 rewind（[keyboard-shortcuts](https://docs.x.ai/build/keyboard-shortcuts)） |
 | `Ctrl+Enter` / `Ctrl+I` | 插话（interject，在 VS Code 系终端里是 `Ctrl+L`） |
 | `Ctrl+P` 或 `?` | 命令面板 |
 | `Ctrl+T` | 待办面板 |
 | `Ctrl+B` | 后台任务面板 |
 | `Ctrl+G` | 任务面板 |
 | `Ctrl+S` | 会话面板 |
-| `Ctrl+M` | 模型选择器 |
+| `Ctrl+M` | 输入框聚焦时切换多行；未聚焦时打开模型选择器 |
 | `Ctrl+\` | Dashboard |
 | `Ctrl+O` | 切到 always-approve |
 | `F2` / `Ctrl+,` | 设置 |
@@ -110,7 +112,9 @@ grok inspect --json
 
 **权限决定「这次工具调用能不能跑」，沙箱决定「跑起来能碰到什么」**，两者正交，可以同时开。
 
-三档权限模式：
+TUI 模式和 headless 的 `--permission-mode` 是**两套词**。TUI 循环的是 Ask / Auto / Always-approve；CI 用的是 Claude Code 风格的 `dontAsk` / `acceptEdits`（见 [enterprise](https://docs.x.ai/build/enterprise) 与 [速查表](./grok-cheatsheet.md#权限与模式)）。不要混着写。
+
+三档 TUI 权限模式：
 
 | 模式 | 行为 | 怎么进 |
 |------|------|--------|
@@ -191,7 +195,7 @@ Linux 上要用「可读但拒绝某些路径」的能力需要系统装 `bubble
 | 恢复指定会话 | `grok --resume <id>` |
 | TUI 内恢复 | `/resume` |
 | 从当前会话分叉 | `/fork [指令]`，可加 `--worktree` / `--no-worktree` |
-| 回退历史 | `/rewind` 或 `Esc Esc` |
+| 回退历史 | `/rewind`，或输入框为空时 `Esc Esc` |
 | 压缩上下文 | `/compact [重点]`；也会自动压缩 |
 | 看上下文占用 | `/context`、`/session-info` |
 | 列出 / 搜索 / 删除 | `grok sessions list` / `search` / `delete` |

--- a/docs/zh/products/ai-coding/grok/grok-connectors.md
+++ b/docs/zh/products/ai-coding/grok/grok-connectors.md
@@ -1,0 +1,109 @@
+# Grok Connectors
+
+> 官方定义（[docs.x.ai/grok/connectors](https://docs.x.ai/grok/connectors)）：
+> "Connectors are available to all Grok users and let Grok access your external tools and data sources directly within a conversation. Search your email, browse files in cloud storage, check your calendar, and more without leaving the chat."
+>
+> 对位 [Claude Connectors](../claude/connectors.md)。本页是**聊天**里的 connector 目录。不是 Grok Build 的 MCP（`grok mcp add`），也不是 Grok Bot 的 Plugins。
+
+## 目标与非目标
+
+**写给谁：** 想在 grok.com 对话里读邮件、Drive、日历，或接自定义 MCP 的人。
+
+**目标：** 列出官方三种类型、内置表、Business 管理员门槛、本地隧道规则。
+
+**非目标：** 再写一遍 MCP 协议教程、臆造目录条目，或 Grok Build 的 `[mcp_servers]` 配置（那是 [grok-cli.md](./grok-cli.md) / [cookbook](./grok-cookbook.md)）。
+
+## 三种类型
+
+[connectors](https://docs.x.ai/grok/connectors)：
+
+| 类型 | 谁维护 | 怎么加 |
+|------|--------|--------|
+| **Built-in** | xAI，原生 OAuth | [grok.com/connectors](https://grok.com/connectors) → **New Connector** → 选服务 → OAuth |
+| **Catalog** | 更多第三方服务的预配置 OAuth | 同一页浏览目录。官方文档没有冻死完整名单 |
+| **Custom MCP** | 你（公网 MCP 服务器） | **New Connector** → **Custom** → MCP 服务器 URL + 认证 |
+
+连上之后，问题跟该服务相关时，Grok 可以自动调用它的工具。本页没有写「每个对话再勾选一次」。
+
+### 内置 connectors
+
+官方表（[connectors](https://docs.x.ai/grok/connectors)）：
+
+| Connector | 连什么 |
+|-----------|--------|
+| **Gmail & Google Calendar** | Gmail 邮件与 Google Calendar 日程 |
+| **Google Drive** | Google Drive 文件、Docs、Sheets、Slides |
+| **OneDrive** | Microsoft OneDrive 个人存储 |
+| **Outlook Mail & Calendar** | Outlook 邮件与日历 |
+| **Microsoft Teams** | Microsoft Teams 消息、频道、聊天 |
+| **SharePoint** | Microsoft SharePoint 站点与文档库 |
+| **Salesforce** | Salesforce CRM — 浏览对象、查询、创建与更新记录 |
+
+### 自定义 MCP connectors
+
+官方能力（[connectors](https://docs.x.ai/grok/connectors)）：
+
+- 把内部 API、数据库或 SaaS 工具暴露给 Grok。
+- 自定义工具的 schema 与逻辑。
+- 认证和访问控制放在你自己的基础设施上。
+
+MCP 服务器**必须能从公网访问**。`localhost` 与 RFC1918 地址（`127.0.0.1`、`10.x`、`172.16.x`、`192.168.x`）会被**拒绝**（[custom-mcp-tunneling](https://docs.x.ai/grok/connectors/custom-mcp-tunneling)）。
+
+该页的隧道形状：
+
+```text
+Grok ──► https://your-tunnel.example.com ──► tunnel provider ──► localhost:3001
+```
+
+官方举例：**ngrok**（`ngrok http 3001`）和 **Cloudflare Tunnel**（`cloudflared tunnel --url http://localhost:3001`）。Cloudflare **quick** tunnel **不支持 SSE**——服务器走 SSE 就用 ngrok。Streamable HTTP 在 Cloudflare 上没问题。
+
+免费档隧道 URL 多半是临时的。重启 → 新 URL → 在 Grok 里删掉旧 connector 再加新的。本地服务器要一直开着；Grok 按需调用。
+
+## Business 与 Enterprise
+
+[connectors](https://docs.x.ai/grok/connectors)：
+
+> For Grok Business and Enterprise users, a team admin must first provision a connector in the [cloud console](https://docs.x.ai/grok/connector-management) before it is available to members of the organization.
+
+管理员路径（[connector-management](https://docs.x.ai/grok/connector-management)）：[console.x.ai](https://console.x.ai) → 团队 → **Grok Business → Connectors**。增删需要 **Team Read-Write**。
+
+1. **+ Add Connector** 从目录选，或 **Other** + MCP URL。
+2. 部分 Microsoft / Salesforce 还要管理员同意。管理页指向 SharePoint、OneDrive、Salesforce 的专项指南。
+3. 管理员开通之后，成员仍要在 [grok.com/connectors](https://grok.com/connectors) 连接**自己的**账号。
+4. **Remove** 对全队删除；与该 connector 相关的索引数据可能被清掉。
+
+个人（非 Business）账号没有管理员这一步。
+
+## 不是这些 connectors
+
+| 看起来像 | 其实是 |
+|----------|--------|
+| Grok 聊天 Connectors | 本页 |
+| Grok Build MCP | `grok mcp add` / `~/.grok/config.toml` 的 `[mcp_servers]` — 工具名带 `<server>__<tool>` |
+| Grok Bot「Plugins」 | [Grok Bot](./grok-bot.md) Settings → Plugins；`@` 挂上 |
+| Voice API 的 `mcp` 工具 | `wss://api.x.ai/v1/realtime` 上的服务端 MCP（[Voice](./grok-voice.md)） |
+
+## 常见陷阱
+
+- 自定义 connector 填 `http://localhost:3001`。官方会拒。
+- Business 成员在管理员开通之前就指望看到 Gmail。
+- 把 Grok Build 的 MCP 配置抄到 grok.com。产品不同，宿主不同。
+- SSE MCP 服务器走 Cloudflare quick tunnel。
+
+## 官方文档
+
+| 页面 | 用来干什么 |
+|------|------------|
+| [docs.x.ai/grok/connectors](https://docs.x.ai/grok/connectors) | 三种类型 + 内置表 |
+| [docs.x.ai/grok/connector-management](https://docs.x.ai/grok/connector-management) | Business 管理员开通 |
+| [docs.x.ai/grok/connectors/custom-mcp-tunneling](https://docs.x.ai/grok/connectors/custom-mcp-tunneling) | 公网 URL / 隧道 |
+| [grok.com/connectors](https://grok.com/connectors) | 用户侧添加 / 连接 |
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | 聊天能力里的 Connectors |
+
+## 相关页面
+
+- [Grok 聊天](./grok-chat.md)
+- [Grok Business](./grok-business.md) — 必须先由管理员开通
+- [Grok Build cookbook](./grok-cookbook.md) — CLI MCP，不是这个
+- [Grok Bot](./grok-bot.md)
+- [Grok 学习地图](./index.md)

--- a/docs/zh/products/ai-coding/grok/grok-cookbook.md
+++ b/docs/zh/products/ai-coding/grok/grok-cookbook.md
@@ -230,7 +230,11 @@ grok worktree gc --max-age 7d      # 清目录已消失的条目；--max-age 额
 
 ## 7. Subagents、Personas 和 Workflows
 
-**Subagents** 是独立上下文的子会话，结束时把摘要交回父会话，设置未显式配置时默认开启。三个内置类型：
+**Subagents** 是独立上下文的子会话，结束时把摘要交回父会话。[subagents](https://docs.x.ai/build/features/subagents) 原文：“Enabled by default when the setting is unset.” 同时 [settings/reference](https://docs.x.ai/build/settings/reference) 里 `GROK_SUBAGENTS` 的默认值是 `0`。两处官方说法不一致——不要猜哪个赢，以本机 `grok inspect` 为准。
+
+<!-- TODO: 待核实 —— `[subagents] enabled` / `GROK_SUBAGENTS` 未设置时到底开还是关；功能页与环境变量表互相矛盾 -->
+
+三个内置类型：
 
 | 类型 | 角色 |
 | --- | --- |

--- a/docs/zh/products/ai-coding/grok/grok-cookbook.md
+++ b/docs/zh/products/ai-coding/grok/grok-cookbook.md
@@ -337,3 +337,4 @@ Grok 也会读 `AGENTS.md` 家族（`AGENTS.md`、`Agents.md`、`AGENT.md`，从
 - [Grok Build 教程](./grok-cli.md) — 安装、认证、TUI、权限、headless
 - [Grok Build 速查表](./grok-cheatsheet.md) — 命令、flag、配置键、环境变量
 - [Grok Build 术语表](./grok-glossary.md) — 为什么这么设计
+- [Grok Bot](./grok-bot.md) — 云电脑同事，不是这个 CLI

--- a/docs/zh/products/ai-coding/grok/grok-cookbook.md
+++ b/docs/zh/products/ai-coding/grok/grok-cookbook.md
@@ -1,0 +1,335 @@
+# Grok Build 实战手册
+
+面向"已经装好、能跑起来"的读者。每个配方都是一个具体任务：先说目标，再给命令或配置，最后说坑在哪。
+
+不清楚安装和认证的先看 [Grok Build 教程](./grok-cli.md)；只想查命令的直接去 [速查表](./grok-cheatsheet.md)。
+
+## 1. 从 Claude Code 迁移
+
+Grok Build 对 Claude Code 的兼容是官方承诺的能力，不是社区 hack。官方原文：
+
+> Grok is fully compatible with Claude Code with zero configuration needed.
+> Grok automatically reads Claude Code marketplaces, plugins, skills, MCPs, agents, hooks, and instruction files (`CLAUDE.md`, `Claude.md`, `CLAUDE.local.md`, and `.claude/rules/`) alongside `.grok/`.
+> — [Skills, Plugins & Marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces)
+
+所以迁移的正确姿势是**什么都不改，先跑一次**：
+
+```bash
+cd your-claude-code-project
+grok
+grok inspect          # 看它到底读到了哪些配置、skill、hook、MCP
+```
+
+`grok inspect` 是迁移期最有用的命令，它会列出配置来源、instructions、skills、plugins、hooks 和 MCP servers（`--json` 输出机器可读格式）。
+
+配套的迁移工具：
+
+| 手段 | 作用 |
+| --- | --- |
+| `/import-claude` | 打开 Claude 设置导入弹窗 |
+| `[compat.claude] mcps = false` | 关掉对 Claude MCP 配置的扫描 |
+| `[compat.cursor] mcps = false` | 关掉对 Cursor MCP 配置的扫描 |
+
+`[compat.claude]` / `[compat.cursor]` 下可单独开关 `skills` / `rules` / `agents` / `mcps` / `hooks`，默认全部 `true`。
+
+CLI flag 也保留了 Claude Code 的别名：`--allowedTools`、`--disallowedTools`、`--append-system-prompt`、`--system-prompt`、`--dangerously-skip-permissions`。
+
+**坑**：有一条兼容是**故意不做**的。Claude Code 的 `managed-settings.json` 里 `disableBypassPermissionsMode: "disable"` 不会作用到 Grok 的 always-approve 模式——官方明确说这是为了不让 Grok 继承宿主机的 Claude Code 封锁策略。要在 Grok 侧锁掉，得在 Grok 自己的 `requirements.toml` 里写 `[ui] disable_bypass_permissions_mode = true`。
+
+## 2. 接入 MCP 外部工具
+
+三种传输方式一条命令搞定：
+
+```bash
+# 本地 stdio server，-- 之后是 server 的启动命令
+grok mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /path/to/dir
+
+# 远端 HTTP server（OAuth 自动处理）
+grok mcp add --transport http linear https://mcp.linear.app/mcp
+
+# 远端 + 静态认证头（--header 可重复）
+grok mcp add --transport http api https://mcp.example.com/mcp --header "Authorization: Bearer ${API_TOKEN}"
+```
+
+日常管理：`grok mcp list`、`grok mcp remove <name>`、`grok mcp doctor [name]`（诊断配置与连通性）。`list` 和 `doctor` 支持 `--json`。
+
+写进配置文件的等价形式：
+
+```toml
+# ~/.grok/config.toml
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+env = { API_KEY = "${MY_API_KEY}" }   # ${VAR} 在加载时展开
+startup_timeout_sec = 30              # 默认 30
+tool_timeout_sec = 6000               # 默认 6000
+
+[mcp_servers.linear]
+url = "https://mcp.linear.app/mcp"
+headers = { "x-mcp-session-id" = "{{session_id}}" }
+```
+
+`url`、`command`、`args`、`env`、`headers` 里都支持 `${VAR}` 和 `${VAR:-default}` 展开，密钥可以留在环境变量里不落盘。OAuth token 存在 `~/.grok/mcp_credentials.json`。
+
+要让 MCP 配置跟着仓库走，加 `--scope project`，它会写进当前目录的 `.grok/config.toml`。加载时 Grok 从当前目录一路向上走到 git 根目录读每一个 `.grok/config.toml`，**同名的项目级 server 会整体替换用户级的**（不是合并）。
+
+**坑三条**：
+
+1. MCP 工具在会话里的名字带命名空间：`<server>__<tool>`，写 allow / deny 规则时要用全名。
+2. stdio server 启起来但连不上，去看 `~/.grok/logs/mcp/<server>.stderr.log`。
+3. 冷启动要下载包的 `npx` server 经常在 30 秒默认超时内起不来，调大 `startup_timeout_sec`。
+
+TUI 里 `/mcps` 打开 MCP 面板：`Space` 开关某个 server，`r` 改完配置后刷新，`i` 走 OAuth 认证，`a` / `x` 增删。
+
+## 3. 用 hooks 拦住危险命令
+
+hook 是生命周期事件触发的 shell 命令或 HTTP 端点。个人 hook 放 `~/.grok/hooks/*.json`，项目 hook 放 `<project>/.grok/hooks/*.json`。
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "bin/safety-check.sh", "timeout": 10 }]
+      }
+    ]
+  }
+}
+```
+
+`matcher` 是对工具名做匹配的正则（Claude 的工具名如 `Bash` / `Read` / `Edit` 会自动映射到 Grok 的），省略则匹配全部。`type` 取 `"command"` 或 `"http"`（后者要给 `url`，事件用 POST 发过去）。`timeout` 单位是秒，默认 5。
+
+脚本契约：事件以 JSON 从 stdin 进来，含 `hookEventName`、`sessionId`、`cwd`、`workspaceRoot`，工具类事件还有 `toolName` 和 `toolInput`；环境变量里有 `GROK_HOOK_EVENT`、`GROK_HOOK_NAME`、`GROK_SESSION_ID`、`GROK_WORKSPACE_ROOT`。
+
+要拦一个调用，`PreToolUse` 往 stdout 写：
+
+```json
+{ "decision": "deny", "reason": "Unsafe command detected" }
+```
+
+**关键行为**：退出码 0 放行，退出码 2 拦截。其余情况——超时、崩溃、输出格式不对——**全部 fail-open**，失败会记进会话但工具照样执行。只有显式 `deny` 才真拦得住。所以安全 hook 不能靠"脚本挂了就不放行"这种假设。
+
+`PreToolUse` 是唯一的阻塞事件。全部事件：`SessionStart` / `SessionEnd`、`UserPromptSubmit`、`PreToolUse`、`PostToolUse` / `PostToolUseFailure`、`PermissionDenied`、`Stop` / `StopFailure`、`Notification`、`SubagentStart` / `SubagentStop`、`PreCompact` / `PostCompact`。
+
+**坑**：项目 hook 要先信任才会跑。第一次打开带 hook 的仓库时用 `/hooks-trust` 授权，或者启动时加 `--trust`。决定存在 `~/.grok/trusted_folders.toml`，并且这个信任同时覆盖项目级 MCP 和 LSP server。
+
+## 4. 收紧权限：团队仓库与不可信仓库
+
+先记住官方那句区分：
+
+> Permissions decide which tool calls may run. The sandbox is separate: it limits what an approved call can do on the filesystem and network.
+
+**权限规则**写在 `[permission]`：
+
+```toml
+[permission]
+rules = [
+  { action = "allow", tool = "bash", pattern = "git *" },
+  { action = "allow", tool = "read" },
+  { action = "deny",  tool = "bash", pattern = "rm -rf *" },
+]
+```
+
+支持的过滤器包含 `Bash`、`Edit`、`Read`、`Grep`、`MCPTool`、`WebFetch`、`WebSearch`。`deny` 永远赢过 `allow`。另外，即使你之前点过"always allow"，遇到 `rm`、`git push` 这类危险模式还是会再问一次。
+
+**沙箱**是另一个开关，默认关闭（Linux 用 Landlock，macOS 用 Seatbelt）：
+
+```bash
+grok --sandbox workspace          # 一次性
+```
+
+```toml
+[sandbox]
+profile = "workspace"             # 或 GROK_SANDBOX=workspace
+```
+
+五个内置 profile 的定位：`off` 无限制（默认）、`workspace` 正常开发、`devbox` 云开发机、`read-only` 代码审查/审计、`strict` 不可信仓库。完整的读写/网络矩阵见 [速查表](./grok-cheatsheet.md#沙箱-profile)。
+
+自定义 profile 写在 `~/.grok/sandbox.toml` 或项目 `.grok/sandbox.toml`：
+
+```toml
+[profiles.my-profile]
+extends = "workspace"
+restrict_network = true
+deny = ["/secrets", "**/.env", "**/*.pem"]
+```
+
+内置名字（`off`、`workspace`、`read-only`、`strict`、`devbox`）不能被重定义。
+
+**沙箱的三条局限**（官方明写，别想当然）：
+
+1. 子进程网络限制只在 Linux 生效，macOS 上对 `read-only` / `strict` 是空操作。
+2. 内置 profile **不会**永久保护 `~/.ssh` 之类路径，要自己写 `deny` 列表。
+3. `~/.grok/` 在所有沙箱 profile 下都保持可写（否则会话没法持久化）；模型 API 和 web 工具不受子进程网络限制影响。
+
+团队统一策略用 `requirements.toml`——它的优先级高于用户 `config.toml`、环境变量和远端设置。锁掉 always-approve：
+
+```toml
+[ui]
+disable_bypass_permissions_mode = true
+```
+
+这条会堵住所有回退路径：`--yolo`、`--permission-mode bypassPermissions`、`Ctrl+O`、`/always-approve`、`Shift+Tab` 模式循环，以及 `*` / `**` 这类兜底 allow 规则。但注意**只有 root 拥有的来源才生效**（`/etc/grok/requirements.toml` 或系统层），用户可写的 `~/.grok/requirements.toml` 里写了不算，这是防篡改设计。
+
+## 5. 在 CI 和脚本里跑 headless
+
+CI 场景有两个专用权限模式：
+
+| 模式 | 行为 | 典型场景 |
+| --- | --- | --- |
+| `dontAsk` | 静默拒绝一切没有显式 allow 的调用 | headless、CI |
+| `acceptEdits` | 自动批准文件编辑，shell 命令仍然询问 | 半自动化流程 |
+
+官方给的 headless 示例：
+
+```bash
+grok -p "Review the API changes" \
+  --permission-mode dontAsk \
+  --allow 'Bash(git *)' \
+  --allow 'Bash(gh *)' \
+  --allow 'Read' \
+  --allow 'Grep' \
+  --deny 'Bash(rm -rf *)' \
+  --sandbox strict
+```
+
+要串多步自动化，把 session ID 读回来再传给 `-r`：
+
+```bash
+grok -p "Start the refactor" --output-format json | jq -r '.sessionId'
+```
+
+`--output-format` 三个取值：`plain`（默认）、`json`、`streaming-json`。
+
+**坑**：`-s, --session-id` 是给新会话指定一个你自己生成的 UUID，**不是**用来恢复已有会话的；恢复用 `-r` / `--resume`。想在恢复的基础上分叉而不是接着写，加 `--fork-session`。
+
+## 6. 并行开发：worktree + Dashboard
+
+worktree 会话跑在仓库的隔离副本里，多个 agent 不会互相覆盖文件。位置在 `~/.grok/worktrees/<repo>/<name>`，从当前 HEAD 起（**包含未提交的改动**），需要是 git 仓库。
+
+```bash
+grok -w
+grok --worktree=feat "refactor module X"   # = 让 prompt 不参与命名
+grok -w --ref main "fix the flaky test"    # 从指定 ref 干净签出
+grok -w -r <session-id>                    # 在新 worktree 里恢复会话
+```
+
+TUI 里：`/fork --worktree` 把当前会话分叉进 worktree；欢迎页 `Ctrl+W` 打开新建 worktree 对话框；Agent Dashboard 里 `Ctrl+W` 把新 agent 直接派进 worktree。
+
+**坑**：worktree 不会自己消失。结束或删除会话都不会删掉它的 worktree，`gc` 只在你手动调用时才跑。
+
+```bash
+grok worktree list
+grok worktree show <id>
+grok worktree rm <ids...>          # --dry-run 先看
+grok worktree gc --max-age 7d      # 清目录已消失的条目；--max-age 额外淘汰闲置的
+```
+
+多会话总览用 Dashboard：`Ctrl+\`、`/dashboard` 或 shell 里 `grok dashboard`。行按状态分组（Needs input / Working / Idle / Inactive / Completed / Failed）实时刷新，`Ctrl+G` 改成按目录分组。选中一行会开 peek 面板，直接打字就能回复——空闲的 agent 立刻收到，忙的排队；权限提示可以用数字键就地回答。分组和置顶状态存在 `[dashboard]` 段，`enabled = false` 或 `GROK_AGENT_DASHBOARD=0` 可关掉整个特性。
+
+## 7. Subagents、Personas 和 Workflows
+
+**Subagents** 是独立上下文的子会话，结束时把摘要交回父会话，设置未显式配置时默认开启。三个内置类型：
+
+| 类型 | 角色 |
+| --- | --- |
+| `general-purpose` | 默认全能力子 agent |
+| `explore` | 只读、列目录、搜索（无 shell、不改文件） |
+| `plan` | 起草实现计划（无 shell、不改文件） |
+
+自定义类型放 `.grok/agents/` 或 `~/.grok/agents/`，用 `/config-agents`（别名 `/agents`）管理。
+
+**Personas** 只是行为叠加层（语气、关注点、契约），不改变能力；定义在 `[subagents.personas]` 或 `.grok/personas/*.toml` / `~/.grok/personas/*.toml`，用 `/personas` 管理。
+
+**Workflows** 在后台编排一组有界的 subagent：扇出、验证、回传结果，默认开启。
+
+```text
+/create-workflow Review the current branch for bugs, then verify each finding
+```
+
+Grok 会问扇出方式、验证方式和范围，然后生成、冒烟测试并保存成 `.grok/workflows/<name>.rhai`（项目级）或 `~/.grok/workflows/<name>.rhai`（全局）。运行：
+
+```text
+/workflow review-changes {"target":"origin/main...HEAD"}
+/workflow pause review-changes
+/workflow resume review-changes
+/workflow stop review-changes-2
+```
+
+`/workflows` 是全屏的实时运行看板，列的是**运行中和保留的 run，不是保存的文件**。内置研究工作流用 `/deep-research <query>`。关掉整个特性：`[workflows] enabled = false` 或 `GROK_WORKFLOWS=0`。
+
+按类型路由模型：`[subagents.models]` 是 subagent → model id 的映射；`[subagents.toggle]` 单独开关某个类型。
+
+## 8. 后台任务与定时巡检
+
+`Ctrl+G` 开任务面板看当前所有运行中的东西，`/tasks` 在滚动区打一份快照；前台命令跑太久，`Ctrl+B` 把它降到后台而不是干等。滚动区里选中一个后台任务按 `x` 杀掉。
+
+定时跑同一个 prompt：
+
+```text
+/loop 5m Check if the test suite passes and report any failures
+```
+
+间隔支持 `Ns`（最小 60）、`Nm`、`Nh`、`Nd`。**提交后立刻触发一次**，然后按间隔重复，每次触发都是一个新的 agent turn。硬限制：loop 7 天后过期，同时最多 50 个定时任务。
+
+要的是实时事件流而不是周期检查，就让 agent 给脚本挂 monitor——脚本打的每一行都会变成会话里的一条通知。所以 monitor 脚本必须写得克制，**每一行输出都会打断对话**。
+
+turn 运行中提交的 prompt 会进队列而不是被丢弃，`Ctrl+;` 开关队列面板，`/queue` 列出来。
+
+区分清楚三个东西：background tasks（长跑进程和 monitor）、todos（`Ctrl+T`，多步计划的进度）、scheduled tasks（`/loop`）。
+
+## 9. 会话管理与跨会话记忆
+
+会话自动全量落盘在 `~/.grok/sessions/`，按工作目录索引，prompt、响应、工具调用、文件快照都在里面。TUI、headless、ACP 三种面行为一致。
+
+| 操作 | 命令 |
+| --- | --- |
+| 恢复指定会话 | `grok --resume <session-id>` |
+| 恢复本目录最近一个 | `grok --resume` / `grok -c` |
+| TUI 里挑一个恢复 | `/resume` |
+| 分叉当前会话 | `/fork [directive]`（`--worktree` / `--no-worktree`） |
+| 回退到某个 turn | `/rewind` 或空闲时 `Esc Esc` |
+| 压缩上下文 | `/compact [context]` |
+| 查上下文占用 | `/context` 或 `/session-info` |
+| 搜索历史会话 | `grok sessions search <query>` |
+| 导出成 Markdown | `grok export <id> [file]`（`--clipboard` 复制） |
+
+**坑**：`/rewind` 会**改磁盘上的文件**——它把所有文件恢复到那个时间点并截断对话，没提交 git 的改动就没了。
+
+跨会话记忆默认关闭（`[memory] enabled` 默认 off）。开启方式：`--experimental-memory` flag、`[memory] enabled = true`，或 `GROK_MEMORY=1`。开启后多出三个 shell 提供的命令：`/flush`（立刻把对话记忆写盘）、`/memory`（别名 `/mem`，浏览管理记忆）、`/dream`（跑记忆整合）。单条记录用 `/remember <note>`。清理：`grok memory clear [--workspace|--global|--all]`。
+
+## 10. Skills 和 Plugins
+
+**Skill** 是一个装着 markdown 说明、脚本和资源的可复用目录。发现路径：`./.grok/skills/`（一路走到仓库根）、`~/.grok/skills/`、任何启用的 plugin 的 `skills/` 目录、`[skills] paths` 里的额外路径。user-invocable 的 skill 会同时以 `/<skill-name>` 出现在斜杠命令里。
+
+`SKILL.md` 的 YAML frontmatter 字段（多余的 key 会被忽略）：
+
+| 字段 | 说明 |
+| --- | --- |
+| `name` | 标识符，省略则用目录名 |
+| `description` | 做什么、什么时候用；省略则取正文第一段 |
+| `when-to-use` | 额外触发短语（别名 `when_to_use`） |
+| `paths` | gitignore 风格 glob；直到碰到匹配文件才显现 |
+| `allowed-tools` | **不授予也不限制工具**；接受 YAML 列表或逗号/空格分隔的字符串 |
+| `argument-hint` | 斜杠命令自动补全提示 |
+| `user-invocable` | 是否作为斜杠命令出现，默认 `true` |
+| `disable-model-invocation` | 只做斜杠命令，不自动调用，默认 `false` |
+| `metadata` | 字符串映射，`author` 和 `short-description` 会显示在 UI |
+
+**两个反直觉点**：`allowed-tools` 名字听着像权限控制，但官方明确说它既不授权也不限制工具；`user-invocable` 只认字面量 `true`，写 `yes` 等于 `false`。另外 `model`、`effort`、`license`、`compatibility` 这四个字段 Grok 接受但**不生效**。
+
+**Plugin** 带来额外的 skills、agents、hooks、MCP servers 和 LSP servers，从 `./.grok/plugins/`、`~/.grok/plugins/`、`~/.grok/plugins/marketplaces/`、`[plugins] paths`、`--plugin-dir <PATH>` 加载。plugin 的 hook 额外拿到 `GROK_PLUGIN_ROOT` 和 `GROK_PLUGIN_DATA` 环境变量。
+
+`/plugins`、`/hooks`、`/skills`、`/mcps`、`/marketplace` 打开的是**同一个扩展弹窗**，只是预选了不同标签页。Marketplace 源来自 `[[marketplace.sources]]` 和 `~/.grok/plugins/known_marketplaces.json`。
+
+`[skills] disabled` / `[plugins] disabled` 是"发现但不激活"，`[plugins] enabled` 用来显式启用（项目级 plugin 可能默认关闭）。
+
+Grok 也会读 `AGENTS.md` 家族（`AGENTS.md`、`Agents.md`、`AGENT.md`，从 cwd 走到仓库根），以及 `~/.agents/skills/` 和 `~/.agents/commands/` 下的用户级 skill 与命令。
+
+## 相关页面
+
+- [Grok Build 学习地图](./index.md)
+- [Grok Build 教程](./grok-cli.md) — 安装、认证、TUI、权限、headless
+- [Grok Build 速查表](./grok-cheatsheet.md) — 命令、flag、配置键、环境变量
+- [Grok Build 术语表](./grok-glossary.md) — 为什么这么设计

--- a/docs/zh/products/ai-coding/grok/grok-glossary.md
+++ b/docs/zh/products/ai-coding/grok/grok-glossary.md
@@ -8,12 +8,15 @@
 
 | 名字 | 是什么 | 在哪用 |
 | --- | --- | --- |
-| Grok（聊天） | 面向消费者的通用助手 | grok.com、Grok App、X |
-| Imagine | 生图 / 生视频 / 编辑 | [grok.com/imagine](https://grok.com/imagine)；程序入口是 [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine) |
-| Build Mode | grok.com / Grok App 的**聊天模式**（模式切换选 **Build**）。SuperGrok Heavy Early Beta。在对话里出可运行预览并发布。**不是** Grok Build | grok.com |
+| [Grok（聊天）](./grok-chat.md) | 面向消费者的通用助手 | grok.com、Grok App、X |
+| [Imagine](./grok-imagine.md) | 生图 / 生视频 / 编辑 | [grok.com/imagine](https://grok.com/imagine)；程序入口是 [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine) |
+| [Voice](./grok-voice.md) | 两箱：**产品** Voice（grok.com / App 免提说话）和 **Voice API**（TTS / STT / Speech to Speech） | grok.com；`api.x.ai` |
+| [Connectors](./grok-connectors.md) | 聊天里连邮箱、文件、日历、目录 OAuth 或公网 MCP。不是 Grok Build 的 `grok mcp add` | [grok.com/connectors](https://grok.com/connectors) |
+| Build Mode | grok.com / Grok App 的**聊天模式**（模式切换选 **Build**）。Early Beta 仅 SuperGrok Heavy，Web / iOS / Android（[x.ai/grok/build-mode](https://x.ai/grok/build-mode)、[news](https://x.ai/news/grok-build-mode)）。官方原文："Tell Grok an idea, and it builds a working version live in your chat." 发布到 grok.me 或自定义域名。网站 / 应用 / 游戏 / 看板（看板可用 Connectors）。不用安装。**不是** Grok Build。官方密度仍是营销页 + 一篇 news，不单独开教程 | grok.com |
 | grok.me | Build Mode 的**发布域名**（官方原文："Publish to a grok.me link or a custom domain you own"）。不是独立产品，也不是 CLI | `*.grok.me` |
 | **Grok Build** | 编码 agent，命令行工具，二进制名 `grok`。文档在 `docs.x.ai/build/*` | 你的终端 |
-| Grok Bot | 跑在一台持久云电脑上的具名同事。桌面 + iOS。文档：[docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview)。**不是** Grok Build 的 headless | [x.ai/bot](https://x.ai/bot) |
+| [Grok Bot](./grok-bot.md) | 跑在一台持久云电脑上的具名同事。桌面 + iOS。文档：[docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview)。**不是** Grok Build 的 headless | [x.ai/bot](https://x.ai/bot) |
+| [Grok Business](./grok-business.md) | 团队工作区、SuperGrok / SuperGrok Heavy 许可证、组织分享。文档：[docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide) | console.x.ai + grok.com |
 | `grok-4.6` | 通用旗舰模型，也是 Grok Build 的默认驱动 | Grok Build 和 xAI API 都能用 |
 | `grok-build-0.1` | 专为编码 agent 场景训练的模型 | 同上 |
 | xAI API | `https://api.x.ai/v1`，模型的 HTTP 接口 | 你自己的程序 |
@@ -27,7 +30,7 @@
 - 把 grok.me 当成独立 "Build 产品" —— 它只是 Build Mode 的发布 URL。
 - 三方博客里的「Grok 4.3」「200 万 token 上下文」「Arena Mode」「8 路并行」当作产品规格 —— 本套文档只记录 [docs.x.ai](https://docs.x.ai/developers/models) 或 [x.ai](https://x.ai) 原文里出现的 slug 和限额。
 
-选哪个产品面，看 [学习地图](./index.md) 的决策树。Grok Bot 有独立页：[Grok Bot](./grok-bot.md)。
+选哪个产品面，看 [学习地图](./index.md) 的决策树。产品地图：[聊天](./grok-chat.md)、[Imagine](./grok-imagine.md)、[Voice](./grok-voice.md)、[Connectors](./grok-connectors.md)、[Grok Bot](./grok-bot.md)、[Business](./grok-business.md)。
 
 ## 一个 agent，三张脸
 
@@ -184,4 +187,9 @@ Grok Build 目前是 early beta，2026 年 5 月 25 日发布。npm `@xai-offici
 - [Grok Build 教程](./grok-cli.md) — 从零跑起来
 - [Grok Build 实战手册](./grok-cookbook.md) — 具体任务怎么做
 - [Grok Build 速查表](./grok-cheatsheet.md) — 命令、配置键、环境变量
+- [Grok 聊天](./grok-chat.md)
+- [Imagine](./grok-imagine.md)
+- [Voice](./grok-voice.md)
+- [Connectors](./grok-connectors.md)
 - [Grok Bot](./grok-bot.md) — 云电脑同事
+- [Grok Business](./grok-business.md)

--- a/docs/zh/products/ai-coding/grok/grok-glossary.md
+++ b/docs/zh/products/ai-coding/grok/grok-glossary.md
@@ -1,0 +1,175 @@
+# Grok Build 术语表与设计解读
+
+不教操作，只解释"为什么长这样"。理解了这些，速查表里那些看着零散的键和 flag 就会各归其位。
+
+## 五个都叫 Grok 的东西
+
+第一次接触 xAI 的东西，最容易在名字上翻车。
+
+| 名字 | 是什么 | 在哪用 |
+| --- | --- | --- |
+| Grok | 面向消费者的聊天产品 | grok.com、X 客户端 |
+| **Grok Build** | 编码 agent，命令行工具，二进制名 `grok` | 你的终端 |
+| `grok-4.6` | 通用旗舰模型，也是 Grok Build 的默认驱动 | Grok Build 和 xAI API 都能用 |
+| `grok-build-0.1` | 专为编码 agent 场景训练的模型 | 同上 |
+| xAI API | `https://api.x.ai/v1`，模型的 HTTP 接口 | 你自己的程序 |
+
+本站这套文档讲的是**中间那个**。这也是为什么官方文档站分成两棵树：`docs.x.ai/build/*` 讲 CLI，`docs.x.ai/developers/*` 讲 API，两边的术语和配置互不通用。
+
+顺带说一个常见笔误：官方从来没有"Grok Code"或"Grok CLI"这两个产品名，产品名是 Grok Build，`grok` 只是它的可执行文件名。
+
+## 一个 agent，三张脸
+
+官方对自己的定义是一句话：
+
+> Grok Build is a powerful and extensible coding agent. Use it via an interactive TUI, headlessly in scripts or bots, or through the Agent Client Protocol (ACP) in other apps.
+
+三种"面"不是三个产品，是同一个 agent 的三个入口：
+
+| 面 | 入口 | 典型用途 |
+| --- | --- | --- |
+| TUI | `grok` | 人在终端里交互 |
+| Headless | `grok -p "..."` | CI、脚本、机器人 |
+| ACP | `grok agent stdio` | 嵌进编辑器或自建编排器 |
+
+理解这点有实际收益：会话持久化、权限规则、hook、MCP、skill 在三种面下**行为一致**。你在 TUI 里调好的权限规则，headless 跑 CI 时照样生效；TUI 里开的会话，可以用 `grok --resume <id>` 在脚本里接着跑。所以这些能力只需要学一遍。
+
+## 权限和沙箱是两个正交的轴
+
+这是 Grok Build 最容易被误解的设计。官方那句区分值得逐字记住：
+
+> Permissions decide which tool calls may run. The sandbox is separate: it limits what an approved call can do on the filesystem and network.
+
+两个轴的分工：
+
+- **权限**回答"这次调用要不要问我"。它在**调用发起前**起作用，产物是允许 / 拒绝 / 询问。
+- **沙箱**回答"批准之后它最多能干到哪"。它是**操作系统级别**的强制（Linux Landlock、macOS Seatbelt），不依赖模型或 agent 的自觉。
+
+为什么必须分开？因为二者的失效模式不同。权限是策略层，可以被"我点了 always allow"绕过；沙箱是执行层，即使 agent 完全失控、即使你开了 always-approve，它写不出 profile 允许的范围。真正需要安全兜底的场景（跑不可信仓库、审查陌生 PR）应该开沙箱，而不是指望自己每次都认真看权限提示。
+
+反过来也成立：沙箱不是权限的替代品。`read-only` 能拦住写文件，但拦不住一次昂贵的、你并不想跑的只读操作。
+
+顺着这个思路就能理解一个细节：always-approve 模式下，`deny` 规则和 `PreToolUse` hook **仍然生效**。因为 always-approve 只是把"询问"变成"自动批准"，并没有拆掉策略层本身。
+
+## 五层配置：为什么最高优先级在 `/etc`
+
+配置的合并顺序是从低到高五层：
+
+| 优先级 | 来源 | 用途 |
+| --- | --- | --- |
+| 1（最低） | `/etc/grok/managed_config.toml` | 系统级托管配置 |
+| 2 | `~/.grok/managed_config.toml` | 用户级托管配置 |
+| 3 | `~/.grok/config.toml` | 用户偏好 |
+| 4 | `~/.grok/requirements.toml` | 用户级钉死设置 |
+| 5（最高） | `/etc/grok/requirements.toml` | 系统级钉死设置 |
+
+注意这个顺序有点反直觉的地方：`managed_config.toml` 在**最低**两层，`requirements.toml` 在**最高**两层。同一个 `/etc/grok/` 目录下的两个文件，一个垫底一个封顶。
+
+拆开看就合理了，两类文件的语义完全不同：
+
+- `managed_config.toml` 是**默认值分发**——公司帮你预设好，但你想改就能改。所以它必须在用户配置下面。
+- `requirements.toml` 是**策略钉死**（官方叫 fail-closed pin）——它的值不能被用户 `config.toml`、环境变量、远端设置或任何更低层覆盖。所以它必须在最上面。
+
+于是 `/etc/grok/requirements.toml` 成了合规策略的唯一权威来源，也是 MDM 推送的落点。同理可以解释另一条看似奇怪的规定：`[ui] disable_bypass_permissions_mode` 只在 **root 拥有的来源**里生效。如果用户自己写在 `~/.grok/requirements.toml` 里也算，那"锁掉 always-approve"这个策略就等于没锁——用户能加就能删。防篡改必须靠文件所有权，不能靠配置层级。
+
+项目级 `.grok/config.toml` 的限制也出自同一逻辑：它只贡献 `[mcp_servers]`、`[plugins]`、`[permission]`。因为项目配置来自你 clone 的仓库，**是别人写的**。让一个仓库改你的模型、主题、沙箱默认值太危险；但共享 MCP 配置和权限规则是团队协作的合理需求，所以这三段开了口子。
+
+## 认证：四条路和一个解析顺序
+
+| 方式 | 触发 | 可刷新 | 适合 |
+| --- | --- | --- | --- |
+| 浏览器 OIDC | `grok login`（默认） | 是 | 有浏览器的交互终端 |
+| 设备码 | `grok login --device-auth` | 是 | SSH、容器、无头主机 |
+| 外部 auth provider | 配置里 `auth_provider_command` | 是 | 企业 IdP、自建 token broker |
+| API key | `XAI_API_KEY` 或配置里 `model.api_key` | 否 | 脚本、CI/CD、无头自动化 |
+
+多种凭证同时存在时，Grok **按模型**逐个解析，顺序是：`model.api_key` > `model.env_key` > 当前会话 token > `XAI_API_KEY`。
+
+这个顺序解释了一个实际现象：你明明 `grok login` 登录过了，某个自定义模型却还在用 API key——因为 `[model.<id>]` 里配的 key 优先级高于会话 token。BYOK 模型和官方模型可以在同一个会话里走不同凭证，这是设计如此。
+
+配置里请用 `env_key` 而不是 `api_key`，把密钥留在环境变量里，别落进会被 commit 的文件。
+
+## AGENTS.md：为什么越深的文件越优先
+
+项目规则的加载顺序是：先 `~/.grok/` 的全局规则，然后从仓库根一路向下读到当前工作目录，**冲突时更深的文件胜出**。
+
+这个"深者优先"是为 monorepo 设计的。仓库根的 `AGENTS.md` 写全局约定，`packages/frontend/AGENTS.md` 写"用 React，优先 CSS modules"，`packages/backend/AGENTS.md` 写"用 Express，遵循 REST"。你在哪个包里工作，就自动拿到那个包的约定，不需要在 prompt 里重复说。
+
+两个连带的设计：
+
+- `.gitignore` 命中的规则文件会被跳过。所以 `CLAUDE.local.md` 这种个人覆盖不会污染团队共享上下文——它本来就该被 ignore。
+- 规则文件**全量加载，没有大小上限**。听起来很爽，但官方紧接着提醒："短而具体的指令比长的更容易被遵守。" 规则文件不是文档，是给模型的约束，写长了等于没写。
+
+## Plan 模式门的是编辑，不是 shell
+
+计划模式下只有会话计划文件能被编辑，其他编辑工具会被拒绝——**即使在 auto 或 always-approve 下也一样**。
+
+但有一条必须知道的边界：
+
+> Plan mode gates edit tools, not the shell — bash can still write via redirection.
+
+也就是说 plan 模式挡的是 `write` / `edit` 这类工具，不挡 bash。模型完全可以用 `echo ... > file` 绕过去。所以 plan 模式的定位是**协作机制**（让你在动手前先看到方案），不是**安全机制**。要真正防写，用沙箱。
+
+同理，subagent 不受父会话 plan 模式的编辑门限制（但会继承权限模式）。
+
+## 会话是可分支的状态，不是一条聊天记录
+
+Grok Build 的会话默认全量落盘在 `~/.grok/sessions/`，按工作目录索引，prompt、响应、工具调用、文件快照都在里面。理解成"带快照的状态机"比理解成"聊天记录"更准确，因为它支持的操作是状态操作：
+
+| 操作 | 语义 |
+| --- | --- |
+| `--resume` / `-c` | 加载状态继续 |
+| `/fork` | 从当前状态分叉出一个对等 agent |
+| `/rewind` | 把状态**连同磁盘文件**回退到某个 turn |
+| `/compact` | 压缩历史，腾出上下文预算 |
+
+`/rewind` 会改磁盘文件这件事必须单独强调一遍：它不是"撤销对话"，是"撤销这段时间发生的一切"，没提交 git 的改动会没。
+
+`--fork-session` 和 `/fork` 存在的理由是"探索性分叉"：同一个上下文起点，试两种方案互不干扰。配合 worktree（`grok -w`）就变成文件层面也隔离的并行开发——多个 agent 同时改同一个仓库而不互相覆盖。
+
+worktree 不会自动清理，这也是有意的：agent 跑出来的东西你可能还没看过就删了太危险，所以 `gc` 只在手动调用时才跑。代价是你得自己记得 `grok worktree gc`。
+
+## 五种扩展机制的分工
+
+这五个概念最容易糊成一团，因为它们都能"给 agent 加东西"。区别在于加的是什么：
+
+| 机制 | 加的是 | 边界 |
+| --- | --- | --- |
+| **Skill** | 知识和流程（markdown + 脚本 + 资源） | 不改变可用工具集 |
+| **MCP server** | 工具（外部系统的能力） | 通过协议接入，工具名带 `<server>__` 前缀 |
+| **Plugin** | 打包分发的组合（skills + agents + hooks + MCP + LSP） | 是容器，不是新能力类型 |
+| **Subagent** | 独立上下文的执行单元 | 结束时把摘要交回父会话 |
+| **Workflow** | 编排（扇出、验证、汇总一组 subagent） | `.rhai` 脚本，跑在后台 |
+| **Persona** | 行为叠加层（语气、关注点、契约） | **只改行为，不改能力** |
+
+两个高频误解值得点名：
+
+1. **`allowed-tools` 不是权限控制**。它在 `SKILL.md` frontmatter 里，名字听着像白名单，但官方明确说它既不授予也不限制工具。想控制工具，用 `[permission]` 规则或 `--tools` / `--disallowed-tools`。
+2. **Persona 不是 subagent 类型**。换 persona 只换说话方式和关注点，不换它能调什么工具。
+
+Subagent 存在的根本理由是**上下文经济**：探索一个大仓库会产生大量中间输出，这些东西留在主会话里就是纯浪费。所以 `explore` 类型只读、无 shell、不改文件，它的职责是把一堆搜索结果压成一段结论交回来。同理 `plan` 类型也不动文件。
+
+## 为什么它主动兼容 Claude Code
+
+Grok Build 明确承诺零配置兼容 Claude Code：自动读 Claude 的 marketplace、plugin、skill、MCP、agent、hook 和指令文件，CLI flag 也保留 Claude 的别名。
+
+这是一个迁移成本策略：AI 编码工具的切换成本主要不在"学新命令"，而在"重建那一整套配置"——你攒了半年的 skill、调好的 MCP、写熟的 `CLAUDE.md`。把这些东西直接读进来，切换成本就从"重建"降到"跑一次试试"。
+
+但兼容有一条**故意的例外**：Claude 的 `managed-settings.json` 里 `disableBypassPermissionsMode: "disable"` 不会作用到 Grok 的 always-approve。官方给的理由是不让 Grok 继承宿主机的 Claude Code 封锁策略。这个例外本身很能说明兼容层的定位——它兼容的是**你的资产**，不是**别人对你的限制**。要在 Grok 侧锁，就在 Grok 自己的 `requirements.toml` 里写。
+
+## 为什么这份文档一定会过期
+
+Grok Build 目前是 early beta，2026 年 5 月 25 日发布，npm 上的发布节奏是一到三天一个版本。这意味着：
+
+- 看到本站和你机器上的行为不一致，**先信你的机器**，然后按 `grok --version` 去对 [changelog](https://x.ai/build/changelog)。
+- changelog 通常比文档站更新更快。文档里查不到的新行为，去 changelog 找。
+- 上游仓库 [xai-org/grok-build](https://github.com/xai-org/grok-build) 是 Apache-2.0 开源的，但**不接受外部 PR**，反馈渠道是 TUI 里的 `/feedback`。所以不要指望社区 fork 能反哺主线，社区信息的权重要比官方低一档。
+
+判断一条信息还有效的最快手段是 `grok inspect`——它直接告诉你这台机器上实际加载了什么配置、规则、skill、plugin、hook 和 MCP server。文档讲的是应该怎样，`grok inspect` 讲的是实际怎样。
+
+## 相关页面
+
+- [Grok Build 学习地图](./index.md)
+- [Grok Build 教程](./grok-cli.md) — 从零跑起来
+- [Grok Build 实战手册](./grok-cookbook.md) — 具体任务怎么做
+- [Grok Build 速查表](./grok-cheatsheet.md) — 命令、配置键、环境变量

--- a/docs/zh/products/ai-coding/grok/grok-glossary.md
+++ b/docs/zh/products/ai-coding/grok/grok-glossary.md
@@ -159,10 +159,10 @@ Grok Build 明确承诺零配置兼容 Claude Code：自动读 Claude 的 market
 
 ## 为什么这份文档一定会过期
 
-Grok Build 目前是 early beta，2026 年 5 月 25 日发布，npm 上的发布节奏是一到三天一个版本。这意味着：
+Grok Build 目前是 early beta，2026 年 5 月 25 日发布。npm `@xai-official/grok` 的 `latest` 在 2026-08-12 到 2026-08-16 之间从 1.0.3 到 1.0.5。这意味着：
 
-- 看到本站和你机器上的行为不一致，**先信你的机器**，然后按 `grok --version` 去对 [changelog](https://x.ai/build/changelog)。
-- changelog 通常比文档站更新更快。文档里查不到的新行为，去 changelog 找。
+- 看到本站和你机器上的行为不一致，**先信你的机器**，然后按 `grok version` 去对 [changelog](https://x.ai/build/changelog)。
+- changelog 可以比 [CLI Reference](https://docs.x.ai/build/cli/reference) 更早上新命令。文档里查不到的新行为，去 changelog 找。
 - 上游仓库 [xai-org/grok-build](https://github.com/xai-org/grok-build) 是 Apache-2.0 开源的，但**不接受外部 PR**，反馈渠道是 TUI 里的 `/feedback`。所以不要指望社区 fork 能反哺主线，社区信息的权重要比官方低一档。
 
 判断一条信息还有效的最快手段是 `grok inspect`——它直接告诉你这台机器上实际加载了什么配置、规则、skill、plugin、hook 和 MCP server。文档讲的是应该怎样，`grok inspect` 讲的是实际怎样。

--- a/docs/zh/products/ai-coding/grok/grok-glossary.md
+++ b/docs/zh/products/ai-coding/grok/grok-glossary.md
@@ -2,21 +2,32 @@
 
 不教操作，只解释"为什么长这样"。理解了这些，速查表里那些看着零散的键和 flag 就会各归其位。
 
-## 五个都叫 Grok 的东西
+## 都叫 Grok 的东西
 
 第一次接触 xAI 的东西，最容易在名字上翻车。
 
 | 名字 | 是什么 | 在哪用 |
 | --- | --- | --- |
-| Grok | 面向消费者的聊天产品 | grok.com、X 客户端 |
-| **Grok Build** | 编码 agent，命令行工具，二进制名 `grok` | 你的终端 |
+| Grok（聊天） | 面向消费者的通用助手 | grok.com、Grok App、X |
+| Imagine | 生图 / 生视频 / 编辑 | [grok.com/imagine](https://grok.com/imagine)；程序入口是 [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine) |
+| Build Mode | grok.com / Grok App 的**聊天模式**（模式切换选 **Build**）。SuperGrok Heavy Early Beta。在对话里出可运行预览并发布。**不是** Grok Build | grok.com |
+| grok.me | Build Mode 的**发布域名**（官方原文："Publish to a grok.me link or a custom domain you own"）。不是独立产品，也不是 CLI | `*.grok.me` |
+| **Grok Build** | 编码 agent，命令行工具，二进制名 `grok`。文档在 `docs.x.ai/build/*` | 你的终端 |
+| Grok Bot | 跑在一台持久云电脑上的具名同事。桌面 + iOS。文档：[docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview)。**不是** Grok Build 的 headless | [x.ai/bot](https://x.ai/bot) |
 | `grok-4.6` | 通用旗舰模型，也是 Grok Build 的默认驱动 | Grok Build 和 xAI API 都能用 |
 | `grok-build-0.1` | 专为编码 agent 场景训练的模型 | 同上 |
 | xAI API | `https://api.x.ai/v1`，模型的 HTTP 接口 | 你自己的程序 |
 
-本站这套文档讲的是**中间那个**。这也是为什么官方文档站分成两棵树：`docs.x.ai/build/*` 讲 CLI，`docs.x.ai/developers/*` 讲 API，两边的术语和配置互不通用。
+本站这套文档的主线是 **Grok Build**。官方文档站其实不止两棵树：`docs.x.ai/build/*` 讲 CLI，`docs.x.ai/developers/*` 讲 API，`docs.x.ai/grok/*` 讲 grok.com 消费端，`docs.x.ai/grok-bot/*` 讲 Grok Bot。两边的术语和配置互不通用。
 
-顺带说一个常见笔误：官方从来没有"Grok Code"或"Grok CLI"这两个产品名，产品名是 Grok Build，`grok` 只是它的可执行文件名。
+**不是官方产品名或产品规格（正文不要当事实写）：**
+
+- "Grok Code"、"Grok CLI" —— 官方产品名是 Grok Build，可执行文件是 `grok`，仓库是 [xai-org/grok-build](https://github.com/xai-org/grok-build)。
+- 官方 VS Code / JetBrains 插件 —— 编辑器集成走 ACP（`grok agent stdio`）。
+- 把 grok.me 当成独立 "Build 产品" —— 它只是 Build Mode 的发布 URL。
+- 三方博客里的「Grok 4.3」「200 万 token 上下文」「Arena Mode」「8 路并行」当作产品规格 —— 本套文档只记录 [docs.x.ai](https://docs.x.ai/developers/models) 或 [x.ai](https://x.ai) 原文里出现的 slug 和限额。
+
+选哪个产品面，看 [学习地图](./index.md) 的决策树。Grok Bot 有独立页：[Grok Bot](./grok-bot.md)。
 
 ## 一个 agent，三张脸
 
@@ -173,3 +184,4 @@ Grok Build 目前是 early beta，2026 年 5 月 25 日发布。npm `@xai-offici
 - [Grok Build 教程](./grok-cli.md) — 从零跑起来
 - [Grok Build 实战手册](./grok-cookbook.md) — 具体任务怎么做
 - [Grok Build 速查表](./grok-cheatsheet.md) — 命令、配置键、环境变量
+- [Grok Bot](./grok-bot.md) — 云电脑同事

--- a/docs/zh/products/ai-coding/grok/grok-imagine.md
+++ b/docs/zh/products/ai-coding/grok/grok-imagine.md
@@ -1,0 +1,155 @@
+# Grok Imagine
+
+> **Imagine** 是 xAI 的生图 / 视频面。消费端入口是 [grok.com/imagine](https://grok.com/imagine)。API 入口是 [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine)：
+> "The Imagine API lets you generate and edit images and videos with Grok Imagine models."
+>
+> 本页同时画**产品**（聊天 + grok.com/imagine + iOS/Android）和 **API**。对位 Claude Design / Gemini Flow——创作面，**不是**编程 Agent。
+
+## 目标与非目标
+
+**写给谁：** 想在 Grok 里出图 / 短视频，或在自己的程序里调 Imagine API 的人。
+
+**目标：** 把产品 Imagine 和 Imagine API 分开，列出官方模型与工作流，指向文档。
+
+**非目标：** 再抄一遍完整 REST 参考、臆造配额，或写三方「Grok 4.3 / 200 万 token」。不要把 Imagine 当成 Grok Build。
+
+## 两扇门
+
+| 门 | 给谁 | 入口 |
+|----|------|------|
+| **产品 Imagine** | grok.com / iOS / Android 的聊天用户 | [grok.com/imagine](https://grok.com/imagine)，或在 [Grok 聊天](./grok-chat.md) 线程里生成 |
+| **Imagine API** | 你自己的应用 | [docs.x.ai/developers/model-capabilities/imagine](https://docs.x.ai/developers/model-capabilities/imagine)，playground 在 [console.x.ai](https://console.x.ai) |
+
+[x.ai/grok](https://x.ai/grok) 一句话：用文本或参考图生图 / 生视频；改风格、编辑、迭代，不用离开对话。该页营销数字：静帧最高 **2K**，视频最长 **15 秒**（功能网格里视频还写过「最长 15 秒、720p」——分辨率上限还跟套餐有关，见 FAQ）。
+
+付费用量与 Chat / Voice / Build 抽**同一份每周 SuperGrok 池**（[FAQ](https://docs.x.ai/grok/faq)）。本页不臆造某档套餐含多少张图。
+
+## 产品 Imagine
+
+官方消费端事实：
+
+- [overview](https://docs.x.ai/grok/overview)："Create images and video with Grok Imagine."
+- [x.ai/news/grok-imagine-image-2](https://x.ai/news/grok-imagine-image-2)（2026-08-07）：**Imagine Image 2.0** 作为 **Quality Mode** 在 grok.com/imagine 与 iOS / Android App 正式可用。
+- 同一篇：产品工具包括 **magic wand**（改你点的区域）、**segmentation**、**抠背景**、**多参考编辑（最多 5 张输入图）**、**smart resize** 换画幅，以及 **templates**（修图、产品图、证件照、图标、游戏资产等）。
+- [x.ai/news/grok-imagine-video-1-5-references](https://x.ai/news/grok-imagine-video-1-5-references)（2026-07-31）：**文生视频**与**原生 1080p**（文生视频、图生视频）已在 grok.com/imagine、iOS、Android 正式可用。图像 + 语音参考先在美国对 SuperGrok Heavy / SuperGrok Plus 开放，再铺开。每次生成最多 **7** 张参考图。
+
+### 产品侧会撞上的规则（[FAQ](https://docs.x.ai/grok/faq)）
+
+- 生成的图和视频带 **Grok 水印**。没有去水印开关。去掉、改、遮水印违反 Acceptable Use Policy。
+- 打开 **NSFW** **不会**关掉审核。CSAM 与非自愿私密影像一律禁止。
+- **720p 视频在你这一档的 720p 额度用完后自动回落到 480p**。
+
+## Imagine API
+
+官方总览（[imagine](https://docs.x.ai/developers/model-capabilities/imagine)）：文生图、最多 **3** 张参考图的改图、文生 / 图生视频、改视频、reference-to-video、视频续写，以及 Files API。
+
+API 改图的 **3 张上限**，和产品 Image 2.0 的「最多 5 张输入图」不是同一个数字。引用你正在看的那一页。
+
+### 模型（官方 slug）
+
+| 用途 | 官方选型（[developers/models](https://docs.x.ai/developers/models)、[imagine](https://docs.x.ai/developers/model-capabilities/imagine)） |
+|------|------------------------------------------------------------------------------------------------------------------------------------------|
+| 图 | `grok-imagine-image-2.0` |
+| 视频 | `grok-imagine-video-1.5` |
+
+[x.ai/api/imagine](https://x.ai/api/imagine)：最高 **2K**，单次最多 **10** 张图，视频最长 **15s**。生图按张一口价。改图按**输入图 + 输出图**计。视频按秒，时长和分辨率都影响价格。价格以 [developers/models](https://docs.x.ai/developers/models) / [pricing](https://docs.x.ai/developers/pricing#imagine-api-pricing) 为准——不要抄三方表。
+
+### 生图
+
+端点：`POST https://api.x.ai/v1/images/generations`。官方旋钮（[images/generation](https://docs.x.ai/developers/model-capabilities/images/generation)）：
+
+- `n` — 一次多张（总览：最多 10）。
+- `aspect_ratio` — `1:1`、`16:9` / `9:16`、`4:3` / `3:4`、`3:2` / `2:3`、`2:1` / `1:2`、`19.5:9` / `9:19.5`、`20:9` / `9:20`、`auto`。
+- `resolution` — `1k` 或 `2k`。
+- `quality` — `low` 或 `medium`（默认 `medium`）。**仅** `grok-imagine-image-2.0`。
+- 默认返回**临时 URL**。尽快下载，或要 base64。
+
+```bash
+curl -X POST https://api.x.ai/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -d '{
+    "model": "grok-imagine-image-2.0",
+    "prompt": "A collage of London landmarks in a stenciled street-art style",
+    "aspect_ratio": "16:9",
+    "resolution": "2k"
+  }'
+```
+
+改图：`POST https://api.x.ai/v1/images/edits`，公网 URL 或 `data:` URI（[imagine](https://docs.x.ai/developers/model-capabilities/imagine)）。
+
+### 生视频
+
+端点：`POST https://api.x.ai/v1/videos/generations`，再轮询 `GET https://api.x.ai/v1/videos/{request_id}`（[video/generation](https://docs.x.ai/developers/model-capabilities/video/generation)）。
+
+官方约束：
+
+| 旋钮 | 官方范围 |
+|------|----------|
+| `duration` | 1–15 秒 |
+| `aspect_ratio` | `1:1`、`16:9` / `9:16`（默认 `16:9`）、`4:3` / `3:4`、`3:2` / `2:3` |
+| `resolution` | `480p`（默认）、`720p`；`grok-imagine-video-1.5` 的文生视频 / 图生视频支持 `1080p`。reference-to-video 最高 720p |
+| 状态 | `pending` → `done` / `expired` / `failed` |
+| 模式（每次只能一种） | 文生视频、图生视频、reference-to-video、改视频、续写 |
+
+**不要**同时传 `image` 和 `reference_images`（400）。视频 URL 也是临时的。
+
+```bash
+REQUEST_ID=$(curl -s -X POST https://api.x.ai/v1/videos/generations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -d '{
+    "model": "grok-imagine-video-1.5",
+    "prompt": "A glowing crystal-powered rocket launching from Mars",
+    "duration": 10,
+    "aspect_ratio": "16:9",
+    "resolution": "720p"
+  }' | jq -r '.request_id')
+
+curl -s "https://api.x.ai/v1/videos/$REQUEST_ID" \
+  -H "Authorization: Bearer $XAI_API_KEY"
+```
+
+xAI SDK 的 `generate()` 会帮你轮询。REST 必须自己轮询。
+
+视频配音：reference-to-video 上的预设 `voice_id`（与 TTS 同一套）一般可用。**用你自己的音频做 voice reference** 仅对 trusted partner 开放，需 [单独申请](https://x.ai/contact-sales?interest=imagine)（[video/generation](https://docs.x.ai/developers/model-capabilities/video/generation)、[news](https://x.ai/news/grok-imagine-video-1-5-references)）。
+
+生成媒体会过内容审核，且**不用于训练**（[imagine](https://docs.x.ai/developers/model-capabilities/imagine)）。该页企业条目：SOC 2 Type II、HIPAA eligible、GDPR、数据驻留、SSO & RBAC。
+
+## 什么时候用哪个
+
+| 你想要 | 用 |
+|--------|----|
+| 在 Grok 里出一张海报 / 一段片子 | 产品 Imagine：grok.com/imagine 或对话里 |
+| 在自己的产品里出图 / 视频 | Imagine API |
+| 一个能打开的网站 / 游戏，`*.grok.me` 链接 | grok.com 上的 **Build Mode**，不是 Imagine（[x.ai/grok/build-mode](https://x.ai/grok/build-mode)） |
+| 改真实 git 仓库 | [Grok Build](./grok-cli.md) |
+
+## 常见陷阱
+
+- 把产品编辑器的 **5 张图** 和 API 改图的 **3 张上限** 混为一谈。
+- 以为 API 每种模式都能 1080p——reference-to-video 最高 720p；改视频保持输入分辨率，且封顶 720p。
+- 把 Imagine 输出晾在临时 URL 上。
+- 把 Imagine 写成「Grok 4.3、200 万上下文」。图 / 视频 slug 是 `grok-imagine-*`。编码旗舰是 `grok-4.6`。
+- 去掉产品水印。官方禁止。
+
+## 官方文档
+
+| 页面 | 用来干什么 |
+|------|------------|
+| [grok.com/imagine](https://grok.com/imagine) | 消费端工作室 |
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | 聊天能力里的 Imagine |
+| [docs.x.ai/grok/faq](https://docs.x.ai/grok/faq) | 水印、NSFW、720p 回落、每周池 |
+| [docs.x.ai/developers/model-capabilities/imagine](https://docs.x.ai/developers/model-capabilities/imagine) | API 总览 |
+| [images/generation](https://docs.x.ai/developers/model-capabilities/images/generation) | 静帧 |
+| [video/generation](https://docs.x.ai/developers/model-capabilities/video/generation) | 视频 |
+| [x.ai/api/imagine](https://x.ai/api/imagine) | API 营销 |
+| [x.ai/news/grok-imagine-image-2](https://x.ai/news/grok-imagine-image-2) | Image 2.0 / Quality Mode |
+| [x.ai/news/grok-imagine-video-1-5-references](https://x.ai/news/grok-imagine-video-1-5-references) | 1080p、参考图 |
+
+## 相关页面
+
+- [Grok 聊天](./grok-chat.md) — 对话里也能 Imagine
+- [Voice](./grok-voice.md) — 视频预设音色与 TTS 共用名单
+- [Grok 学习地图](./index.md)
+- [术语表](./grok-glossary.md)

--- a/docs/zh/products/ai-coding/grok/grok-voice.md
+++ b/docs/zh/products/ai-coding/grok/grok-voice.md
@@ -1,0 +1,184 @@
+# Grok Voice
+
+> **Voice** 这个词指两件不同的事。
+>
+> **产品 Voice** 是 grok.com 与 iOS / Android App 上的 "Talk to Grok hands-free with voice"（[docs.x.ai/grok/overview](https://docs.x.ai/grok/overview)）。
+>
+> **Voice API** 是开发者栈，文档在 [docs.x.ai/developers/model-capabilities/audio/voice](https://docs.x.ai/developers/model-capabilities/audio/voice)：Speech to Speech、Text to Speech、Speech to Text、自定义音色。
+>
+> 本页两面都画。它**不是** Grok Build。
+
+## 目标与非目标
+
+**写给谁：** 想跟 Grok 说话，或在自己的应用里接语音的人。
+
+**目标：** 把产品 Voice 和 Voice API 分箱；列出官方端点；产品 UI 细节找不到就标 TODO。
+
+**非目标：** 完整 realtime 事件手册、臆造 App 按钮路径，或把三方 voice-arena 排名写成产品规格。
+
+## 产品 Voice（grok.com / App）
+
+官方页实际写了的：
+
+| 事实 | 来源 |
+|------|------|
+| 免提语音是 Grok 的一等能力 | [overview](https://docs.x.ai/grok/overview) |
+| "Natural voice conversations with low-latency back and forth" / "sub-second latency" | [x.ai/grok](https://x.ai/grok) |
+| Web、iOS、Android 可用，历史同步 | [overview](https://docs.x.ai/grok/overview)、[x.ai/grok](https://x.ai/grok) |
+| Voice 是**每周 SuperGrok 用量池**的一块（与 Chat、Imagine、Build、API 共享） | [FAQ](https://docs.x.ai/grok/faq) |
+| 付费周上限撞上后，**免费档 Chat 与 Voice 限额仍可用**，按自己的周期重置 | [FAQ](https://docs.x.ai/grok/faq) |
+
+**TODO — 产品 Voice UI（docs.x.ai / x.ai / grok.com 没有操作走查页）：**
+
+- grok.com / iOS / Android 上到底点哪个控件开始 Voice（麦克风、模式切换、锁屏等）。
+- 产品 Voice 是否暴露 API 那套音色名单（`eve`、`ara` …），还是 App 内更短的列表。
+- 产品 Voice 通话中能否调 [Connectors](./grok-connectors.md)。
+- 插话、转写、语言选择，以及和 Companion 的重叠（[FAQ](https://docs.x.ai/grok/faq) 写 Companions **仅 iOS**；那不是 Voice 本身）。
+
+在这些页出现之前，不要编点击路径。打开 grok.com 或 Grok App，用你实际看到的 Voice 控件。
+
+产品 Voice 是聊天能力。要合上笔记本还在云 VM 上干活的同事，用 [Grok Bot](./grok-bot.md)。
+
+## Voice API
+
+官方栈（[voice overview](https://docs.x.ai/developers/model-capabilities/audio/voice)、[x.ai/api/voice](https://x.ai/api/voice)）：
+
+| 面 | 干什么 | 官方入口 |
+|----|--------|----------|
+| **Speech to Speech**（Realtime） | 全双工语音 Agent、工具、插话 | `wss://api.x.ai/v1/realtime?model=grok-voice-latest` |
+| **Text to Speech** | 文本 → 音频 | `POST https://api.x.ai/v1/tts` 与 `wss://api.x.ai/v1/tts` |
+| **Speech to Text** | 音频 → 文本 | `POST https://api.x.ai/v1/stt` 与 `wss://api.x.ai/v1/stt` |
+| **自定义音色** | 短音频克隆，再传 `voice_id` | `POST https://api.x.ai/v1/custom-voices` |
+
+音频实时处理，**不存储、不用于训练**（[voice overview](https://docs.x.ai/developers/model-capabilities/audio/voice)）。企业条目与 Imagine 相同：SOC 2 Type II、HIPAA eligible、GDPR、数据驻留、SSO & RBAC。
+
+官方价格在 [developers/models](https://docs.x.ai/developers/models)（Speech to Speech、TTS 每百万字符、STT REST vs 流式）。[x.ai/api/voice](https://x.ai/api/voice) 也有营销数字——和 `docs.x.ai` 不一致时，**信 docs.x.ai**。
+
+### Text to Speech
+
+文本转语音（[text-to-speech](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech)）。默认音色 **`eve`**。Voice ID 大小写不敏感。
+
+```bash
+curl -X POST https://api.x.ai/v1/tts \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Hello! Welcome to the xAI Text to Speech API.",
+    "voice_id": "eve",
+    "language": "en"
+  }' \
+  --output hello.mp3
+```
+
+值得记住的官方旋钮：
+
+- `text` — 必填，一元 `POST /v1/tts` 最多 **15,000** 字符。WebSocket 无总上限（单条 `text.delta` 仍 ≤ 15,000）。
+- `language` — 必填。BCP-47 或 `auto`。TTS 页表格列了 20 个代码（`en`、`zh`、`pt-BR` …）。
+- `output_format` — 默认 **MP3 24 kHz / 128 kbps**。编码：`mp3`、`wav`、`pcm`、`mulaw`、`alaw`。
+- `speed` — `0.7`–`1.5`。
+- Speech tags — 行内 `[pause]` / `[laugh]`，包裹 `<whisper>…</whisper>`。
+- `replace` — 发音替换表（拼写或 IPA），合成前生效。计费仍按你发送的原文。
+- `with_timestamps` — JSON 信封：base64 音频 + 逐字符时间。
+- 列音色：`GET https://api.x.ai/v1/tts/voices`。
+- **永远不要在浏览器里用 API key 直接打 TTS。** 走后端代理。
+
+流式：`wss://api.x.ai/v1/tts`，每团队最多 **50** 个并发会话。
+
+Playground：[console.x.ai text-to-speech](https://console.x.ai/team/default/voice/text-to-speech)。
+
+### Speech to Text
+
+转写文件或流（[speech-to-text](https://docs.x.ai/developers/model-capabilities/audio/speech-to-text)）。
+
+```bash
+curl -X POST https://api.x.ai/v1/stt \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -F format=true \
+  -F language=en \
+  -F file=@audio.mp3
+```
+
+官方限制：必须提供 `file` 或 `url`；`file` 必须是 multipart 最后一个字段；最大 **500 MB**。可选：词级时间戳、`diarize`、`multichannel`（最多 8 声道）、`keyterm`、`filler_words`、逆文本正规化（`format=true` + `language`）。流式：`wss://api.x.ai/v1/stt`，带 Smart Turn 话轮检测。
+
+Voice 总览写 STT 支持 **25 种语言**；STT 页另有一张具体的 formatting 语言表。不要把这两句压成你自己发明的一张数字表——链回原页。
+
+### Speech to Speech（Realtime）
+
+用 WebSocket 做语音 Agent（[speech-to-speech](https://docs.x.ai/developers/model-capabilities/audio/speech-to-speech)）。
+
+```javascript
+import WebSocket from "ws";
+
+const ws = new WebSocket("wss://api.x.ai/v1/realtime?model=grok-voice-latest", {
+  headers: { Authorization: `Bearer ${process.env.XAI_API_KEY}` },
+});
+
+ws.on("open", () => {
+  ws.send(JSON.stringify({
+    type: "session.update",
+    session: {
+      voice: "eve",
+      instructions: "You are a helpful customer support agent.",
+      turn_detection: { type: "server_vad" },
+      tools: [{ type: "web_search" }],
+    },
+  }));
+});
+```
+
+官方模型 slug：
+
+| Slug | 含义 |
+|------|------|
+| `grok-voice-latest` | `grok-voice-think-fast-2.0` 的别名 |
+| `grok-voice-think-fast-2.0` | 旗舰语音模型 |
+| `grok-voice-think-fast-1.0` | 上一代 |
+
+客户端应用应使用 **[ephemeral tokens](https://docs.x.ai/developers/model-capabilities/audio/ephemeral-tokens)**，不要把 API key 放到浏览器。浏览器不能设 WebSocket header；协议里传 `xai-client-secret.<token>`。
+
+会话上的服务端工具：`file_search`、`web_search`、`x_search`、`mcp`。客户端：自定义 `function`。会话恢复需显式打开（`resumption.enabled`），用 `conversation_id` 做键，**30 分钟**不活动即丢。
+
+文档里的 demo：[Web Agent](https://github.com/xai-org/xai-cookbook/tree/main/voice-examples/agent/web)、[WebRTC](https://github.com/xai-org/xai-cookbook/tree/main/voice-examples/agent/webrtc)、[Twilio](https://github.com/xai-org/xai-cookbook/tree/main/voice-examples/agent/telephony)、[iOS tester](https://github.com/xai-org/xai-cookbook/tree/main/iOS/VoiceTesterApp)。
+
+### 自定义音色
+
+用参考音频克隆（Voice 总览写 **最长 120s**；[x.ai/api/voice](https://x.ai/api/voice) 写 "two minutes"）。得到的 `voice_id` 可用于 TTS、流式 TTS、Speech to Speech。
+
+## 什么时候用哪个
+
+| 你想要 | 用 |
+|--------|----|
+| 免提跟 Grok 说话 | grok.com / Grok App 上的产品 Voice |
+| 念稿、字幕、电话提示音 | TTS API |
+| 转写会议或直播 | STT API |
+| 会搜索 / 调工具的语音 Agent | Speech to Speech API |
+| 云电脑上的具名同事 | [Grok Bot](./grok-bot.md)，不是 Voice |
+
+## 常见陷阱
+
+- 在浏览器语音组件里塞 API key。用 ephemeral token 或后端代理。
+- 把产品 Voice（订阅每周池）和 Voice API（API credit / 团队账单）混成一笔账。
+- 工具调用后、播放还没完就发 `response.create`——官方 Speech-to-Speech 文档警告会叠音。
+- 臆造 App 设置路径去选 `eve` / `ara`。在 xAI 写出产品 Voice UI 之前标 **TODO**。
+
+## 官方文档
+
+| 页面 | 用来干什么 |
+|------|------------|
+| [docs.x.ai/grok/overview](https://docs.x.ai/grok/overview) | 产品 Voice 一句话 |
+| [docs.x.ai/grok/faq](https://docs.x.ai/grok/faq) | 每周池、撞上限后的免费 Voice |
+| [docs.x.ai/developers/model-capabilities/audio/voice](https://docs.x.ai/developers/model-capabilities/audio/voice) | API 栈 |
+| [text-to-speech](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech) | TTS |
+| [speech-to-text](https://docs.x.ai/developers/model-capabilities/audio/speech-to-text) | STT |
+| [speech-to-speech](https://docs.x.ai/developers/model-capabilities/audio/speech-to-speech) | Realtime |
+| [custom-voices](https://docs.x.ai/developers/model-capabilities/audio/custom-voices) | 克隆音色 |
+| [x.ai/api/voice](https://x.ai/api/voice) | API 营销 + 在线 demo |
+| [x.ai/grok](https://x.ai/grok) | 产品营销 |
+
+## 相关页面
+
+- [Grok 聊天](./grok-chat.md) — Voice 挨着 Chat
+- [Imagine](./grok-imagine.md) — 视频预设音色与 TTS 共用名单
+- [Connectors](./grok-connectors.md)
+- [Grok 学习地图](./index.md)
+- [术语表](./grok-glossary.md)

--- a/docs/zh/products/ai-coding/grok/index.md
+++ b/docs/zh/products/ai-coding/grok/index.md
@@ -38,7 +38,7 @@
 **什么情况下先别急？**
 
 - 你要的是 IDE 内联补全 —— Grok Build 是终端 Agent，没有补全能力，也没有官方 IDE 插件。
-- 你需要长期稳定的 API 面 —— 它仍处于 beta，npm 上从 2025-10-22 至今已发布 552 个版本（近期基本 1-3 天一版），命令与配置键仍在变动。
+- 你需要长期稳定的产品面 —— 它仍处于 beta。npm `@xai-official/grok` 的 `latest` 在 2026-08-12 还是 1.0.3，2026-08-16 已是 1.0.5；命令与配置键仍在变动。绑定任何东西之前先跑 `grok version` 并对 [changelog](https://x.ai/build/changelog)。
 
 ## 学习路径
 

--- a/docs/zh/products/ai-coding/grok/index.md
+++ b/docs/zh/products/ai-coding/grok/index.md
@@ -1,6 +1,6 @@
 # Grok 学习地图
 
-> **Grok Build** 是 xAI（官方英文署名 SpaceXAI）的第一方终端编程 Agent。可执行文件名是 `grok`，源码开放在 [xai-org/grok-build](https://github.com/xai-org/grok-build)。
+> **Grok Build** 是 xAI 的第一方终端编程 Agent。可执行文件名是 `grok`，源码开放在 [xai-org/grok-build](https://github.com/xai-org/grok-build)。
 >
 > 官方定义（[docs.x.ai/build/overview](https://docs.x.ai/build/overview)）：
 > "**Grok Build** is a powerful and extensible coding agent. Use it via an interactive TUI, headlessly in scripts or bots, or through the Agent Client Protocol (ACP) in other apps."

--- a/docs/zh/products/ai-coding/grok/index.md
+++ b/docs/zh/products/ai-coding/grok/index.md
@@ -1,0 +1,103 @@
+# Grok 学习地图
+
+> **Grok Build** 是 xAI（官方英文署名 SpaceXAI）的第一方终端编程 Agent。可执行文件名是 `grok`，源码开放在 [xai-org/grok-build](https://github.com/xai-org/grok-build)。
+>
+> 官方定义（[docs.x.ai/build/overview](https://docs.x.ai/build/overview)）：
+> "**Grok Build** is a powerful and extensible coding agent. Use it via an interactive TUI, headlessly in scripts or bots, or through the Agent Client Protocol (ACP) in other apps."
+
+## 一分钟认清产品形态
+
+很多人会把 Grok 的几个产品混在一起，先分清：
+
+| 产品 | 是什么 | 入口 |
+|------|--------|------|
+| **Grok Build** | 终端编程 Agent（本文档的主题） | 命令 `grok` |
+| Grok（聊天） | 通用对话产品 | [grok.com](https://grok.com)、X 内置 |
+| xAI API | 模型 API（`grok-4.6` 等） | [api.x.ai](https://docs.x.ai/developers/quickstart) |
+
+三者共用同一套账号与模型，但**只有 Grok Build 是编程工具**。它没有官方 IDE 插件——需要在编辑器里用时走 ACP 协议（见下文）。
+
+## 三种使用面
+
+| 使用面 | 入口 | 用在哪 |
+|--------|------|--------|
+| 交互式 TUI | `grok` | 日常开发，全屏终端界面 |
+| Headless | `grok -p "<提示词>"` | 脚本、CI、批处理 |
+| ACP | `grok agent stdio` | 被编辑器 / 自建编排器嵌入（JSON-RPC over stdin/stdout） |
+
+来源：[docs.x.ai/build/overview](https://docs.x.ai/build/overview)、[docs.x.ai/build/cli/reference](https://docs.x.ai/build/cli/reference)
+
+## 快速决策
+
+**什么情况下值得试？**
+
+- 你已经在用 Claude Code，想低成本横向对比。官方明确宣称零配置兼容（读 `CLAUDE.md`、`.claude/settings.json`，接受 Claude Code 的 flag 别名，`grok import` 可导入 Claude Code 会话）——迁移成本几乎为零。
+- 你需要终端里的长任务编排：后台任务、定时循环、subagent 并行、worktree 隔离都是内置能力。
+- 你已经是 SuperGrok 或 X Premium Plus 订阅者（[发布公告](https://x.ai/news/grok-build-cli) 原文：Available now to all SuperGrok and X Premium Plus subscribers），或者手上有 `XAI_API_KEY`。
+
+**什么情况下先别急？**
+
+- 你要的是 IDE 内联补全 —— Grok Build 是终端 Agent，没有补全能力，也没有官方 IDE 插件。
+- 你需要长期稳定的 API 面 —— 它仍处于 beta，npm 上从 2025-10-22 至今已发布 552 个版本（近期基本 1-3 天一版），命令与配置键仍在变动。
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 装上能跑 | [Grok Build 教程](./grok-cli.md) 的安装与认证 | 15 分钟内跑通第一次对话 |
+| 2. 会用核心能力 | [Grok Build 教程](./grok-cli.md) 的 TUI / 计划模式 / 权限 | 敢让它改代码 |
+| 3. 接进工作流 | [实战 Cookbook](./grok-cookbook.md) | headless、CI、hooks、MCP、subagent |
+| 4. 回查参数 | [速查表](./grok-cheatsheet.md) | 命令、flag、配置键、环境变量、价格 |
+| 5. 理清概念 | [术语表](./grok-glossary.md) | 权限模式 vs 沙箱、skill vs plugin、memory vs session |
+
+## 功能速查表
+
+下表只列 Grok Build 已有官方文档页的能力，每项都指向官方原文。
+
+| 能力 | 一句话 | 官方文档 |
+|------|--------|----------|
+| 计划模式 Plan Mode | 先出计划、审批后再动手 | [plan-mode](https://docs.x.ai/build/features/plan-mode) |
+| 权限规则 | `allow` / `ask` / `deny` 规则匹配工具调用 | [permissions](https://docs.x.ai/build/features/permissions) |
+| 沙箱 Sandbox | Landlock / Seatbelt 系统级隔离，5 档 profile | [sandbox](https://docs.x.ai/build/features/sandbox) |
+| 项目规则 | 读 `AGENTS.md`，也读 `CLAUDE.md` / `.cursor/rules` | [project-rules](https://docs.x.ai/build/features/project-rules) |
+| Skills | `SKILL.md` 定义可复用能力，可作 `/<name>` 调用 | [skills-plugins-marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces) |
+| Plugins / Marketplace | 打包 skills+commands+agents+hooks+MCP 分发 | [skills-plugins-marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces) |
+| Hooks | 生命周期事件触发外部命令，可拦截工具调用 | [hooks](https://docs.x.ai/build/features/hooks) |
+| MCP | `grok mcp add`，工具名空间为 `<server>__<tool>` | [mcp-servers](https://docs.x.ai/build/features/mcp-servers) |
+| Subagents / Personas | 内置 `general-purpose` / `explore` / `plan`，可自定义 | [subagents](https://docs.x.ai/build/features/subagents) |
+| Sessions | 按工作目录归档，可 resume / fork / rewind / compact | [sessions](https://docs.x.ai/build/features/sessions) |
+| Worktrees | 在 `~/.grok/worktrees/` 里开隔离分支干活 | [worktrees](https://docs.x.ai/build/features/worktrees) |
+| 后台任务 | 任务面板 + `/loop` 定时循环 | [background-tasks](https://docs.x.ai/build/features/background-tasks) |
+| Dashboard | 多会话状态总览 | [dashboard](https://docs.x.ai/build/features/dashboard) |
+| Headless | `-p` 单次提示，`--output-format` 可出 JSON | [headless-scripting](https://docs.x.ai/build/cli/headless-scripting) |
+| ACP | `grok agent stdio` 作为 ACP agent 被宿主调用 | [headless-scripting](https://docs.x.ai/build/cli/headless-scripting) |
+| 企业策略 | 五层配置、OIDC、MDM 托管策略 | [enterprise](https://docs.x.ai/build/enterprise) |
+| 主题 | 内置 GrokNight / GrokDay 等，支持跟随系统 | [theming](https://docs.x.ai/build/features/theming) |
+
+## 模型参考
+
+| 模型 slug | 定位（官方原文） | 上下文 |
+|-----------|------------------|--------|
+| `grok-4.6` | "For everything else, including code, use Grok 4.6. It is the most intelligent and fastest model we've built." | 500k |
+| `grok-build-0.1` | "xAI's coding model, trained specifically for agentic coding workflows." | 256k |
+
+[x.ai/build](https://x.ai/build) 当前横幅写的是 "Meet Grok 4.6 • Now powering Grok Build"，即默认驱动模型为 `grok-4.6`。价格与限流见 [速查表](./grok-cheatsheet.md#模型与计费)。
+
+来源：[developers/models](https://docs.x.ai/developers/models)、[developers/release-notes](https://docs.x.ai/developers/release-notes)
+
+## 资源链接
+
+- 官方 CLI 文档：<https://docs.x.ai/build/overview>
+- 官方 API 文档：<https://docs.x.ai/developers/quickstart>
+- CLI 变更日志：<https://x.ai/build/changelog>
+- 源码仓库：<https://github.com/xai-org/grok-build>
+- 官方插件市场：<https://github.com/xai-org/plugin-marketplace>
+- 更完整的信息源清单（含访问方式与核实日期）见 [速查表的「高质量信息源」章节](./grok-cheatsheet.md#高质量信息源)
+
+## 相关页面
+
+- [Grok Build 教程](./grok-cli.md) — 安装、认证、TUI、headless、ACP
+- [实战 Cookbook](./grok-cookbook.md) — 场景化配方
+- [速查表](./grok-cheatsheet.md) — 命令 / 配置 / 环境变量 / 价格 / 信息源
+- [术语表](./grok-glossary.md) — 概念是什么、为什么
+- [AI 编程工具总览](../index.md)

--- a/docs/zh/products/ai-coding/grok/index.md
+++ b/docs/zh/products/ai-coding/grok/index.md
@@ -7,7 +7,7 @@
 
 ## 产品全景
 
-好几个 xAI 产品都带 "Grok" 或 "Build" 这两个词。它们**不是**同一个产品的四张皮。本目录这套页面讲的是 **Grok Build**（终端编程 Agent）。其余官方形态必须先画进决策树，否则会进错门。
+好几个 xAI 产品都带 "Grok" 或 "Build" 这两个词。它们**不是**同一个产品的四张皮。本目录的**主学习路径**仍是 **Grok Build**（终端编程 Agent）。其余官方形态现在各自有页，避免进错门。
 
 ```
 xAI / Grok 家族
@@ -26,16 +26,19 @@ xAI / Grok 家族
 | 产品 | 是什么 | 入口 | 对位 Claude 家族 |
 |------|--------|------|------------------|
 | **Grok Build** | 对着真实仓库干活的终端编程 Agent | 命令 `grok` | Claude Code CLI |
-| Grok（聊天） | 通用助手 | [grok.com](https://grok.com)、Grok App、X | Claude.ai |
-| Imagine | 生图 / 生视频 / 编辑 | [grok.com/imagine](https://grok.com/imagine)，或 [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine) | Claude Design（创作面，不是编程 Agent） |
+| [Grok（聊天）](./grok-chat.md) | 通用助手 | [grok.com](https://grok.com)、Grok App、X | Claude.ai |
+| [Imagine](./grok-imagine.md) | 生图 / 生视频 / 编辑 | [grok.com/imagine](https://grok.com/imagine)，或 [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine) | Claude Design（创作面，不是编程 Agent） |
+| [Voice](./grok-voice.md) | App 里免提说话 + Voice API | grok.com / App；[Voice API](https://docs.x.ai/developers/model-capabilities/audio/voice) | Claude 语音 / realtime API |
+| [Connectors](./grok-connectors.md) | 对话里连邮箱 / 文件 / 日历 / 自定义 MCP | [grok.com/connectors](https://grok.com/connectors) | Claude Connectors |
 | Build Mode | 聊天里出可运行预览并发布链接 | grok.com / Grok App 的模式切换选 **Build** | 更接近 Claude.ai Artifacts，**不是** Claude Code |
-| Grok Bot | 共享云 VM 上的常驻同事 | [x.ai/bot](https://x.ai/bot) 桌面 + iOS | Cowork（任务 Agent，不是仓库 CLI） |
+| [Grok Bot](./grok-bot.md) | 共享云 VM 上的常驻同事 | [x.ai/bot](https://x.ai/bot) 桌面 + iOS | Cowork（任务 Agent，不是仓库 CLI） |
+| [Grok Business](./grok-business.md) | 团队工作区、许可证、组织控制 | [docs.x.ai/grok/user-guide](https://docs.x.ai/grok/user-guide) | Claude Team / Enterprise |
 | xAI API | 模型 / Imagine / Voice 的 HTTP API | [docs.x.ai/developers/quickstart](https://docs.x.ai/developers/quickstart) | Anthropic API |
 
 **容易撞名的几条：**
 
-- **Grok Build ≠ Build Mode**。Grok Build 是终端 Agent（`docs.x.ai/build/*`）。Build Mode 是 grok.com 的聊天模式：在对话里写出可运行预览并发布（[x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode)）。
-- **grok.me** 是 Build Mode 的**发布域名**（官方原文："Publish to a grok.me link or a custom domain you own"）。它不是独立产品，也不是 Grok Build CLI。
+- **Grok Build ≠ Build Mode**。Grok Build 是终端 Agent（`docs.x.ai/build/*`）。Build Mode 是 grok.com 的聊天模式：官方原文 "Tell Grok an idea, and it builds a working version live in your chat"，发布则是 "Publish to a grok.me link or a custom domain you own"（[x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode)、[x.ai/grok/build-mode](https://x.ai/grok/build-mode)）。Early Beta 仅 **SuperGrok Heavy**，Web / iOS / Android。官方密度仍是营销页 + 一篇 news，所以留在这张地图上，不单独开教程页。
+- **grok.me** 是 Build Mode 的**发布域名**。它不是独立产品，也不是 Grok Build CLI。
 - **Grok Bot ≠ Grok Build 的 headless "bots"**。Grok Bot 是桌面 / iOS 产品，自己的文档树在 [docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview)。
 - **没有官方 IDE 插件**。要在编辑器里用 Grok Build，走 ACP（`grok agent stdio`）。[terminal-support](https://docs.x.ai/build/cli/terminal-support) 只记录 VS Code / Cursor / Windsurf / Zed 内置终端的按键差异。
 
@@ -51,17 +54,21 @@ xAI / Grok 家族
 │       ├── 在 CI / 脚本？→ headless（`grok -p`）
 │       └── 在编辑器里？→ ACP（`grok agent stdio`）——没有官方 VS Code 插件
 ├── 聊天 / 写作 / 调研 / 语音 / 上传文件
-│   └── → grok.com 或 Grok iOS / Android App
+│   └── → [Grok 聊天](./grok-chat.md)：grok.com 或 Grok iOS / Android App
+│       ├── 免提说话 → [Voice](./grok-voice.md)（产品；Voice API 是另一套）
+│       └── 对话里连邮箱 / Drive / 日历 → [Connectors](./grok-connectors.md)
 ├── 生图 / 生视频 / 改图改视频
-│   └── → Imagine
+│   └── → [Imagine](./grok-imagine.md)
 │       ├── 在产品里？→ grok.com/imagine（grok.com 对话里也能用）
 │       └── 在自己的程序里？→ Imagine API
 ├── 在聊天里做网站 / 应用 / 游戏并分享链接
 │   └── → Build Mode（grok.com 模式切换 → Build）
 │       └── SuperGrok Heavy Early Beta；发布到 grok.me 或自定义域名
 ├── 把活交给同事，合上笔记本也继续跑
-│   └── → Grok Bot（桌面 + iOS）
+│   └── → [Grok Bot](./grok-bot.md)（桌面 + iOS）
 │       └── SuperGrok Heavy / Cursor Ultra / Cursor Teams Premium
+├── 团队工作区 / 许可证 / 组织分享
+│   └── → [Grok Business](./grok-business.md)
 └── 在自己的软件里调模型
     └── → xAI API
 ```
@@ -153,5 +160,10 @@ xAI / Grok 家族
 - [实战 Cookbook](./grok-cookbook.md) — 场景化配方
 - [速查表](./grok-cheatsheet.md) — 命令 / 配置 / 环境变量 / 价格 / 信息源
 - [术语表](./grok-glossary.md) — 概念是什么、为什么
+- [Grok 聊天](./grok-chat.md) — grok.com / iOS / Android
+- [Imagine](./grok-imagine.md) — 生图与视频
+- [Voice](./grok-voice.md) — 产品 Voice + Voice API
+- [Connectors](./grok-connectors.md) — 对话里连邮箱 / 文件 / 日历
 - [Grok Bot](./grok-bot.md) — 云电脑同事（不是 CLI）
+- [Grok Business](./grok-business.md) — 团队工作区
 - [AI 编程工具总览](../index.md)

--- a/docs/zh/products/ai-coding/grok/index.md
+++ b/docs/zh/products/ai-coding/grok/index.md
@@ -5,19 +5,70 @@
 > 官方定义（[docs.x.ai/build/overview](https://docs.x.ai/build/overview)）：
 > "**Grok Build** is a powerful and extensible coding agent. Use it via an interactive TUI, headlessly in scripts or bots, or through the Agent Client Protocol (ACP) in other apps."
 
-## 一分钟认清产品形态
+## 产品全景
 
-很多人会把 Grok 的几个产品混在一起，先分清：
+好几个 xAI 产品都带 "Grok" 或 "Build" 这两个词。它们**不是**同一个产品的四张皮。本目录这套页面讲的是 **Grok Build**（终端编程 Agent）。其余官方形态必须先画进决策树，否则会进错门。
 
-| 产品 | 是什么 | 入口 |
-|------|--------|------|
-| **Grok Build** | 终端编程 Agent（本文档的主题） | 命令 `grok` |
-| Grok（聊天） | 通用对话产品 | [grok.com](https://grok.com)、X 内置 |
-| xAI API | 模型 API（`grok-4.6` 等） | [api.x.ai](https://docs.x.ai/developers/quickstart) |
+```
+xAI / Grok 家族
+├── Grok（聊天）— grok.com、iOS、Android、X
+│   ├── 对话 / 搜索 / 语音 / 上传文件
+│   ├── Imagine — 生图与视频（也在 grok.com/imagine）
+│   └── Build Mode — 对话里做网站 / 应用 / 游戏，发布到 grok.me
+├── Grok Build — 终端编程 Agent（命令 `grok`）
+│   ├── 交互式 TUI
+│   ├── Headless（`grok -p`）
+│   └── ACP（`grok agent stdio`）
+├── Grok Bot — 跑在持久云电脑上的具名同事
+└── xAI API — 模型 HTTP API，含 Imagine API
+```
 
-三者共用同一套账号与模型，但**只有 Grok Build 是编程工具**。它没有官方 IDE 插件——需要在编辑器里用时走 ACP 协议（见下文）。
+| 产品 | 是什么 | 入口 | 对位 Claude 家族 |
+|------|--------|------|------------------|
+| **Grok Build** | 对着真实仓库干活的终端编程 Agent | 命令 `grok` | Claude Code CLI |
+| Grok（聊天） | 通用助手 | [grok.com](https://grok.com)、Grok App、X | Claude.ai |
+| Imagine | 生图 / 生视频 / 编辑 | [grok.com/imagine](https://grok.com/imagine)，或 [Imagine API](https://docs.x.ai/developers/model-capabilities/imagine) | Claude Design（创作面，不是编程 Agent） |
+| Build Mode | 聊天里出可运行预览并发布链接 | grok.com / Grok App 的模式切换选 **Build** | 更接近 Claude.ai Artifacts，**不是** Claude Code |
+| Grok Bot | 共享云 VM 上的常驻同事 | [x.ai/bot](https://x.ai/bot) 桌面 + iOS | Cowork（任务 Agent，不是仓库 CLI） |
+| xAI API | 模型 / Imagine / Voice 的 HTTP API | [docs.x.ai/developers/quickstart](https://docs.x.ai/developers/quickstart) | Anthropic API |
 
-## 三种使用面
+**容易撞名的几条：**
+
+- **Grok Build ≠ Build Mode**。Grok Build 是终端 Agent（`docs.x.ai/build/*`）。Build Mode 是 grok.com 的聊天模式：在对话里写出可运行预览并发布（[x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode)）。
+- **grok.me** 是 Build Mode 的**发布域名**（官方原文："Publish to a grok.me link or a custom domain you own"）。它不是独立产品，也不是 Grok Build CLI。
+- **Grok Bot ≠ Grok Build 的 headless "bots"**。Grok Bot 是桌面 / iOS 产品，自己的文档树在 [docs.x.ai/grok-bot](https://docs.x.ai/grok-bot/overview)。
+- **没有官方 IDE 插件**。要在编辑器里用 Grok Build，走 ACP（`grok agent stdio`）。[terminal-support](https://docs.x.ai/build/cli/terminal-support) 只记录 VS Code / Cursor / Windsurf / Zed 内置终端的按键差异。
+
+账号也**不是**同一口池子。Grok Build 接受 SuperGrok / X Premium Plus 登录或 `XAI_API_KEY`。Grok Bot 用 **Cursor** 账号认证，资格是 SuperGrok Heavy、Cursor Ultra、Cursor Teams Premium（[get-started](https://docs.x.ai/grok-bot/get-started)）。Build Mode 的 Early Beta 仅 SuperGrok Heavy。
+
+### 快速决策：我该用哪个？
+
+```
+我要做什么？
+├── 在真实仓库里写代码 / 调试 / 重构 / 提 PR
+│   └── → Grok Build（`grok`）
+│       ├── 在终端？→ TUI（`grok`）
+│       ├── 在 CI / 脚本？→ headless（`grok -p`）
+│       └── 在编辑器里？→ ACP（`grok agent stdio`）——没有官方 VS Code 插件
+├── 聊天 / 写作 / 调研 / 语音 / 上传文件
+│   └── → grok.com 或 Grok iOS / Android App
+├── 生图 / 生视频 / 改图改视频
+│   └── → Imagine
+│       ├── 在产品里？→ grok.com/imagine（grok.com 对话里也能用）
+│       └── 在自己的程序里？→ Imagine API
+├── 在聊天里做网站 / 应用 / 游戏并分享链接
+│   └── → Build Mode（grok.com 模式切换 → Build）
+│       └── SuperGrok Heavy Early Beta；发布到 grok.me 或自定义域名
+├── 把活交给同事，合上笔记本也继续跑
+│   └── → Grok Bot（桌面 + iOS）
+│       └── SuperGrok Heavy / Cursor Ultra / Cursor Teams Premium
+└── 在自己的软件里调模型
+    └── → xAI API
+```
+
+来源：[docs.x.ai/grok/overview](https://docs.x.ai/grok/overview)、[docs.x.ai/build/overview](https://docs.x.ai/build/overview)、[docs.x.ai/grok-bot/overview](https://docs.x.ai/grok-bot/overview)、[x.ai/grok](https://x.ai/grok)、[x.ai/grok/build-mode](https://x.ai/grok/build-mode)、[x.ai/news/grok-build-mode](https://x.ai/news/grok-build-mode)、[docs.x.ai/developers/model-capabilities/imagine](https://docs.x.ai/developers/model-capabilities/imagine)、[x.ai/bot](https://x.ai/bot)。
+
+## Grok Build 的三种使用面
 
 | 使用面 | 入口 | 用在哪 |
 |--------|------|--------|
@@ -27,7 +78,7 @@
 
 来源：[docs.x.ai/build/overview](https://docs.x.ai/build/overview)、[docs.x.ai/build/cli/reference](https://docs.x.ai/build/cli/reference)
 
-## 快速决策
+## 什么时候值得试 Grok Build
 
 **什么情况下值得试？**
 
@@ -38,7 +89,9 @@
 **什么情况下先别急？**
 
 - 你要的是 IDE 内联补全 —— Grok Build 是终端 Agent，没有补全能力，也没有官方 IDE 插件。
-- 你需要长期稳定的产品面 —— 它仍处于 beta。npm `@xai-official/grok` 的 `latest` 在 2026-08-12 还是 1.0.3，2026-08-16 已是 1.0.5；命令与配置键仍在变动。绑定任何东西之前先跑 `grok version` 并对 [changelog](https://x.ai/build/changelog)。
+- 你要的是合上笔记本还继续干活的同事 —— 那是 [Grok Bot](./grok-bot.md)，不是 Grok Build。
+- 你要的是不用安装、聊天里出预览并发布 `*.grok.me` 链接 —— 那是 grok.com 上的 Build Mode，SuperGrok Heavy Early Beta。
+- 你需要长期稳定的产品面 —— Grok Build 仍处于 beta。npm `@xai-official/grok` 的 `latest` 在 2026-08-12 还是 1.0.3，2026-08-16 已是 1.0.5；命令与配置键仍在变动。绑定任何东西之前先跑 `grok version` 并对 [changelog](https://x.ai/build/changelog)。
 
 ## 学习路径
 
@@ -100,4 +153,5 @@
 - [实战 Cookbook](./grok-cookbook.md) — 场景化配方
 - [速查表](./grok-cheatsheet.md) — 命令 / 配置 / 环境变量 / 价格 / 信息源
 - [术语表](./grok-glossary.md) — 概念是什么、为什么
+- [Grok Bot](./grok-bot.md) — 云电脑同事（不是 CLI）
 - [AI 编程工具总览](../index.md)

--- a/docs/zh/products/ai-coding/index.md
+++ b/docs/zh/products/ai-coding/index.md
@@ -21,6 +21,7 @@
 - [Claude CLI](./claude/index.md) - 命令行 AI 编程助手（Claude 系列）
 - **Codex CLI** ([./codex/index.md](./codex/index.md)) - OpenAI 官方命令行代理，**ChatGPT Plus 会员专属执行工具**
 - [Gemini CLI](./gemini-cli.md) - Google 的 AI 编程助手
+- [Grok](./grok/index.md) - xAI 第一方终端编程 Agent（Grok Build）
 - [其他工具](./othertools.md) - 探索更多 AI 编程工具
 
 ## 快速开始
@@ -211,6 +212,23 @@
 | [Async Tasks](https://openai.com/index/introducing-codex) | 后台任务执行 |
 | [Task Tracking](https://openai.com/index/introducing-codex) | 进度监控 |
 | [Internet Access](https://openai.com/index/introducing-codex) | 实时网络搜索 |
+
+### Grok Build
+
+| Feature | 描述 |
+|:--------|:------------|
+| [AGENTS.md](https://docs.x.ai/build/features/project-rules) | 项目规则，同时兼容 `CLAUDE.md` / `.cursor/rules` |
+| [Plan Mode](https://docs.x.ai/build/features/plan-mode) | 先出计划、审批后动手 |
+| [Permissions](https://docs.x.ai/build/features/permissions) | `allow` / `ask` / `deny` 规则，deny 优先 |
+| [Sandbox](https://docs.x.ai/build/features/sandbox) | Landlock / Seatbelt 系统级隔离，5 档 profile |
+| [Skills & Plugins](https://docs.x.ai/build/features/skills-plugins-marketplaces) | 技能、插件、官方 marketplace |
+| [Hooks](https://docs.x.ai/build/features/hooks) | 生命周期事件，`PreToolUse` 可拦截 |
+| [MCP](https://docs.x.ai/build/features/mcp-servers) | 工具名空间 `<server>__<tool>` |
+| [Subagents](https://docs.x.ai/build/features/subagents) | 内置 `general-purpose` / `explore` / `plan` |
+| [Worktrees](https://docs.x.ai/build/features/worktrees) | Git worktree 隔离并行开发 |
+| [Background Tasks](https://docs.x.ai/build/features/background-tasks) | 后台任务与 `/loop` 定时循环 |
+| [Dashboard](https://docs.x.ai/build/features/dashboard) | 多会话状态总览 |
+| [Headless / ACP](https://docs.x.ai/build/cli/headless-scripting) | 脚本与编辑器嵌入两种非交互面 |
 
 ## 下一步
 


### PR DESCRIPTION
Creates the Grok (xAI) documentation set from zero, in both EN and ZH, following the Diataxis four-quadrant split.

## Grok product-form research conclusion

Recorded in `.claude/skills/doc-research/references/grok.md` **before** any tutorial prose was written, with a source for every claim:

- **Official name is Grok Build** — not "Grok Code", not "Grok CLI". Executable `grok`; the build artifact is `xai-grok-pager`. Written in Rust, source at [xai-org/grok-build](https://github.com/xai-org/grok-build) (Apache-2.0). External PRs are explicitly not accepted; feedback goes through `/feedback`.
- **Form is a terminal coding agent with three surfaces**, not three products: interactive TUI (`grok`), headless (`grok -p`), and ACP (`grok agent stdio`). There is no official IDE plugin — editor integration means an editor speaking ACP to the same binary.
- **Two doc trees, different subjects**: `docs.x.ai/build/*` is the CLI, `docs.x.ai/developers/*` is the model API. `x.ai/build/changelog` moves faster than either.
- **Two coding models**: `grok-4.6` (500k ctx, the current default driver) and `grok-build-0.1` (256k ctx, trained for agentic coding).
- **Beta, and fast**: launched 2026-05-25; npm `@xai-official/grok` has shipped 552 versions since 2025-10-22, recently roughly one every one to three days.

## Suitability judgment: clearly suitable

Grok Build fits this site's "AI coding tools for frontend engineers" positioning:

- Installs via npm (`@xai-official/grok`, `bin.grok`, `engines.node >= 20`) — a channel frontend engineers already have.
- xAI states it is "fully compatible with Claude Code with zero configuration needed": it reads `CLAUDE.md` and `.claude/settings.json`, accepts Claude Code flag aliases, and `grok import` pulls in Claude Code sessions. For readers who already use Claude Code, the switching cost for a side-by-side comparison is close to zero — which is directly useful rather than merely novel.
- Terminal-agent capabilities (permissions, sandbox, hooks, MCP, subagents, worktrees, background tasks) map onto the same concepts the Claude and Codex pages already teach, so it slots into the existing structure.

No padding was added to reach a file count.

## File structure and why

Five files per language, decided by the Diataxis quadrant boundaries after the research — deliberately **not** assumed isomorphic with the Claude or Codex trees:

| File | Quadrant | Why it exists separately |
|------|----------|--------------------------|
| `index.md` | — | Learning map. Needed because five products share the "Grok" name; readers have to disambiguate before anything else is useful. |
| `grok-cli.md` | Tutorial | One linear path from install to daily use. 13 numbered steps. |
| `grok-cookbook.md` | How-to | 10 task-scoped recipes (Claude Code migration, MCP, hooks, permission hardening, CI, worktrees, subagents, background tasks, memory, plugins). Recipes are entered by goal, not read in order — hence separate from the tutorial. |
| `grok-cheatsheet.md` | Reference | Lookup only: subcommands, flags, slash commands, key bindings, config keys, env vars, hook events, pricing, sources. Kept apart because reference tables have no narrative and would drown a tutorial. |
| `grok-glossary.md` | Explanation | The "why" that does not belong in any of the above: permissions vs. sandbox as orthogonal axes, why the highest config priority lives in `/etc`, why deeper `AGENTS.md` wins, why plan mode does not gate the shell, why subagents exist (context economy), why xAI courts Claude Code compatibility. |

Files: `docs/products/ai-coding/grok/` (EN) and `docs/zh/products/ai-coding/grok/` (ZH).

## Anti-fabrication

Every command, flag, config key, URL, price, quota, version, and model name in these pages traces to an official source, cited inline. Unverifiable material was escalated rather than guessed. No "should be" / "usually" / "roughly" hedging was used to paper over a gap.

**One TODO, in both languages** (`grok-cli.md`, section 2 "Authenticate"):

- `<!-- TODO: 待核实 -->` on the **free-tier quota numbers and the conversion between SuperGrok / X Premium Plus entitlements and Grok Build usage**. Reason: the sources contradict each other and neither quantifies anything. The [launch announcement](https://x.ai/news/grok-build-cli) says "Available now to all SuperGrok and X Premium Plus subscribers", while [x.ai/build](https://x.ai/build) currently says "Available to try for Free". No official page states a number. `console.x.ai` (where quota would be visible) returns 403 to non-browser clients, so it could not be checked. The pages state the discrepancy openly and tell the reader to trust the quota shown after login.

## Shared-file changes (kept minimal)

Four other agents are editing the same three shared files concurrently, so changes are surgical and additive only — no reordering, reformatting, or touching unrelated entries:

- `docs/.vitepress/config.mjs` — one Grok group added to the EN AI Coding sidebar and one to the ZH sidebar (+18 lines, no deletions).
- `docs/products/ai-coding/index.md` — one bullet.
- `docs/zh/products/ai-coding/index.md` — one bullet plus a `### Grok Build` capability table.

No claude / codex / gemini / cursor / copilot doc files were touched.

## Acceptance criteria

- [x] **Research before writing** — `references/grok.md` contains the "产品形态调研结论" section with a source per claim, committed before the first tutorial file.
- [x] **File names and count driven by research, judged against Diataxis** — five files per language, rationale table above; not copied from the Claude/Codex layout.
- [x] **Full RAPID flow run** — Retrieve (official property map: two doc trees, changelog, GitHub source, npm registry, plugin marketplace), Acquire (`docs.x.ai/llms.txt` full-text mirror plus per-page reads; the mirror was kept outside the repo and is not committed), Pattern (Diataxis boundaries, aligned with the existing Claude pages' structure and depth), Integrate (10 pages plus sidebar and overview wiring), Deepen (the glossary's design rationale and the named misconceptions).
- [x] **Every command / flag / config key / URL / price / quota / version / model name sourced** — cited inline throughout.
- [x] **Unverifiable material marked** — one TODO, described above, with the reason stated in place.
- [x] **No "should be" / "usually" / "roughly"; no invented flags, config keys, or product names** — an earlier draft claim about an official English signature was deleted rather than softened, precisely because it could not be sourced.
- [x] **2025-and-earlier information re-verified** — version cadence, model lineup (`grok-4.6`, not 4.5), and pricing tiers were re-checked against current pages; a stale cache that reported "Grok 4.5" was caught and corrected.
- [x] **Suitability judged, with evidence** — see above; verdict is suitable.
- [x] **EN/ZH parity** — five files each, same structure and depth.
- [x] **`pnpm docs:build` genuinely passes** — clean build; all 10 pages emitted under `dist`.
- [x] **Reachable from both sidebars, no dead links** — build's dead-link check passes. Cross-file anchors were verified against the generated HTML ids, which caught one real bug: VitePress prefixes ids that begin with a digit, so `#8-session-management` had to become `#_8-session-management`. Fixed and rebuilt.
- [x] **Minimal shared-file edits** — additive only, listed above.
- [x] **Branch and commit scope** — `docs/grok-diataxis`, all commits `docs(grok): ...`, staged per file.
- [x] **Pre-push security review** — full branch diff scanned; no tokens, keys, cookies, internal addresses, local absolute paths, `.env` files, or personal contact details. No `node_modules`, `dist`, or `.vitepress/cache` staged. The only `xai-`-shaped matches are the npm package name `@xai-official/grok`; the `XAI_API_KEY="xai-..."` in the tutorial is a documentation placeholder.

Closes #64
