### PR TITLE
docs(lingma): add Lingma handbook (ZH+EN) for #84

### DIFF
--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -12,5 +12,6 @@
 | Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
 | Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
 | Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| Lingma | [`lingma.md`](./lingma.md) | `docs/zh/products/lingma/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/.claude/skills/doc-research/references/lingma.md
+++ b/.claude/skills/doc-research/references/lingma.md
@@ -1,0 +1,115 @@
+# 通义灵码 / Qoder CN 维护参考
+
+> 这是 [`_template.md`](./_template.md) 针对通义灵码（现 Qoder CN 编码子产品）的具体化。读者可见的数据源写在 `docs/zh/products/lingma/lingma-cheatsheet.md` 的「高质量信息源」，本文件不抄一份。
+
+## 基本信息
+
+- 工具名：通义灵码（TONGYI Lingma / Lingma）。**2026-05-20** 起官方系列名改为 **Qoder CN**；编码子产品仍是同一产品。
+- 官方营销站：<https://lingma.aliyun.com/>
+- 新品牌站：<https://qoder.com.cn/>
+- 新文档站（官方标为最新）：<https://docs.qoder.cn/>
+- 阿里云帮助中心（路径仍是 `/zh/lingma/`）：<https://help.aliyun.com/zh/lingma/>
+- 国际站帮助：<https://www.alibabacloud.com/help/en/lingma/>
+- 发版节奏：帮助中心按月有更新日志；IDE / JetBrains 为现行迭代面
+- 当前覆盖版本：2026-08-19 快照（lingma.aliyun.com + help.aliyun.com/zh/lingma + docs.qoder.cn + qoder.com.cn）
+
+## 产品形态调研（先于动笔）
+
+本 issue **只写编码助手**：插件 + 独立 IDE。对位 Copilot / Cursor。
+
+官方现行形态（不要写成「只有插件」）：
+
+| 形态 | 官方怎么叫 | 本站 |
+|------|------------|------|
+| 独立 IDE | 营销站仍写 **Lingma IDE**；帮助中心 / 新站写 **Qoder CN IDE** | 独立 Tutorial |
+| JetBrains 插件 | 营销站搜「通义灵码（TONGYI Lingma）」；帮助中心搜 **Qoder CN** | 并入 Tutorial |
+| Visual Studio Code 插件 | 市场 ID `Alibaba-Cloud.tongyi-lingma`；展示名 **Qoder CN (Formerly Lingma)** | 并入 Tutorial，并写停更冲突 |
+| Visual Studio 插件 | 帮助中心仍列 VS 2022 / 2019 | Tutorial 一行 + 兼容表 |
+
+**VS Code 插件口径打架（写正文必须点明，不要抹平）：**
+
+- [兼容 IDE](https://help.aliyun.com/zh/lingma/compatible-ide-and-system)、[安装指南](https://help.aliyun.com/zh/lingma/installation-guide)：仍给安装步骤，并写「产品功能迭代将主要集中在 Qoder CN IDE 和 Qoder CN JetBrains 插件中，VSCode 插件更新节奏将会放缓」。
+- [计费说明](https://help.aliyun.com/zh/lingma/billing-description)：写「VSC 插件停止演进」。
+- [docs.qoder.cn 什么是 Qoder CN IDE](https://docs.qoder.cn/user-guide/what-is-qoder-cn)：写「Visual Studio Code 插件已停止维护」。
+- 国际站 [update log](https://www.alibabacloud.com/help/en/lingma/product-overview/qoder-cn-update-log)：原文 “VS Code plugin support discontinued … no longer part of the product suite”。
+
+以新文档站 / 更新日志为准标「停更」，安装步骤仍可抄帮助中心，并建议切 Qoder CN IDE。
+
+## 官方一级导航（产品家族）
+
+来源：[什么是 Qoder CN 系列](https://help.aliyun.com/zh/lingma/introduction-of-lingma)、[docs.qoder.cn 系列介绍](https://docs.qoder.cn/product-overview/introduction-of-qodercn)、[qoder.com.cn](https://qoder.com.cn/)。
+
+| 官方一级入口 | 官方 URL | 本站去向 | 不拆页理由（若一行） |
+|--------------|----------|----------|----------------------|
+| Qoder CN / 通义灵码（IDE + JetBrains / VS Code / Visual Studio 插件） | https://lingma.aliyun.com/ · https://qoder.com.cn/ | 独立页 | 本 issue 正文 |
+| Qoder CN CLI | https://qoder.com.cn/cli · https://help.aliyun.com/zh/lingma/what-is-qoder-cli-cn | 地图一行 | 终端形态，另产品；本 issue 不写正文 |
+| QoderWork CN | https://help.aliyun.com/zh/lingma/what-is-qoderwork-cn | 地图一行 | 日常办公桌面助手，非编码主线 |
+| QoderWake CN | https://qoder.com.cn/qoderwake | 地图一行 | 数字员工 |
+| Qoder Cloud Agents | https://qoder.com.cn/cloud-agents | 地图一行 | 云端托管 Agent 平台 |
+| Qoder CN Mobile | https://qoder.com.cn/mobile | 地图一行 | 移动指挥面 |
+| 通义千问 | https://www.qianwen.com/ | 地图一行 | 同厂对话产品，#83 |
+| 阿里云百炼 | https://www.aliyun.com/product/bailian | 地图一行 | 同厂模型平台，#85 |
+| 淘宝 / ECS / 支付等非 AI | — | 非本站 | 不是 AI 产品 |
+
+易撞名：
+
+- **通义灵码 ≠ 通义千问**。前者是编码助手（现 Qoder CN）；后者是通用对话助手。
+- **通义灵码 ≠ 百炼**。百炼是模型 / Agent 开发平台。
+- **Lingma IDE ≠ JetBrains / VS Code 插件**。IDE 开箱即用、无需再装插件；插件装进已有 IDE。
+- **智能会话里的智能体模式 ≠ Qoder CN CLI ≠ Cloud Agents ≠ QoderWake**。前者跑在本机 IDE；CLI / Cloud / Wake 是系列里另几个子产品。
+- **Ask / Edit / Agent 是会话模式，不是三个产品。**
+- 可执行文件 / 市场 ID 仍大量残留 `tongyi-lingma`、`TONGYI Lingma`，营销页也还在用旧名。
+
+## 文档文件结构（Diataxis）
+
+```
+docs/zh/products/lingma/
+├── index.md                 # 学习地图 + 家族图
+├── lingma.md                # Tutorial：装、登录、补全、三种会话
+├── lingma-cookbook.md       # How-to：模式选择、提示、Agent、MCP
+├── lingma-cheatsheet.md     # Reference：安装入口、快捷键、套餐、数据源
+└── lingma-glossary.md       # Explanation：更名、形态、模式、Credits
+
+docs/products/lingma/        # 英文同构
+```
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 + 速查 | 家族图、决策树、学习路径 | 逐步安装、参数清单 |
+| `lingma.md` | Tutorial | 官方安装原文、登录、补全、会话三模式 | 套餐全表、MCP 逐步配置 |
+| `lingma-cookbook.md` | How-to | 场景配方、官方提示建议、MCP、避坑 | 安装、术语定义 |
+| `lingma-cheatsheet.md` | Reference | 兼容表、安装 URL、快捷键、套餐、数据源 | 概念散文、学习路径 |
+| `lingma-glossary.md` | Explanation | 更名、不是什么、模式区别 | 操作步骤、价格表 |
+
+## 监控页面
+
+- 新文档站：https://docs.qoder.cn/
+- 系列介绍：https://help.aliyun.com/zh/lingma/introduction-of-lingma
+- 什么是 Qoder CN：https://help.aliyun.com/zh/lingma/what-is-qoder-cn
+- 安装指南：https://help.aliyun.com/zh/lingma/installation-guide
+- 下载页（旧品牌）：https://lingma.aliyun.com/download
+- 下载页（新品牌）：https://qoder.com.cn/download
+- 计费：https://help.aliyun.com/zh/lingma/billing-description
+- 智能会话：https://help.aliyun.com/zh/lingma/overview-of-chat
+- 智能体：https://help.aliyun.com/zh/lingma/agent
+- MCP：https://help.aliyun.com/zh/lingma/guide-for-using-mcp
+- 兼容 IDE：https://help.aliyun.com/zh/lingma/compatible-ide-and-system
+- VS Marketplace：https://marketplace.visualstudio.com/items?itemName=Alibaba-Cloud.tongyi-lingma
+- 更新日志：https://help.aliyun.com/zh/lingma/qoder-cn-update-log
+
+## Git 提交 scope
+
+```
+docs(lingma): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+- **先写维护参考再动教程。** 更名 + VS Code 停更 + 双下载站，是正文必须面对的事实，不是附录。
+- **安装步骤逐字抄官方**，不要把营销站「通义灵码（TONGYI Lingma）」和帮助中心「Qoder CN」合成一个搜索词。
+- **价格有三套页签**：Qoder CN（全家桶）、Qoder CN（原灵码）、通义灵码（存量）。只抄打开的表，并写清适用范围。
+- **不写淘宝 / ECS / 支付**。Retrieve 时阿里云首页会冒出非 AI 项，地图标「非本站」。
+- **通义千问、百炼只在家族图一行**，本目录不展开。
+- **不写模型内部机制**；需要模型原理时链 Learn LLM。
+- **不改** `products-gallery.js` / `sidebars/ai-coding.mjs`（本轮执行约束）。
+- 国际站英文帮助覆盖不全；英文教程以中文官方 + Marketplace 英文原文 + `alibabacloud.com/help/en/lingma` 能打开的页为准。

--- a/docs/products/lingma/index.md
+++ b/docs/products/lingma/index.md
@@ -1,0 +1,131 @@
+---
+title: Lingma learning map
+description: "TONGYI Lingma is Alibaba Cloud's coding assistant, renamed Qoder CN on 2026-05-20. This directory covers the plugin and standalone IDE only; Qwen, Model Studio, CLI, and office agents stay on one family-map row."
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# Lingma learning map
+
+> **TONGYI Lingma** (Lingma) is Alibaba Cloud's intelligent coding assistant: code generation, ask, multi-file edits, and a coding agent. It maps to Copilot / Cursor, not to a consumer chat app.
+>
+> On **2026-05-20** the official suite name became **Qoder CN**. Help Center: "The Qoder CN series was formerly named 'AI Coding Assistant TONGYI Lingma' (Lingma) and was officially renamed on May 20, 2026. If you see references to TONGYI Lingma elsewhere, they refer to the same product." ([What is Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn), [EN quick start](https://www.alibabacloud.com/help/en/lingma/getting-started/individual-edition-quick-start))
+>
+> This directory documents **only the coding sub-product**: the standalone IDE and the IDE plugins. Other Alibaba AI products get one row on the family table.
+
+## Product family
+
+Primary official entries come from [What is the Qoder CN series](https://help.aliyun.com/zh/lingma/introduction-of-lingma) and [docs.qoder.cn](https://docs.qoder.cn/product-overview/introduction-of-qodercn). The marketing site [lingma.aliyun.com](https://lingma.aliyun.com/) still uses the old brand.
+
+```
+Alibaba Cloud AI (this handbook expands the coding assistant only)
+├── TONGYI Lingma / Qoder CN (coding) — this directory
+│   ├── Qoder CN IDE (marketing pages still say Lingma IDE)
+│   ├── JetBrains plugin (current iteration surface)
+│   ├── Visual Studio Code plugin (officially slowed / discontinued)
+│   └── Visual Studio plugin
+├── Qoder CN CLI — terminal, one map row
+├── QoderWork CN — office desktop agent, one map row
+├── QoderWake CN — digital employee, one map row
+├── Qoder Cloud Agents — hosted agents, one map row
+├── Qoder CN Mobile — mobile, one map row
+├── Tongyi Qianwen / Qwen — consumer chat, one map row (#83)
+└── Alibaba Cloud Model Studio (Bailian) — model platform, one map row (#85)
+```
+
+| Official first-level entry | Official URL | This site |
+|----------------------------|--------------|-----------|
+| **TONGYI Lingma / Qoder CN** (IDE + plugins) | [lingma.aliyun.com](https://lingma.aliyun.com/) · [qoder.com.cn](https://qoder.com.cn/) | **Standalone pages** (this directory) |
+| Qoder CN CLI | [qoder.com.cn/cli](https://qoder.com.cn/cli) | One map row. Terminal product, not the plugin |
+| QoderWork CN | [What is QoderWork CN](https://help.aliyun.com/zh/lingma/what-is-qoderwork-cn) | One map row. Office assistant, not a coding IDE |
+| QoderWake CN | [qoder.com.cn/qoderwake](https://qoder.com.cn/qoderwake) | One map row. Digital employee |
+| Qoder Cloud Agents | [qoder.com.cn/cloud-agents](https://qoder.com.cn/cloud-agents) | One map row. Hosted agent platform |
+| Qoder CN Mobile | [qoder.com.cn/mobile](https://qoder.com.cn/mobile) | One map row. Mobile control surface |
+| **Tongyi Qianwen / Qwen** | [qianwen.com](https://www.qianwen.com/) | One map row. Consumer chat; issue #83 |
+| **Model Studio (Bailian)** | [Product page](https://www.aliyun.com/product/bailian) | One map row. Model / agent platform; issue #85 |
+| Taobao / ECS / payments | — | **Out of scope.** Non-AI Alibaba products |
+
+**Do not collapse these names:**
+
+| Easy to mix | Difference |
+|-------------|------------|
+| Lingma vs **Qwen** | Coding assistant vs consumer chat |
+| Lingma vs **Model Studio** | IDE / plugin vs model platform |
+| **Lingma IDE / Qoder CN IDE** vs plugin | Standalone editor vs extension in your existing IDE |
+| Chat **Agent mode** vs **Qoder CN CLI** vs **Cloud Agents** | Local IDE agent vs terminal product vs hosted platform |
+| Marketplace search **TONGYI Lingma** vs Help Center **Qoder CN** | Old and new display names for the same plugin |
+
+### Decision tree
+
+```
+What are you doing?
+├── Already in a JetBrains IDE
+│   └── → JetBrains plugin (current official iteration surface)
+├── Want an AI-native IDE, no extra plugin
+│   └── → Qoder CN IDE (marketing: Lingma IDE)
+├── Still in VS Code
+│   └── → Plugin is still installable; official docs say updates slowed / discontinued
+│       └── If it breaks, official advice is to switch to Qoder CN IDE
+├── In Visual Studio
+│   └── → Visual Studio plugin (chat currently Ask-only)
+├── Terminal only, no IDE
+│   └── → Qoder CN CLI (not covered here)
+├── Docs / files / office automation
+│   └── → QoderWork CN (not covered here)
+└── Chat with a model, or call an API
+    └── → Qwen / Model Studio (not covered here)
+```
+
+## Which page to read
+
+| Page | Type | When |
+|------|------|------|
+| [Tutorial](./lingma) | Tutorial | First run: install → sign in → complete → three chat modes |
+| [Cookbook](./lingma-cookbook) | How-to | Mode choice, prompts, agent, MCP |
+| [Cheatsheet](./lingma-cheatsheet) | Reference | Install URLs, compatibility, shortcuts, plans, sources |
+| [Glossary](./lingma-glossary) | Explanation | Rename, surfaces, modes, "not this" |
+
+## Learning path
+
+| Stage | Goal | Link |
+|-------|------|------|
+| 1. Name the product | Lingma = today's Qoder CN coding sub-product | Family table; [glossary](./lingma-glossary) |
+| 2. Install and sign in | IDE or plugin; Alibaba Cloud account | [Tutorial · install](./lingma#step-1-install) |
+| 3. Completion + chat | Inline complete; Ask / Edit / Agent | [Tutorial · steps 3–4](./lingma#step-3-inline-completion) |
+| 4. Let it work | Agent, terminal confirm, MCP | [Cookbook](./lingma-cookbook) |
+| 5. Look up | Shortcuts, plans, official pages | [Cheatsheet](./lingma-cheatsheet) |
+
+## Feature snapshot
+
+From [What is Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn) and [Chat overview](https://help.aliyun.com/zh/lingma/overview-of-chat). Marketplace English names: Code Completion, Ask, Multi-file Edits, Code Agent.
+
+| Capability | One line | Docs |
+|------------|----------|------|
+| Inline completion | Line / function suggestions from current + cross-file context | [Tutorial](./lingma) |
+| Next Edit Suggestion (NES) | Predict the next edit; Tab to accept | [Cookbook](./lingma-cookbook) |
+| Ask | Answers only; does not edit the repo | [Glossary](./lingma-glossary) |
+| Edit | Multi-file edits in the range you give; **not on Lingma IDE / JetBrains** | [Official Edit](https://help.aliyun.com/zh/lingma/edit) |
+| Agent | Plans, edits, terminal, optional MCP | [Cookbook](./lingma-cookbook) |
+| Project awareness | Infers framework, stack, files, errors from the task | [lingma.aliyun.com](https://lingma.aliyun.com/) |
+| Memory | Builds personal / project / issue memory during chat | [Official memory](https://help.aliyun.com/zh/lingma/memory) |
+| MCP | Agent can call configured MCP servers | [Cookbook](./lingma-cookbook) |
+| Model picker / Experts / Quest / RepoWiki | IDE-side upgrades, billed in Credits | [Glossary](./lingma-glossary) |
+
+## Freshness
+
+- **Brand:** suite name is Qoder CN from 2026-05-20. Older "TONGYI Lingma" pages still mean this product.
+- **VS Code plugin:** Help Center still documents install and says updates will slow; billing says evolution stopped; docs.qoder.cn says unmaintained; EN update log says discontinued. Do not treat it as the current primary surface.
+- **Edit mode:** official text excludes Lingma IDE and the JetBrains plugin. Visual Studio chat is Ask-only for now.
+- **Plans:** Credits started 2026-05-20. Individual Pro free promo ended. Copy numbers only from [Billing](https://help.aliyun.com/zh/lingma/billing-description).
+- **Docs host:** Help Center points newer content at [docs.qoder.cn](https://docs.qoder.cn/).
+
+## Links
+
+- [Lingma marketing site](https://lingma.aliyun.com/)
+- [Qoder CN](https://qoder.com.cn/)
+- [docs.qoder.cn](https://docs.qoder.cn/)
+- [Help Center](https://help.aliyun.com/zh/lingma/)
+- [EN Help Center](https://www.alibabacloud.com/help/en/lingma/)
+- [Cheatsheet · sources](./lingma-cheatsheet#high-quality-sources)

--- a/docs/products/lingma/lingma-cheatsheet.md
+++ b/docs/products/lingma/lingma-cheatsheet.md
@@ -1,0 +1,141 @@
+---
+title: Lingma cheatsheet
+description: "TONGYI Lingma / Qoder CN install URLs, compatibility, shortcuts, chat modes, plans, and official sources. Copied from pages that open."
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# Lingma cheatsheet
+
+> **Reference.** Do not learn from this page. Concepts: [glossary](./lingma-glossary). First run: [tutorial](./lingma).
+>
+> Last verified: 2026-08-19. When Help Center and [docs.qoder.cn](https://docs.qoder.cn/) disagree, this table records both.
+
+## Term index
+
+| Term | One line |
+|------|----------|
+| [TONGYI Lingma / Qoder CN](./lingma-glossary#tongyi-lingma--qoder-cn) | Alibaba Cloud coding assistant; renamed 2026-05-20 |
+| [Qoder CN IDE](./lingma-glossary#qoder-cn-ide--lingma-ide) | Standalone IDE; marketing still says Lingma IDE |
+| [IDE plugins](./lingma-glossary#ide-plugins) | JetBrains / VS Code / Visual Studio |
+| [Ask / Edit / Agent](./lingma-glossary#ask--edit--agent) | Chat modes, not products |
+| [NES](./lingma-glossary#nes-next-edit-suggestion) | Next-edit prediction |
+| [Credits](./lingma-glossary#credits) | Usage unit from 2026-05-20 |
+| [Qwen / Model Studio](./lingma-glossary#not-this) | Sibling products, not this handbook |
+
+## Install entry points
+
+| Surface | Official entry | Official note |
+|---------|----------------|---------------|
+| Qoder CN IDE | [qoder.com.cn/download](https://qoder.com.cn/download) | URL named by Help Center |
+| Lingma IDE (legacy brand page) | [lingma.aliyun.com/download](https://lingma.aliyun.com/download) | Marketing still uses this name |
+| JetBrains marketplace | Search **TONGYI Lingma** or **Qoder CN** | Both strings are official |
+| JetBrains offline zip | [tongyi-jetbrains-latest.zip](https://tongyi-code.oss-cn-hangzhou.aliyuncs.com/jetbrain/tongyi-jetbrains-latest.zip) | Help Center |
+| JetBrains offline zip (new brand) | [qodercn-jetbrains-latest.zip](https://qodercn-jb.oss-cn-hangzhou.aliyuncs.com/qodercn-jetbrains-latest.zip) | qoder.com.cn |
+| VS Code marketplace | `vscode:extension/Alibaba-Cloud.tongyi-lingma` | Help Center "Install now" |
+| VS Code VSIX | [tongyi-lingma-latest.vsix](https://tongyi-code.oss-cn-hangzhou.aliyuncs.com/vscode/tongyi-lingma-latest.vsix) | Help Center |
+| Install guide | [ZH](https://help.aliyun.com/zh/lingma/installation-guide) | IDE + JetBrains + VS Code |
+| Sign-in guide | [ZH](https://help.aliyun.com/zh/lingma/installation-and-login-guide/) · [EN](https://www.alibabacloud.com/help/en/lingma/installation-and-login-guide/) | Individual / Business / Dedicated |
+
+Step text: [Tutorial · Step 1](./lingma#step-1-install).
+
+## Compatible IDEs and OS
+
+Sources: [Compatible IDEs](https://help.aliyun.com/zh/lingma/compatible-ide-and-system), [What is Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn), [EN compatible IDEs](https://www.alibabacloud.com/help/en/lingma/qoder-cn/user-guide/compatible-ide-and-system).
+
+| Client | Floor |
+|--------|-------|
+| Qoder CN IDE | Windows 10/11 (x64; product page also lists arm64), macOS 11.0+; install guide also lists Linux x64 `.deb`/`.rpm` |
+| JetBrains IDEs | 2020.3+ IntelliJ IDEA, PyCharm, GoLand, WebStorm, Android Studio, HUAWEI DevEco Studio, …; Windows 7+ / macOS / Linux |
+| Visual Studio Code | 1.68.0+; Windows 7+ / macOS / Linux |
+| Visual Studio | 2022 17.3.0+ or 2019 16.3.0+; Windows 10+ |
+| Other | Remote SSH, WSL; VS Code WebIDE / Open VSX |
+
+Official addendum: iteration focuses on **Qoder CN IDE + JetBrains**. VS Code updates slowed; newer official pages say unmaintained / discontinued.
+
+Languages named by Help Center: Java, Python, Go, C#, C/C++, JavaScript, TypeScript, PHP, Ruby, Rust, Scala, Kotlin. The marketing site also says "200 languages" — this table only lists languages the Help Center names.
+
+## Shortcuts
+
+Sources: [Chat overview](https://help.aliyun.com/zh/lingma/overview-of-chat), [NES](https://help.aliyun.com/zh/lingma/next-edit-suggestion), [Plugin configuration](https://help.aliyun.com/zh/lingma/plug-in-configuration-guide). Keys not on those pages are omitted.
+
+| Action | macOS | Windows |
+|--------|-------|---------|
+| Toggle chat (JetBrains, VS Code) | `⌘ ⇧ L` | `Ctrl Shift L` |
+| Toggle chat (Lingma IDE) | `⌘ L` | `Ctrl Shift L` |
+| Accept inline suggestion | `Tab` | `Tab` |
+| Accept NES | `Tab` | `Tab` |
+| Reject NES | `Esc` | `Esc` |
+| Open personal settings (enable NES) | `⌘ ⇧ ,` | `Ctrl Shift ,` |
+
+VS Code can start a new chat with `/newChat`. Agent planning: `/plan`.
+
+## Chat modes
+
+| | Ask | Edit | Agent |
+|---|-----|------|-------|
+| Edits files | No | Yes (your range) | Yes (it chooses) |
+| Runs terminal | No | No | Yes (confirm by default) |
+| VS Code | Yes | Yes | Yes |
+| Lingma IDE / JetBrains | Yes | **No** | Yes |
+| Visual Studio | Yes | Not documented | Not documented |
+
+## Plans (copied from the open official table)
+
+Source: [Billing](https://help.aliyun.com/zh/lingma/billing-description), "Qoder CN (full suite)" tab opened 2026-08-19. **Prices change. Re-open the official page before you buy.**
+
+Official premises:
+
+- New price + Credits from 2026-05-20 23:00:00 (Beijing time).
+- Individual Pro free promo ended 2026-05-20 18:00:00.
+- From 2026-06-20, full-suite individual Credits share across Desktop, JetBrains, QoderWork, CLI, Wake, Mobile.
+- That page states VS Code plugin evolution has stopped.
+
+| Plan | Official list price | Official Credits |
+|------|---------------------|------------------|
+| Individual Trial (Free) | Free | Limited trial; 2-week trial and 300 Credits |
+| Individual Pro | CNY 59 / month | 2,000 Credits / month |
+| Individual Pro+ | CNY 169 / month | 6,000 Credits / month |
+| Teams | CNY 99 / seat / month | 3,000 Credits / seat / month |
+| Enterprise | CNY 149 / seat / month | 3,000 Credits / seat / month, shareable; 10 seats min |
+| Enterprise VPC | CNY 199 / seat / month | 3,000 Credits / seat / month, shareable; 50 seats min |
+
+The "Qoder CN (formerly Lingma)" tab is the **single-product** enterprise subscription for IDE / JetBrains / VS Code: Enterprise Standard CNY 99 / seat / month, Enterprise Dedicated CNY 199 / seat / month. Pre-2026-05-20 contracts use a third tab; this table does not copy legacy prices.
+
+Add-on pack (formerly Lingma, individual): CNY 40 / 1,000 Credits, 1 month. Enterprise: CNY 80 / 2,000 Credits, 3 months. Unused Credits expire.
+
+## High-quality sources
+
+Last verified: 2026-08-19. Ranked by authority. Reviews are clues, not facts.
+
+### Official
+
+| Source | Use |
+|--------|-----|
+| [lingma.aliyun.com](https://lingma.aliyun.com/) | Legacy marketing home; starting URL for issue #84 |
+| [lingma.aliyun.com/download](https://lingma.aliyun.com/download) | Lingma IDE + JetBrains install wording |
+| [qoder.com.cn](https://qoder.com.cn/) | New brand site |
+| [qoder.com.cn/download](https://qoder.com.cn/download) | IDE download named by Help Center |
+| [docs.qoder.cn](https://docs.qoder.cn/) | Docs host marked current |
+| [What is the Qoder CN series](https://help.aliyun.com/zh/lingma/introduction-of-lingma) | Family map |
+| [What is Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn) | Coding sub-product |
+| [Installation guide](https://help.aliyun.com/zh/lingma/installation-guide) | IDE / JetBrains / VS Code |
+| [Setup and install](https://help.aliyun.com/zh/lingma/installation-and-login-guide/) | Sign-in split |
+| [Individual quick start](https://help.aliyun.com/zh/lingma/individual-edition-quick-start) | Individual account |
+| [Compatible IDEs](https://help.aliyun.com/zh/lingma/compatible-ide-and-system) | Version floors |
+| [Chat overview](https://help.aliyun.com/zh/lingma/overview-of-chat) | Three modes + shortcuts |
+| [Agent](https://help.aliyun.com/zh/lingma/agent) | `/plan`, terminal confirm, Auto-Run |
+| [MCP](https://help.aliyun.com/zh/lingma/guide-for-using-mcp) | MCP setup |
+| [Billing](https://help.aliyun.com/zh/lingma/billing-description) | Prices and Credits |
+| [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=Alibaba-Cloud.tongyi-lingma) | Extension ID + English feature names |
+| [EN Help Center](https://www.alibabacloud.com/help/en/lingma/) | English counterpart |
+
+### Same vendor, not this handbook
+
+| Source | Use |
+|--------|-----|
+| [qianwen.com](https://www.qianwen.com/) | Qwen chat |
+| [Model Studio](https://www.aliyun.com/product/bailian) | Model platform |
+| [Qoder CN CLI](https://qoder.com.cn/cli) | Terminal product |

--- a/docs/products/lingma/lingma-cookbook.md
+++ b/docs/products/lingma/lingma-cookbook.md
@@ -1,0 +1,111 @@
+---
+title: Lingma cookbook
+description: "After Lingma / Qoder CN is installed: pick a chat mode, write a structured task, let Agent run the terminal, and attach MCP."
+domain: product
+tags:
+  - coding-agent
+role: cookbook
+---
+
+# Lingma cookbook
+
+For readers who can already sign in and accept a completion. Install is in the [tutorial](./lingma). Keys are in the [cheatsheet](./lingma-cheatsheet).
+
+## Pick the chat mode
+
+| Job | Mode | Official reason |
+|-----|------|-----------------|
+| Explain this React component | **Ask** | "Does not edit project files" |
+| Change a named set of files and review the diff | **Edit** | Precise, faster than Agent |
+| Add a feature: edit + install + test | **Agent** | Can plan, use the terminal, call MCP |
+| Multi-file edits in Lingma IDE / JetBrains | **Agent** (there is no Edit) | Official: those clients do not support Edit |
+| Visual Studio | **Ask** | Official: Ask-only for now |
+
+If you can spot a wrong edit at a glance, use Agent. Otherwise start in Ask.
+
+Sources: [Chat overview](https://help.aliyun.com/zh/lingma/overview-of-chat), [Edit](https://help.aliyun.com/zh/lingma/edit), [Agent](https://help.aliyun.com/zh/lingma/agent).
+
+## Write the task the way the docs ask
+
+Official text ([Chat overview](https://help.aliyun.com/zh/lingma/overview-of-chat)):
+
+> 结构化地描述需求：首先需要澄清我们需要通义灵码帮我们做什么，建议包含一个明确的目标，并通过步骤式的结构化描述，详细地描述您期望完成的编码任务和要求。
+>
+> 给出相关的上下文：可以选择代码文件、图片、codebase、codeChanges 等上下文。
+>
+> 明确生成要求：告诉通义灵码您期望它遵循的要求，比如语言、规范、格式、变更目标等，如“生成变更时，同时为每个方法生成英文注释”。
+>
+> 多多互动，逐步迭代。
+
+Template (structure from those four bullets):
+
+```text
+Goal: add lastActiveAt sorting to src/components/UserTable.tsx.
+
+Steps:
+1. Change the existing component only
+2. Default descending; click the header to toggle
+3. Add TypeScript types; no any
+
+Requirements:
+- Add English comments for every method you change
+- Do not touch the API layer
+```
+
+Then attach files / images / codebase. Lingma IDE context **does not support the knowledge base** yet (same official page).
+
+Agent mode can expand a draft prompt via the optimize-input control ([Agent](https://help.aliyun.com/zh/lingma/agent)). Read the expanded prompt before you send it.
+
+## Run an Agent task that has side effects
+
+1. Switch to **Agent**.
+2. State the goal and the hard boundary.
+3. For a complex task, wait for a plan or send `/plan`.
+4. When a terminal command appears, click **Run** only if you understand it.
+5. Accept or reject each file in the diff.
+
+Official auto-run allowlist ([Agent](https://help.aliyun.com/zh/lingma/agent)):
+
+> 具体配置路径为插件 **Chat** 设置页面的 **Auto-Run** 区域，在 **Terminal in Agent Mode** 下方的输入框中添加允许自动运行的命令。如需添加多个命令，可以使用英文逗号分隔。
+
+Do not put `rm`, `git push`, or `npm publish` on that list in week one.
+
+If Agent cannot start a terminal in VS Code, read [Terminal exceptions](https://help.aliyun.com/zh/lingma/description-of-terminal-execution-exception): the VS Code plugin needs the Shell Integration API, **VS Code > 1.93**, and a supported default shell. That is a different floor from the 1.68.0 install requirement.
+
+## Attach MCP
+
+Official boundary ([MCP guide](https://help.aliyun.com/zh/lingma/guide-for-using-mcp)):
+
+> MCP（Model Context Protocol）是一种开放标准协议，使其智能体的能力和场景得到拓展。
+>
+> Markets: [ModelScope MCP](https://www.modelscope.cn/mcp), [Higress MCP](https://mcp.higress.ai/).
+>
+> Example jobs: database schemas / DAO, online docs, design-to-code.
+
+Official path into the MCP page in IntelliJ ([MasterGo recipe](https://help.aliyun.com/zh/lingma/use-lingma-mastergo-mcp-to-transforming-mastergo-design-draft-into-front-end-code)):
+
+1. Open **chat** from the sidebar icon.
+2. Open **MCP**: the **MCP tools** link on the welcome line, or avatar → **Personal settings** → **MCP**.
+3. Switch to **Agent**, then write the prompt.
+4. Confirm each MCP call. The result becomes later context.
+
+Do not paste third-party JSON from blog posts as if it were official config. Copy only what the [MCP guide](https://help.aliyun.com/zh/lingma/guide-for-using-mcp) shows.
+
+## Turn on Next Edit Suggestion (NES)
+
+Official definition ([NES](https://help.aliyun.com/zh/lingma/next-edit-suggestion)): predict the next change from full-file context, recent edits, and the caret. **Tab** accepts, **Esc** rejects.
+
+Same page: open personal settings with `⌘ ⇧ ,` (macOS) or `Ctrl Shift ,` (Windows) and enable **NES**. **Qoder CN IDE only supports Auto mode.**
+
+IDE changelogs later rename NES to **NEXT**. Trust the label in your installed client.
+
+## Pitfalls
+
+| Symptom | Check | Source |
+|---------|-------|--------|
+| Marketplace search misses the plugin | Old page says TONGYI Lingma; Help Center says Qoder CN | [Download](https://lingma.aliyun.com/download), [Install](https://help.aliyun.com/zh/lingma/installation-guide) |
+| No VS Code sidebar icon | Right-click the activity bar, enable Qoder CN | [Install](https://help.aliyun.com/zh/lingma/installation-guide) |
+| No Edit mode in JetBrains / Lingma IDE | Use Agent | [Chat overview](https://help.aliyun.com/zh/lingma/overview-of-chat) |
+| Agent cannot run the terminal in VS Code | VS Code > 1.93 + supported shell integration | [Terminal exceptions](https://help.aliyun.com/zh/lingma/description-of-terminal-execution-exception) |
+| Old Lingma IDE missing new features | Uninstall Lingma IDE, install Qoder CN IDE | [Billing](https://help.aliyun.com/zh/lingma/billing-description) |
+| Using it as Qwen chat | Wrong product. See the [map](./) | [qianwen.com](https://www.qianwen.com/) |

--- a/docs/products/lingma/lingma-glossary.md
+++ b/docs/products/lingma/lingma-glossary.md
@@ -1,0 +1,108 @@
+---
+title: Lingma glossary
+description: "Why TONGYI Lingma was renamed Qoder CN, why the IDE is not the plugin, and how Ask / Edit / Agent differ. No install steps, no price table."
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# Lingma glossary
+
+Explains names. Does not teach clicks. Tutorial: [lingma](./lingma). Map: [index](./).
+
+## TONGYI Lingma / Qoder CN
+
+**What it is:** Alibaba Cloud's coding assistant. Marketing: code generation, ask, multi-file edits, coding agent. Help Center: the coding-focused sub-product of the Qoder CN series (formerly "TONGYI Lingma").
+
+**Why the rename:** official date 2026-05-20. The suite now also covers office, terminal, digital-employee, and hosted-agent products. The public-cloud coding desktop app is now **Qoder CN IDE**; the JetBrains plugin continues.
+
+**Role:** maps to Copilot / Cursor (work inside an editor), not to a consumer chat site.
+
+Official: [What is Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn), [What is the Qoder CN series](https://help.aliyun.com/zh/lingma/introduction-of-lingma).
+
+## Qoder CN IDE / Lingma IDE
+
+**What it is:** a standalone desktop IDE with the assistant built in. **No plugin install.** Marketing download pages still say **Lingma IDE**; Help Center and the new brand site say **Qoder CN IDE**.
+
+**Why it exists:** official iteration is concentrated here (and on the JetBrains plugin). When the VS Code plugin slows or stops, this is the official replacement.
+
+**Versus the plugin:** the plugin lives inside your current editor. The IDE is another client. Billing documents the upgrade as: uninstall Lingma IDE, install Qoder CN IDE.
+
+## IDE plugins
+
+**What they are:** extensions for JetBrains IDEs, Visual Studio Code, and Visual Studio. Marketplace / package IDs still say `TONGYI Lingma` / `tongyi-lingma`.
+
+**What they are not:** not Qoder CN CLI, not QoderWork.
+
+**VS Code:** Help Center still teaches install and says updates will slow; billing says evolution stopped; docs.qoder.cn says unmaintained; the EN update log says discontinued. Treat it as installable, not as the current primary surface.
+
+## Ask / Edit / Agent
+
+Three **modes in one chat**, not three products.
+
+| Mode | What | Why it exists |
+|------|------|----------------|
+| Ask | Answers only | Understand first |
+| Edit | Multi-file edits in your range; faster | You already know the files |
+| Agent | Plans, tools, terminal | You only give the goal |
+
+You can switch inside one thread. Edit is missing on Lingma IDE / JetBrains. Visual Studio is Ask-only for now. How-to: [cookbook](./lingma-cookbook).
+
+## NES (Next Edit Suggestion)
+
+**What it is:** predict the **next edit**, not the next line, from full-file context, recent edits, and the caret.
+
+**What it is not:** ordinary inline completion. IDE changelogs later call the upgrade **NEXT**.
+
+Official: [NES](https://help.aliyun.com/zh/lingma/next-edit-suggestion).
+
+## Project awareness / memory
+
+**Project awareness:** infer framework, stack, relevant files, and errors from the task so you do not paste the whole repo.
+
+**Memory:** accumulate personal / project / issue memory during chat ([Memory](https://help.aliyun.com/zh/lingma/memory)).
+
+These explain why opening related files helps. They do not mean "the model was trained on your private repo". Model internals are out of scope; see [Learn LLM](/tech/fundamentals/LLM).
+
+## Quest / RepoWiki / Subagent / Experts
+
+Listed on [What is Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn) as IDE-side upgrades:
+
+- **Quest 2.0:** split a complex coding task into steps.
+- **RepoWiki:** project-level wiki.
+- **Subagent:** child agents.
+- **Experts:** specialist agents for frontend, backend, database, ops, test.
+
+Official: RepoWiki, Quest, and Subagent deduct Credits and are not turn-capped. This handbook does not split them into their own tutorials; operations live on [docs.qoder.cn](https://docs.qoder.cn/).
+
+## Credits
+
+**What it is:** the usage unit introduced with seats on 2026-05-20. Extra Credits are sold as add-on packs. After the full-suite account upgrade, individual Credits can be shared across IDE / JetBrains / QoderWork / CLI and other suite apps.
+
+**What it is not:** unlimited free usage. The trial plan is explicitly limited, including a 2-week trial. Numbers: [Billing](https://help.aliyun.com/zh/lingma/billing-description).
+
+## Not this
+
+| Name | Actually | This site |
+|------|----------|-----------|
+| **Tongyi Qianwen / Qwen** | Consumer assistant ([qianwen.com](https://www.qianwen.com/)) | One map row, #83 |
+| **Model Studio (Bailian)** | Model / agent platform | One map row, #85 |
+| **Qoder CN CLI** | Terminal product | One map row |
+| **QoderWork CN** | Office desktop agent | One map row |
+| **QoderWake CN** | Digital employee | One map row |
+| **Cloud Agents** | Hosted agent platform | One map row |
+| **Taobao / ECS / payments** | Non-AI products | Out of scope |
+| "Lingma is just Qwen's IDE skin" | False | Two products |
+| "It is only a VS Code plugin" | False | Official default is IDE + JetBrains |
+
+## Renamed or retired
+
+| Old wording | Now |
+|-------------|-----|
+| AI Coding Assistant TONGYI Lingma | Qoder CN series from 2026-05-20 |
+| Lingma IDE | Qoder CN IDE; uninstall then reinstall on the official path |
+| TONGYI Lingma plugin display name | Help Center: Qoder CN; marketplace ID still `Alibaba-Cloud.tongyi-lingma` |
+| Individual Pro limited-time free | Ended 2026-05-20 18:00; promo users moved to the community / trial tier |
+
+Which door to open: [learning map](./).

--- a/docs/products/lingma/lingma.md
+++ b/docs/products/lingma/lingma.md
@@ -1,0 +1,204 @@
+---
+title: Lingma tutorial
+description: "Install TONGYI Lingma / Qoder CN as a standalone IDE or IDE plugin, sign in with an Alibaba Cloud account, then use completion and the three chat modes."
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# Lingma tutorial
+
+> This is a **tutorial**. Do it in order: pick a surface → copy the official install text → sign in → complete → three chat modes.
+>
+> Names: [glossary](./lingma-glossary). Keys and plans: [cheatsheet](./lingma-cheatsheet). Recipes: [cookbook](./lingma-cookbook).
+
+Goal: go from "the Chinese Copilot" to "it completes, answers, and edits in my IDE".
+
+## Step 0: Name what you are installing
+
+The Help Center calls the coding sub-product **Qoder CN** (formerly TONGYI Lingma) and offers two ways to use it ([Installation guide](https://help.aliyun.com/zh/lingma/installation-guide)):
+
+> Qoder CN 为您提供两种使用方式。您可以选择下载开箱即用的 Qoder CN IDE，也可以选择在您现有的开发工具中直接安装 Qoder CN 插件。安装后登录账号即可开始使用。
+
+EN Help Center equivalent: install Qoder CN IDE, or install the plugin in an existing IDE, then sign in ([Setup and install](https://www.alibabacloud.com/help/en/lingma/installation-and-login-guide/)).
+
+| You already have | Install | Official stance |
+|------------------|---------|-----------------|
+| No preference / want an AI-native IDE | **Qoder CN IDE** (marketing still says Lingma IDE) | Current default |
+| IntelliJ IDEA / WebStorm / PyCharm | **JetBrains plugin** | Current iteration surface |
+| VS Code | **VS Code plugin** | Still installable; official text says updates slowed / discontinued |
+| Visual Studio 2022 / 2019 | **Visual Studio plugin** | Chat is Ask-only for now |
+
+Individual edition prerequisite: an Alibaba Cloud account; sign in with the primary account ([Individual quick start](https://help.aliyun.com/zh/lingma/individual-edition-quick-start), [EN](https://www.alibabacloud.com/help/en/lingma/getting-started/individual-edition-quick-start)).
+
+## Step 1: Install
+
+The steps below are **copied from official pages**. Do not merge the old and new search strings. Use the wording on the page you opened.
+
+### 1.1 Standalone IDE
+
+Marketing site [lingma.aliyun.com/download](https://lingma.aliyun.com/download):
+
+> Lingma IDE 将增强上下文工程与智能体无缝集成，全面理解代码库，轻松处理复杂任务，同时兼容 JetBrains IDEs 等主流编程工具，开发者可以自由选择。
+>
+> 全面集成智能编码助手的能力，开箱即用更简单，无需安装插件即可享受高效、智能的编程体验。
+
+OS lines on that page:
+
+- **macOS** 11.0+
+- **Windows** 10/11
+- **Linux** `.deb` / `.rpm`
+
+The Help Center names the same client **Qoder CN IDE**, points downloads at [https://qoder.com.cn/download](https://qoder.com.cn/download), and writes:
+
+> 适用操作系统：Windows 10/11（x64）、macOS 11.0 、Linux x64 (.deb/.rpm) 或更新版本。
+
+Both URLs are official. New-brand downloads go through `qoder.com.cn/download`. Official upgrade path: uninstall the original Lingma IDE, then install Qoder CN IDE ([Billing](https://help.aliyun.com/zh/lingma/billing-description)).
+
+### 1.2 JetBrains plugin
+
+Marketing download page, IntelliJ IDEA example:
+
+> **方式一：从插件市场安装**
+>
+> 点击导航-插件，打开应用市场，搜索通义灵码（TONGYI Lingma），找到通义灵码后点击安装。
+>
+> **方式二：下载离线包安装**
+>
+> 1. 下载 JetBrains IDEs 的 zip 安装包；
+> 2. 点击导航-插件，点击设置图标，下拉菜单中单击从本地安装插件，选择下载的 zip 文件后安装。
+>
+> 重启 IntelliJ IDEA，重启成功后登录阿里云账号，即刻开启智能编码之旅。
+
+Help Center (new display name):
+
+> 打开 IntelliJ IDEA 设置窗口，在插件市场中搜索 Qoder CN，找到 Qoder CN 后单击安装。
+>
+> 安装完成后，请重启 IntelliJ IDEA。
+
+Offline zip from Help Center: [tongyi-jetbrains-latest.zip](https://tongyi-code.oss-cn-hangzhou.aliyuncs.com/jetbrain/tongyi-jetbrains-latest.zip). New-brand zip: [qodercn-jetbrains-latest.zip](https://qodercn-jb.oss-cn-hangzhou.aliyuncs.com/qodercn-jetbrains-latest.zip).
+
+Compatibility: JetBrains IDEs **2020.3+**. Full matrix: [Cheatsheet](./lingma-cheatsheet#compatible-ides-and-os).
+
+### 1.3 Visual Studio Code plugin
+
+Read the official stance first:
+
+> 产品功能迭代将主要集中在 Qoder CN IDE 和 Qoder CN JetBrains 插件中，VSCode 插件更新节奏将会放缓。如果您在使用 VSCode 插件过程中遇到问题或不便，建议切换到 Qoder CN IDE. ([Installation guide](https://help.aliyun.com/zh/lingma/installation-guide))
+
+EN update log: "VS Code plugin support discontinued … no longer part of the product suite." ([Update log](https://www.alibabacloud.com/help/en/lingma/product-overview/qoder-cn-update-log))
+
+Help Center install text:
+
+> 下载并安装 Visual Studio Code **1.68.0 及以上版本**。
+>
+> **方法 1：从插件市场安装**
+>
+> 单击 [立即安装](vscode:extension/Alibaba-Cloud.tongyi-lingma) ，唤起 Visual Studio Code 插件市场直接安装，安装后请重启 IDE，即可开启智能编码之旅。
+>
+> 打开 Visual Studio Code 扩展窗口，搜索 Qoder CN，找到 Qoder CN 后单击安装。
+>
+> **方法 2：下载安装包安装**
+>
+> 单击下方链接，下载 Visual Studio Code 的 VSIX 安装包：[Qoder CN-VS Code](https://tongyi-code.oss-cn-hangzhou.aliyuncs.com/vscode/tongyi-lingma-latest.vsix)
+>
+> 打开 Visual Studio Code 后，单击扩展，单击更多按钮，在下拉菜单中单击 **从 VSIX 安装** ，选择下载的 VSIX 文件后安装。
+>
+> 安装完成后，请重启 Visual Studio Code。
+
+Marketplace ID remains `Alibaba-Cloud.tongyi-lingma`. Display name: **Qoder CN (Formerly Lingma)**.
+
+If the sidebar icon is missing:
+
+> 如果安装后在侧边导航上找不到 Qoder CN 入口，可鼠标聚焦在侧边导航后右键查看，勾选 Qoder CN 后即可将插件入口配置在侧边导航上。
+
+### 1.4 Visual Studio
+
+Help Center does not publish a click-by-click Visual Studio walkthrough. It only says: install from the marketplace or an install package ([Setup and install](https://help.aliyun.com/zh/lingma/installation-and-login-guide/)). Compatible versions: Visual Studio **2022 17.3.0+** or **2019 16.3.0+**, Windows 10+ ([Compatible IDEs](https://help.aliyun.com/zh/lingma/compatible-ide-and-system)). Chat on Visual Studio is **Ask-only** for now ([Chat overview](https://help.aliyun.com/zh/lingma/overview-of-chat)). This page does not invent the missing clicks.
+
+## Step 2: Sign in
+
+Individual edition ([Individual quick start](https://help.aliyun.com/zh/lingma/individual-edition-quick-start)):
+
+> 1. 安装完成后，选择 阿里云中国站账号登录 ，前往阿里云登录页完成登录。
+> 2. 在阿里云登录页面完成登录，后续即可看到登录成功页面。
+> 3. 回到 IDE 端即可开始使用 Qoder CN 。
+>
+> 登录成功页面将展示账号名称和 Account ID 等信息。在 IDE 中，可通过 TONGYI Lingma 插件面板右上角的账号名称确认登录状态。
+
+EN Help Center: you can log on with an Alibaba Cloud account. Help Center also documents **AK/SK** login (common for remote SSH). Business / Dedicated login is a different path ([Setup and install](https://help.aliyun.com/zh/lingma/installation-and-login-guide/)); this tutorial does not cover the enterprise console.
+
+## Step 3: Inline completion
+
+Open a real frontend file and type. Official definition ([What is Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn)):
+
+> 根据当前语法和跨文件的代码上下文，自动感知当前工程，实时生成行、函数级代码。
+>
+> 通过注释描述您想要的功能，可直接在编辑器区生成代码。
+
+Marketplace English: "generate line-level or function-level code … based on the context of your current or related files." Accept with **Tab** ([Plugin configuration](https://help.aliyun.com/zh/lingma/plug-in-configuration-guide)). Write the intent in a comment.
+
+Next Edit Suggestion (NES) is a different feature. See [Cookbook](./lingma-cookbook#turn-on-next-edit-suggestion-nes).
+
+## Step 4: Pick a chat mode
+
+Open chat ([Chat overview](https://help.aliyun.com/zh/lingma/overview-of-chat)):
+
+| Action | macOS | Windows |
+|--------|-------|---------|
+| Toggle chat | `⌘ ⇧ L` (JetBrains, VS Code); `⌘ L` (Lingma IDE) | `Ctrl Shift L` |
+
+Three official modes in one thread — you can switch without starting a new chat:
+
+| Mode | Official meaning | Use it when |
+|------|------------------|-------------|
+| **Ask** | R&D Q&A; **does not edit project files** | You need to understand first |
+| **Edit** | Precise multi-file edits, reviewable | You know which files |
+| **Agent** | Plans, uses tools (terminal, MCP), end-to-end | You give the goal |
+
+Support matrix is official, not inferred:
+
+- **Visual Studio Code:** all three
+- **Lingma IDE / JetBrains plugin:** Ask + Agent; **no Edit**
+- **Visual Studio:** Ask only for now
+- Latest chat features: upgrade VS Code / JetBrains plugins to **2.5.0 or later**
+
+Official prompt advice (do not rewrite as "usually"):
+
+> - Describe the task as a structured goal plus steps.
+> - Attach context: files, images, codebase, codeChanges.
+> - State language, style, format, and change targets.
+> - Iterate.
+
+Accept or reject file diffs before they merge into the original files.
+
+## Step 5: Watch terminal confirms in Agent mode
+
+Agent mode can edit many files and run the terminal. Official default ([Agent](https://help.aliyun.com/zh/lingma/agent)):
+
+> 默认每次执行命令前需要开发者进行确认：单击 **运行** 发送到 IDE Terminal；单击 **取消** 跳过此次命令。
+
+Do not enable the auto-run allowlist on day one. MCP calls also ask before they run. Recipes: [Cookbook](./lingma-cookbook).
+
+## Step 6: Safety habits
+
+- **Review generated code**, especially auth, payments, and SQL.
+- In Agent mode, **do not click Run** on a command you cannot read.
+- Enterprise knowledge bases are enterprise features. Do not assume they exist on an individual account.
+- This site does not document model internals. See [Learn LLM](/tech/fundamentals/LLM).
+
+## Next
+
+- Wrong mode, weak prompts, MCP → [Cookbook](./lingma-cookbook)
+- URLs / shortcuts / plans → [Cheatsheet](./lingma-cheatsheet)
+- Rename and "not this" → [Glossary](./lingma-glossary)
+
+## References
+
+- [Installation guide](https://help.aliyun.com/zh/lingma/installation-guide)
+- [Marketing download page](https://lingma.aliyun.com/download)
+- [Individual quick start](https://help.aliyun.com/zh/lingma/individual-edition-quick-start)
+- [Chat overview](https://help.aliyun.com/zh/lingma/overview-of-chat)
+- [What is Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn)
+- [EN Help Center](https://www.alibabacloud.com/help/en/lingma/)

--- a/docs/zh/products/lingma/index.md
+++ b/docs/zh/products/lingma/index.md
@@ -1,0 +1,132 @@
+---
+title: 通义灵码学习地图
+description: "通义灵码是阿里云的智能编码助手，2026-05-20 起系列名改为 Qoder CN。本目录只写插件和独立 IDE；通义千问、百炼、CLI、办公助手只在家族图占一行。"
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# 通义灵码学习地图
+
+> **通义灵码**（TONGYI Lingma / Lingma）是阿里云的智能编码助手，提供代码智能生成、智能问答、多文件修改、编程智能体。对位 Copilot / Cursor。
+>
+> 官方已于 **2026-05-20** 把系列名改为 **Qoder CN**。帮助中心原文：「Qoder CN 系列原名“智能编码助手通义灵码”（Lingma），已于 2026 年 5 月 20 日正式更名。如您在其他渠道看到“通义灵码”相关内容，与本产品为同一产品。」（[什么是 Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn)）
+>
+> 本目录**只写编码子产品**：独立 IDE + IDE 插件。同厂其它 AI 产品只在下面家族图占一行。
+
+## 产品家族
+
+官方一级入口来自 [什么是 Qoder CN 系列](https://help.aliyun.com/zh/lingma/introduction-of-lingma) 和 [docs.qoder.cn 系列介绍](https://docs.qoder.cn/product-overview/introduction-of-qodercn)。营销站 [lingma.aliyun.com](https://lingma.aliyun.com/) 仍用旧品牌。
+
+```
+阿里云 AI（本站只展开编码助手）
+├── 通义灵码 / Qoder CN（编码）——本目录
+│   ├── Qoder CN IDE（营销站仍写 Lingma IDE）
+│   ├── JetBrains 插件（现行迭代面）
+│   ├── Visual Studio Code 插件（官方已标放缓 / 停更）
+│   └── Visual Studio 插件
+├── Qoder CN CLI —— 终端，地图一行
+├── QoderWork CN —— 办公桌面助手，地图一行
+├── QoderWake CN —— 数字员工，地图一行
+├── Qoder Cloud Agents —— 云端托管，地图一行
+├── Qoder CN Mobile —— 移动端，地图一行
+├── 通义千问 —— 通用对话，地图一行（#83）
+└── 阿里云百炼 —— 模型平台，地图一行（#85）
+```
+
+| 官方一级入口 | 官方 URL | 本站去向 |
+|--------------|----------|----------|
+| **通义灵码 / Qoder CN**（IDE + 插件） | [lingma.aliyun.com](https://lingma.aliyun.com/) · [qoder.com.cn](https://qoder.com.cn/) | **独立页**（本目录） |
+| Qoder CN CLI | [qoder.com.cn/cli](https://qoder.com.cn/cli) | 地图一行。终端形态，不是插件，本目录不写正文 |
+| QoderWork CN | [什么是 QoderWork CN](https://help.aliyun.com/zh/lingma/what-is-qoderwork-cn) | 地图一行。日常办公助手，不是编码 IDE |
+| QoderWake CN | [qoder.com.cn/qoderwake](https://qoder.com.cn/qoderwake) | 地图一行。数字员工 |
+| Qoder Cloud Agents | [qoder.com.cn/cloud-agents](https://qoder.com.cn/cloud-agents) | 地图一行。云端托管 Agent 平台 |
+| Qoder CN Mobile | [qoder.com.cn/mobile](https://qoder.com.cn/mobile) | 地图一行。移动指挥面 |
+| **通义千问** | [qianwen.com](https://www.qianwen.com/) | 地图一行。通用对话助手，另 issue #83 |
+| **阿里云百炼** | [产品页](https://www.aliyun.com/product/bailian) | 地图一行。模型 / Agent 开发平台，另 issue #85 |
+| 淘宝 / ECS / 支付等非 AI | — | **非本站**。Retrieve 时阿里云首页会冒出，这里不写 |
+
+**不要当成同一产品：**
+
+| 容易混的 | 区别 |
+|---------|------|
+| 通义灵码 vs **通义千问** | 编码助手 vs 通用对话。本目录不写千问 |
+| 通义灵码 vs **百炼** | IDE / 插件 vs 模型平台。本目录不写百炼 |
+| **Lingma IDE / Qoder CN IDE** vs 插件 | 独立编辑器，开箱即用；插件装进你已有的 JetBrains / VS Code / Visual Studio |
+| 会话里的 **智能体模式** vs **Qoder CN CLI** vs **Cloud Agents** | 本机 IDE 里跑任务；终端子产品；云端托管平台 |
+| 营销站搜「通义灵码（TONGYI Lingma）」vs 帮助中心搜「Qoder CN」 | 同一插件的新旧展示名，安装时按你打开的那一页原文搜 |
+
+### 快速决策：我该用哪个？
+
+```
+我现在要干什么？
+├── 在已有 JetBrains IDE 里写代码
+│   └── → JetBrains 插件（官方现行迭代面）
+├── 想要开箱即用的 AI IDE，不想再装插件
+│   └── → Qoder CN IDE（营销站：Lingma IDE）
+├── 还在 VS Code 里
+│   └── → 插件仍可装，但官方已写更新放缓 / 停止维护
+│       └── 遇到问题，官方建议切到 Qoder CN IDE
+├── 在 Visual Studio 里
+│   └── → Visual Studio 插件（智能会话暂仅智能问答）
+├── 只在终端里派活，不打开 IDE
+│   └── → Qoder CN CLI（本目录不写，见家族图）
+├── 写文档 / 整理文件 / 办公自动化
+│   └── → QoderWork CN（本目录不写）
+└── 跟模型对话、或自己调 API
+    └── → 通义千问 / 百炼（本目录不写）
+```
+
+## 该读哪一篇
+
+本组按 [Diataxis](https://diataxis.fr/) 拆分：
+
+| 文档 | 类型 | 什么时候看 |
+|------|------|-----------|
+| [上手教程](./lingma) | Tutorial | 第一次用：装 IDE 或插件 → 登录 → 补全 → 三种会话 |
+| [实战 Cookbook](./lingma-cookbook) | How-to | 已经会基本操作，要抄模式选择、提示、Agent、MCP |
+| [Cheatsheet](./lingma-cheatsheet) | Reference | 查安装 URL、兼容版本、快捷键、套餐、数据源 |
+| [术语表](./lingma-glossary) | Explanation | 更名、形态、模式、「不是什么」 |
+
+## 学习路径
+
+| 阶段 | 目标 | 链接 |
+|------|------|------|
+| 1. 分清名字 | 灵码 = 现 Qoder CN 编码子产品；不是千问、不是百炼 | 上面的家族图；[术语表](./lingma-glossary) |
+| 2. 装上能登录 | 选 IDE 或插件，抄官方安装原文，用阿里云账号登录 | [教程 · 安装](./lingma#第-1-步装上) |
+| 3. 用上补全和会话 | 行间续写 + 智能问答 / 文件编辑 / 智能体 | [教程 · 第 3–4 步](./lingma#第-3-步行间代码补全) |
+| 4. 让它干活 | 智能体、终端命令确认、MCP | [Cookbook](./lingma-cookbook) |
+| 5. 回查 | 快捷键、套餐、官方页 | [Cheatsheet](./lingma-cheatsheet) |
+
+## 功能速查
+
+官方能力清单来自 [什么是 Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn) 和 [智能会话概览](https://help.aliyun.com/zh/lingma/overview-of-chat)。
+
+| 能力 | 一句话 | 文档 |
+|------|--------|------|
+| 行间代码补全 | 按当前文件和跨文件上下文生成行级 / 函数级代码 | [教程](./lingma) |
+| 行间建议预测（NES） | 按修改和光标位置预测下一处变更，Tab 接受 | [Cookbook](./lingma-cookbook) · [官方](https://help.aliyun.com/zh/lingma/next-edit-suggestion) |
+| 智能问答 Ask | 只回答，不改工程文件 | [术语表](./lingma-glossary) |
+| 文件编辑 Edit | 按你给的范围改多文件；**Lingma IDE / JetBrains 不支持** | [官方](https://help.aliyun.com/zh/lingma/edit) |
+| 智能体 Agent | 自主拆任务、改文件、跑终端；可接 MCP | [Cookbook](./lingma-cookbook) |
+| 工程自动感知 | 按任务描述感知框架、技术栈、相关文件、报错 | [官方产品页](https://lingma.aliyun.com/) |
+| 记忆感知 | 对话中积累个人 / 工程 / 问题记忆 | [官方](https://help.aliyun.com/zh/lingma/memory) |
+| MCP | 智能体可调用你配置的 MCP；可走魔搭等广场 | [Cookbook](./lingma-cookbook) |
+| 模型选择器 / 专家团 / Quest / RepoWiki | IDE 侧升级能力；按 Credits 计 | [术语表](./lingma-glossary) |
+
+## 时效性提醒
+
+- **品牌**：2026-05-20 起官方系列名是 Qoder CN。旧教程里的「通义灵码」仍指同一产品。
+- **VS Code 插件**：帮助中心仍给安装步骤，同时写更新放缓；计费页写「停止演进」；新文档站写「已停止维护」。不要再把它写成现行主入口。
+- **文件编辑模式**：官方写明 Lingma IDE 和 JetBrains 插件不支持；Visual Studio 智能会话暂仅智能问答。
+- **套餐**：2026-05-20 起引入 Credits；个人专业版限免已结束。价格只看 [计费说明](https://help.aliyun.com/zh/lingma/billing-description) 打开的表。
+- **文档站**：帮助中心提示最新能力以 [docs.qoder.cn](https://docs.qoder.cn/) 为准。
+
+## 资源链接
+
+- [通义灵码官网](https://lingma.aliyun.com/)
+- [Qoder CN 官网](https://qoder.com.cn/)
+- [docs.qoder.cn](https://docs.qoder.cn/)
+- [阿里云帮助中心 · Qoder CN / 通义灵码](https://help.aliyun.com/zh/lingma/)
+- [Cheatsheet · 高质量信息源](./lingma-cheatsheet#高质量信息源)

--- a/docs/zh/products/lingma/lingma-cheatsheet.md
+++ b/docs/zh/products/lingma/lingma-cheatsheet.md
@@ -1,0 +1,141 @@
+---
+title: 通义灵码 Cheatsheet
+description: "通义灵码 / Qoder CN 安装入口、兼容版本、快捷键、会话模式、套餐与官方数据源。只抄能打开的官方页。"
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# 通义灵码 Cheatsheet
+
+> **参考页**。只查不学。概念看 [术语表](./lingma-glossary)，上手看 [教程](./lingma)。
+>
+> 最后核实：2026-08-19。套餐和快捷键以打开的官方页为准；帮助中心与 [docs.qoder.cn](https://docs.qoder.cn/) 打架时，在表里同时记下，不抹平。
+
+## 术语索引
+
+| 术语 | 一句话 |
+|------|--------|
+| [通义灵码 / Qoder CN](./lingma-glossary#通义灵码--qoder-cn) | 阿里云编码助手；2026-05-20 更名 |
+| [Qoder CN IDE](./lingma-glossary#qoder-cn-ide--lingma-ide) | 独立 IDE，营销站仍写 Lingma IDE |
+| [IDE 插件](./lingma-glossary#ide-插件) | JetBrains / VS Code / Visual Studio |
+| [智能问答 / 文件编辑 / 智能体](./lingma-glossary#智能问答--文件编辑--智能体) | 三种会话模式，不是三个产品 |
+| [NES](./lingma-glossary#nes-行间建议预测) | 下一处修改预测 |
+| [Credits](./lingma-glossary#credits) | 2026-05-20 起的用量单位 |
+| [通义千问 / 百炼](./lingma-glossary#不是什么) | 同厂其它产品，本目录不写 |
+
+## 安装入口
+
+| 形态 | 官方入口 | 原文要点 |
+|------|----------|----------|
+| Qoder CN IDE | [qoder.com.cn/download](https://qoder.com.cn/download) | 帮助中心指定的 IDE 下载地址 |
+| Lingma IDE（旧品牌页） | [lingma.aliyun.com/download](https://lingma.aliyun.com/download) | 营销站仍用此名 |
+| JetBrains 市场 | IDE 插件页搜 **通义灵码（TONGYI Lingma）** 或 **Qoder CN** | 两套展示名都是官方原文 |
+| JetBrains 离线包 | [tongyi-jetbrains-latest.zip](https://tongyi-code.oss-cn-hangzhou.aliyuncs.com/jetbrain/tongyi-jetbrains-latest.zip) | 帮助中心 |
+| JetBrains 离线包（新品牌） | [qodercn-jetbrains-latest.zip](https://qodercn-jb.oss-cn-hangzhou.aliyuncs.com/qodercn-jetbrains-latest.zip) | qoder.com.cn |
+| VS Code 市场 | `vscode:extension/Alibaba-Cloud.tongyi-lingma` | 帮助中心「立即安装」 |
+| VS Code VSIX | [tongyi-lingma-latest.vsix](https://tongyi-code.oss-cn-hangzhou.aliyuncs.com/vscode/tongyi-lingma-latest.vsix) | 帮助中心 |
+| 安装总入口 | [安装指南](https://help.aliyun.com/zh/lingma/installation-guide) | IDE + JetBrains + VS Code 逐步说明 |
+| 登录总入口 | [安装和登录](https://help.aliyun.com/zh/lingma/installation-and-login-guide/) | 个人 / 企业标准 / 企业专属 |
+
+逐步原文见 [教程 · 第 1 步](./lingma#第-1-步装上)。
+
+## 兼容 IDE 和系统
+
+来源：[兼容 IDE 和系统](https://help.aliyun.com/zh/lingma/compatible-ide-and-system)、[什么是 Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn)。
+
+| 客户端 | IDE / 系统门槛 |
+|--------|----------------|
+| Qoder CN IDE | Windows 10/11（x64；产品页另写 arm64）、macOS 11.0+；安装指南另列 Linux x64 `.deb`/`.rpm` |
+| JetBrains IDEs | 2020.3+：IntelliJ IDEA、PyCharm、GoLand、WebStorm、Android Studio、HUAWEI DevEco Studio 等；Windows 7+ / macOS / Linux |
+| Visual Studio Code | 1.68.0+；Windows 7+ / macOS / Linux |
+| Visual Studio | 2022 17.3.0+ 或 2019 16.3.0+；Windows 10+ |
+| 其它场景 | Remote SSH、WSL；VS Code WebIDE / Open VSX |
+
+官方补充：迭代集中在 **Qoder CN IDE + JetBrains 插件**；VS Code 更新放缓。新文档站写 VS Code 插件已停止维护。
+
+支持语言（产品页 / 帮助中心）：Java、Python、Go、C#、C/C++、JavaScript、TypeScript、PHP、Ruby、Rust、Scala、Kotlin 等。营销站另写「200 种语言」——本表只收录帮助中心点名的主流语言。
+
+## 快捷键
+
+来源：[智能会话概览](https://help.aliyun.com/zh/lingma/overview-of-chat)、[行间建议预测](https://help.aliyun.com/zh/lingma/next-edit-suggestion)、[插件配置](https://help.aliyun.com/zh/lingma/plug-in-configuration-guide)。未在官方表里出现的键不收录。
+
+| 操作 | macOS | Windows |
+|------|-------|---------|
+| 打开 / 关闭智能会话（JetBrains、VS Code） | `⌘ ⇧ L` | `Ctrl Shift L` |
+| 打开 / 关闭智能会话（Lingma IDE） | `⌘ L` | `Ctrl Shift L` |
+| 接受行间代码建议 | `Tab` | `Tab` |
+| 接受 NES | `Tab` | `Tab` |
+| 拒绝 NES | `Esc` | `Esc` |
+| 打开个人设置（开启 NES） | `⌘ ⇧ ,` | `Ctrl Shift ,` |
+
+VS Code 新建会话还可在输入框输入 `/` 后选 `/newChat`（官方：仅 VS Code）。智能体规划可用 `/plan`。
+
+## 会话模式
+
+| | 智能问答 | 文件编辑 | 智能体 |
+|---|----------|----------|--------|
+| 改文件 | 否 | 是（你给的范围） | 是（自己拆任务） |
+| 跑终端 | 否 | 否 | 是（默认先确认） |
+| VS Code | 支持 | 支持 | 支持 |
+| Lingma IDE / JetBrains | 支持 | **不支持** | 支持 |
+| Visual Studio | 支持 | 未写支持 | 未写支持 |
+
+## 套餐（只抄打开的官方表）
+
+来源：[计费说明](https://help.aliyun.com/zh/lingma/billing-description)，2026-08-19 打开的「Qoder CN（全家桶）」页签。**价格会变，下单前打开官方页。**
+
+官方前提：
+
+- 2026-05-20 23:00:00（北京时间）起启用新定价和 Credits。
+- 个人专业版限免已于 2026-05-20 18:00:00 结束。
+- 2026-06-20 起，全家桶个人版 Credits 可在 Desktop、JetBrains 插件、QoderWork、CLI、Wake、Mobile 间共享。
+- 该页写「VSC 插件停止演进」。
+
+| 版本 | 单价（官方表） | Credits（官方表） |
+|------|----------------|-------------------|
+| 个人体验版（Free） | 免费 | 有限体验额度；2 周试用及 300 Credits |
+| 个人专业版（Pro） | 59 元 / 月 | 2,000 Credits / 月 |
+| 个人高级版（Pro+） | 169 元 / 月 | 6,000 Credits / 月 |
+| 团队版（Teams） | 99 元 / 席位·月 | 3,000 Credits / 席位·月 |
+| 企业标准版（Enterprise） | 149 元 / 席位·月 | 3,000 Credits / 席位·月，可共享；10 席位起 |
+| 企业专属版（Enterprise VPC） | 199 元 / 席位·月 | 3,000 Credits / 席位·月，可共享；50 席位起 |
+
+「Qoder CN（原灵码）」页签是 IDE / JetBrains / VS Code **单产品企业订阅**：企业标准版 99 元 / 席位·月，企业专属版 199 元 / 席位·月。存量 2026-05-20 前合同见该页第三个页签，本表不抄旧价以免和下单页打架。
+
+资源包（原灵码个人）：40 元 / 1,000 Credits，有效期 1 个月。企业：80 元 / 2,000 Credits，有效期 3 个月。到期未用完清零。
+
+## 高质量信息源
+
+最后核实：2026-08-19。按可信度排序。社区评测只作线索，不进套餐和命令。
+
+### 一手官方
+
+| 来源 | 用途 |
+|------|------|
+| [lingma.aliyun.com](https://lingma.aliyun.com/) | 旧品牌营销首页，本 issue 指定起点 |
+| [lingma.aliyun.com/download](https://lingma.aliyun.com/download) | Lingma IDE + JetBrains 安装原文 |
+| [qoder.com.cn](https://qoder.com.cn/) | 新品牌站 |
+| [qoder.com.cn/download](https://qoder.com.cn/download) | 帮助中心指定的 IDE 下载页 |
+| [docs.qoder.cn](https://docs.qoder.cn/) | 官方标为最新的文档站 |
+| [什么是 Qoder CN 系列](https://help.aliyun.com/zh/lingma/introduction-of-lingma) | 家族图 |
+| [什么是 Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn) | 编码子产品能力 |
+| [安装指南](https://help.aliyun.com/zh/lingma/installation-guide) | IDE / JetBrains / VS Code 安装 |
+| [安装和登录](https://help.aliyun.com/zh/lingma/installation-and-login-guide/) | 登录分流 |
+| [个人版快速入门](https://help.aliyun.com/zh/lingma/individual-edition-quick-start) | 个人账号路径 |
+| [兼容 IDE 和系统](https://help.aliyun.com/zh/lingma/compatible-ide-and-system) | 版本门槛 |
+| [智能会话概览](https://help.aliyun.com/zh/lingma/overview-of-chat) | 三模式 + 快捷键 |
+| [智能体](https://help.aliyun.com/zh/lingma/agent) | `/plan`、终端确认、Auto-Run |
+| [MCP](https://help.aliyun.com/zh/lingma/guide-for-using-mcp) | MCP 配置 |
+| [计费说明](https://help.aliyun.com/zh/lingma/billing-description) | 价格与 Credits |
+| [VS Marketplace · Alibaba-Cloud.tongyi-lingma](https://marketplace.visualstudio.com/items?itemName=Alibaba-Cloud.tongyi-lingma) | 插件 ID 与英文产品说明 |
+| [国际站帮助](https://www.alibabacloud.com/help/en/lingma/) | 英文对照 |
+
+### 同厂但不在本目录展开
+
+| 来源 | 用途 |
+|------|------|
+| [qianwen.com](https://www.qianwen.com/) | 通义千问 |
+| [阿里云百炼](https://www.aliyun.com/product/bailian) | 模型平台 |
+| [Qoder CN CLI](https://qoder.com.cn/cli) | 终端子产品 |

--- a/docs/zh/products/lingma/lingma-cookbook.md
+++ b/docs/zh/products/lingma/lingma-cookbook.md
@@ -1,0 +1,121 @@
+---
+title: 通义灵码实战 Cookbook
+description: "已经装好通义灵码 / Qoder CN 之后：怎么选会话模式、怎么写需求、怎么让智能体跑终端、怎么接 MCP。"
+domain: product
+tags:
+  - coding-agent
+role: cookbook
+---
+
+# 通义灵码实战 Cookbook
+
+面向「已经登录、能补全」的读者。每个配方解决一个具体问题。安装回 [教程](./lingma)；查键位回 [Cheatsheet](./lingma-cheatsheet)。
+
+## 选对会话模式
+
+目标：少付「选错形态」的税。
+
+| 你要做的事 | 用哪个模式 | 官方依据 |
+|------------|------------|----------|
+| 解释这段 React 组件、对比两种写法 | **智能问答** | 「不会直接对工程文件进行修改」 |
+| 只改点名的几个文件，自己看 diff | **文件编辑** | 「精确编辑……不会做出超出开发者预期的修改」；比智能体更快 |
+| 加一个完整功能：改文件 + 装依赖 + 跑测试 | **智能体** | 可拆任务、用终端、接 MCP |
+| 在 Lingma IDE / JetBrains 里做多文件修改 | **智能体**（不要找文件编辑） | 官方：这两端不支持文件编辑 |
+| 在 Visual Studio 里 | **智能问答** | 官方：VS 暂仅问答 |
+
+判断口诀：你能不能一眼看出它改错了。能 → 智能体；不能 → 退回问答，先要方案。
+
+来源：[智能会话概览](https://help.aliyun.com/zh/lingma/overview-of-chat)、[文件编辑](https://help.aliyun.com/zh/lingma/edit)、[智能体](https://help.aliyun.com/zh/lingma/agent)。
+
+## 把需求写成官方建议的结构
+
+目标：少靠「再问一遍」补上下文。
+
+官方原文（[智能会话概览](https://help.aliyun.com/zh/lingma/overview-of-chat)）：
+
+> 结构化地描述需求：首先需要澄清我们需要通义灵码帮我们做什么，建议包含一个明确的目标，并通过步骤式的结构化描述，详细地描述您期望完成的编码任务和要求。
+>
+> 给出相关的上下文：可以选择代码文件、图片、codebase、codeChanges 等上下文。
+>
+> 明确生成要求：告诉通义灵码您期望它遵循的要求，比如语言、规范、格式、变更目标等，如“生成变更时，同时为每个方法生成英文注释”。
+>
+> 多多互动，逐步迭代。
+
+可直接改的模板（结构来自上面四条，内容换成你的仓库）：
+
+```text
+目标：在 src/components/UserTable.tsx 给表格加上按 lastActiveAt 排序。
+
+步骤：
+1. 只改现有组件，不新建页面
+2. 默认降序，点击表头切换
+3. 补上 TypeScript 类型，不要 any
+
+要求：
+- 生成变更时，同时为每个方法生成英文注释
+- 不要改 API 层
+```
+
+再在输入框里显式加上相关文件 / 图片 / codebase。Lingma IDE 的上下文**暂不支持知识库**（同一页官方说明）。
+
+智能体还提供「优化输入」：先打草稿，再点优化按钮，让它结合已加上下文扩写成可执行提示（[智能体](https://help.aliyun.com/zh/lingma/agent)）。扩完仍要自己看一眼再提交。
+
+## 让智能体跑一个有副作用的任务
+
+目标：端到端改代码，但终端命令仍在你手里。
+
+1. 切到 **智能体**。
+2. 写清目标和边界（见上一节）。
+3. 复杂任务可等它出规划，或主动发 `/plan`（官方：智能体会对复杂任务自动生成方案；也可用 `/plan` 触发）。
+4. 终端命令弹出时，看懂再点 **运行**；看不懂点 **取消**。
+5. 在 diff 里按文件接受或拒绝。
+
+官方还允许把常用命令加入自动执行白名单（[智能体](https://help.aliyun.com/zh/lingma/agent)）：
+
+> 具体配置路径为插件 **Chat** 设置页面的 **Auto-Run** 区域，在 **Terminal in Agent Mode** 下方的输入框中添加允许自动运行的命令。如需添加多个命令，可以使用英文逗号分隔。
+
+第一周不要把 `rm`、`git push`、`npm publish` 放进白名单。
+
+VS Code 里终端唤不起来时，先对 [终端执行异常说明](https://help.aliyun.com/zh/lingma/description-of-terminal-execution-exception)：官方写明 VS Code 插件依赖 Shell 集成 API，需要 **VS Code > 1.93**，且默认终端是受支持的 shell。这和「插件安装要求 1.68.0」不是同一条门槛。
+
+## 给智能体接 MCP
+
+目标：让智能体调用外部工具（设计稿、文档、数据库 schemas）。
+
+官方能力边界（[MCP](https://help.aliyun.com/zh/lingma/guide-for-using-mcp)）：
+
+> MCP（Model Context Protocol）是一种开放标准协议，使其智能体的能力和场景得到拓展。
+>
+> 热门 MCP 市场： [魔搭社区 MCP 市场](https://www.modelscope.cn/mcp) 、 [Higress MCP 市场](https://mcp.higress.ai/) 。
+>
+> 热门场景：数据库 schemas / DAO；在线文档；根据设计稿生成前端代码。
+
+在 IntelliJ 里进入 MCP 页的官方步骤（[MasterGo 示例](https://help.aliyun.com/zh/lingma/use-lingma-mastergo-mcp-to-transforming-mastergo-design-draft-into-front-end-code)，侧栏图标在旧文档里仍写「通义灵码」）：
+
+1. 单击 IDE 侧边栏图标进入 **智能会话**。
+2. 进入 **MCP 服务** 页：欢迎语里的 **MCP 工具** 链接，或右上角头像 → **个人设置** → **MCP 服务**。
+3. 切到 **智能体** 模式，再写提示词。
+4. 智能体要调 MCP 时会先询问；点执行后，返回结果进入后续上下文。
+
+不要把 Marketplace 评测里的第三方 JSON 当成官方配置格式。配置项以 [MCP 指南](https://help.aliyun.com/zh/lingma/guide-for-using-mcp) 打开的页为准。
+
+## 打开行间建议预测（NES）
+
+目标：改完一处之后，让它预测下一处修改。
+
+官方定义（[行间建议预测](https://help.aliyun.com/zh/lingma/next-edit-suggestion)）：基于当前完整代码上下文，结合代码修改和光标位置动态预测变更；**Tab** 接受，**Esc** 拒绝。
+
+开启入口同一页写：用快捷键 `⌘ ⇧ ,`（macOS）或 `Ctrl Shift ,`（Windows）打开个人设置，开启 **行间建议预测（NES）**。并写明：**Qoder CN IDE 仅支持 Auto 模式**。
+
+帮助中心更新日志里，IDE 侧 NES 曾升级为 **NEXT**。若设置页已改名，以你装的客户端设置为准，不要混用旧教程截图。
+
+## 常见坑
+
+| 症状 | 先查什么 | 来源 |
+|------|----------|------|
+| 插件市场搜「通义灵码」找不到 / 搜「Qoder CN」找不到 | 营销站和帮助中心用的展示名不同，按你打开的那一页原文搜 | [下载页](https://lingma.aliyun.com/download)、[安装指南](https://help.aliyun.com/zh/lingma/installation-guide) |
+| VS Code 侧栏没有入口 | 侧栏右键，勾选 Qoder CN | [安装指南](https://help.aliyun.com/zh/lingma/installation-guide) |
+| JetBrains / Lingma IDE 找不到「文件编辑」 | 这两端官方不支持该模式，用智能体 | [智能会话概览](https://help.aliyun.com/zh/lingma/overview-of-chat) |
+| VS Code 智能体跑不了终端 | VS Code > 1.93 + 受支持的 shell 集成 | [终端异常](https://help.aliyun.com/zh/lingma/description-of-terminal-execution-exception) |
+| 还在用旧 Lingma IDE，功能对不上 | 官方升级路径：卸载原 Lingma IDE，改装 Qoder CN IDE | [计费说明](https://help.aliyun.com/zh/lingma/billing-description) |
+| 把它当成通义千问来聊天 | 走错产品。千问是对话助手，见[学习地图](./) | [qianwen.com](https://www.qianwen.com/) |

--- a/docs/zh/products/lingma/lingma-glossary.md
+++ b/docs/zh/products/lingma/lingma-glossary.md
@@ -1,0 +1,108 @@
+---
+title: 通义灵码术语表
+description: "解释通义灵码为什么改名 Qoder CN、IDE 和插件不是一回事、三种会话模式差在哪。不教安装，不列价格。"
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# 通义灵码术语表
+
+不教操作，只解释「是什么 / 不是什么」。上手回 [教程](./lingma)，选型回 [学习地图](./)。
+
+## 通义灵码 / Qoder CN
+
+**是什么：** 阿里云的智能编码助手。营销首页原文：「通义灵码是由阿里云提供的智能编码辅助工具，提供代码智能生成、智能问答、多文件修改、编程智能体等能力。」帮助中心把同一编码子产品定义为 Qoder CN 系列里「面向软件开发场景的核心子产品（原“通义灵码”）」。
+
+**为什么改名：** 官方说明写于 2026-05-20。系列覆盖编码、办公、终端、数字员工、云端 Agent。公共云「通义灵码」升级为 Qoder CN 之后，编码桌面应用现名 **Qoder CN IDE**，并继续提供 JetBrains 插件。
+
+**在生态中的角色：** 对位 Copilot / Cursor 这种「进编辑器干活」的产品，不是对位 ChatGPT 网页。
+
+官方文档：[什么是 Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn)、[什么是 Qoder CN 系列](https://help.aliyun.com/zh/lingma/introduction-of-lingma)。
+
+## Qoder CN IDE / Lingma IDE
+
+**是什么：** 独立桌面 IDE，全面集成编码助手，**无需再装插件**。营销站下载页仍写 **Lingma IDE**；帮助中心和新品牌站写 **Qoder CN IDE**。
+
+**为什么需要：** 官方把迭代重心放到这套 IDE（以及 JetBrains 插件）。VS Code 插件更新放缓或已停止维护时，这是官方建议的替代入口。
+
+**与插件的区别：** 插件寄生在你已有的编辑器里；IDE 是另一个客户端。计费页写过升级路径：卸载原 Lingma IDE，再安装 Qoder CN IDE。
+
+## IDE 插件
+
+**是什么：** 装进 JetBrains IDEs、Visual Studio Code、Visual Studio 的扩展。市场 / 包名长期残留 `TONGYI Lingma`、`tongyi-lingma`。
+
+**不是什么：** 不是 Qoder CN CLI，也不是 QoderWork 桌面办公助手。
+
+**VS Code 的特殊地位：** 帮助中心仍教安装，同时宣布更新放缓；计费页写「停止演进」；docs.qoder.cn 写「已停止维护」；国际站更新日志写 discontinued。三份官方页不完全一致，正文按「可装、但不是现行主入口」处理。
+
+## 智能问答 / 文件编辑 / 智能体
+
+三种是**同一会话窗口里的模式**，不是三个产品。
+
+| 模式 | 是什么 | 为什么单独存在 |
+|------|--------|----------------|
+| 智能问答 Ask | 只给方案，不改仓库 | 先搞懂，避免误改 |
+| 文件编辑 Edit | 在你给的上下文里改多文件，强调精确、更快 | 你已经知道改哪 |
+| 智能体 Agent | 自己拆任务、感知工程、用工具和终端 | 你只给目标 |
+
+官方强调一次会话里可切换，不必新建会话。文件编辑在 Lingma IDE / JetBrains 上不存在；Visual Studio 暂仅问答。详细操作见 [Cookbook](./lingma-cookbook)。
+
+## NES（行间建议预测）
+
+**是什么：** Next Edit Suggestion。根据完整代码上下文、已做修改和光标位置，预测**下一处**变更。
+
+**不是什么：** 不是普通的行间续写。续写补「下一行」；NES 预测「下一处要改的点」。帮助中心更新日志里，IDE 侧 NES 曾升级为 **NEXT**。
+
+官方文档：[行间建议预测](https://help.aliyun.com/zh/lingma/next-edit-suggestion)。
+
+## 工程自动感知 / 记忆感知
+
+**工程自动感知：** 按任务描述感知框架、技术栈、相关文件、报错，不必手动把整个仓库贴进对话框。
+
+**记忆感知：** 对话过程中积累针对个人、工程、问题的记忆，并自动整理。官方单独成页：[记忆](https://help.aliyun.com/zh/lingma/memory)。
+
+这两项解释的是「为什么打开相关文件、连续对话会越来越准」，不是「模型已经训练了你的私有仓库」。本站不写模型内部机制，见 [Learn LLM](/zh/tech/fundamentals/LLM)。
+
+## Quest / RepoWiki / Subagent / 专家团
+
+帮助中心在「什么是 Qoder CN」里把它们列为 IDE 侧升级能力：
+
+- **Quest 2.0**：复杂研发任务自动拆成可执行步骤。
+- **RepoWiki**：工程级知识库。
+- **Subagent**：子智能体。
+- **专家团**：面向前后端、数据库、运维、测试等的专家智能体。
+
+官方写：RepoWiki、Quest、Subagent 等核心能力按量抵扣 Credits、不限次数。本目录不把它们拆成独立教程——密度在产品介绍页，操作细节以 [docs.qoder.cn](https://docs.qoder.cn/) 为准。
+
+## Credits
+
+**是什么：** 2026-05-20 起订阅席位引入的用量单位。超额可买资源包。全家桶个人版 Credits 可跨 IDE / JetBrains / QoderWork / CLI 等共享（完成账号升级后）。
+
+**不是什么：** 不是「免费就永远无限」。个人体验版官方写的是有限体验额度和 2 周试用。具体数字只看 [计费说明](https://help.aliyun.com/zh/lingma/billing-description)，不要背旧博客。
+
+## 不是什么
+
+| 名字 | 实际是 | 本站 |
+|------|--------|------|
+| **通义千问** | 通用 AI 助手（[qianwen.com](https://www.qianwen.com/)） | 家族图一行，#83 |
+| **百炼** | 大模型服务 / Agent 开发平台 | 家族图一行，#85 |
+| **Qoder CN CLI** | 终端子产品 | 家族图一行 |
+| **QoderWork CN** | 办公桌面助手 | 家族图一行 |
+| **QoderWake CN** | 数字员工 | 家族图一行 |
+| **Cloud Agents** | 云端托管 Agent 平台 | 家族图一行 |
+| **淘宝 / ECS / 支付** | 非 AI 产品 | 非本站 |
+| 「通义灵码 = 通义千问的 IDE 皮肤」 | 错误说法 | 两个产品 |
+| 「只有 VS Code 插件」 | 错误说法 | 官方主推 IDE + JetBrains |
+
+## 已退役或已改名
+
+| 旧说法 | 现状 |
+|--------|------|
+| 智能编码助手通义灵码（Lingma） | 2026-05-20 起系列名 Qoder CN |
+| Lingma IDE | 现名 Qoder CN IDE；旧安装包需按官方路径卸载再装 |
+| TONGYI Lingma 插件展示名 | 帮助中心改为 Qoder CN；市场 ID 仍是 `Alibaba-Cloud.tongyi-lingma` |
+| 个人专业版限时免费 | 2026-05-20 18:00 结束，限免用户转个人社区 / 体验档 |
+
+选哪个入口，看 [学习地图](./) 的决策树。

--- a/docs/zh/products/lingma/lingma.md
+++ b/docs/zh/products/lingma/lingma.md
@@ -1,0 +1,201 @@
+---
+title: 通义灵码上手
+description: "从零装上通义灵码 / Qoder CN：独立 IDE 或 IDE 插件，登录阿里云账号，用上补全和三种智能会话。"
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# 通义灵码上手
+
+> 这是一份**教程**。按顺序做完：分清形态 → 抄官方安装 → 登录 → 行间补全 → 三种会话。
+>
+> 名词看 [术语表](./lingma-glossary)；快捷键和套餐看 [Cheatsheet](./lingma-cheatsheet)；场景配方看 [Cookbook](./lingma-cookbook)。
+
+本指南目标：把通义灵码从「听说过国内 Copilot」用成「在 IDE 里能补全、能问、能改」。
+
+## 第 0 步：先确认你在装哪一个
+
+官方帮助中心把编码子产品叫 **Qoder CN**（原通义灵码），并提供两种使用方式（[安装指南](https://help.aliyun.com/zh/lingma/installation-guide)）：
+
+> Qoder CN 为您提供两种使用方式。您可以选择下载开箱即用的 Qoder CN IDE，也可以选择在您现有的开发工具中直接安装 Qoder CN 插件。安装后登录账号即可开始使用。
+
+| 你已有的环境 | 装什么 | 官方态度 |
+|--------------|--------|----------|
+| 没有偏好 / 想要 AI 原生 IDE | **Qoder CN IDE**（营销站仍写 Lingma IDE） | 现行主推 |
+| IntelliJ IDEA / WebStorm / PyCharm 等 | **JetBrains 插件** | 现行迭代面 |
+| VS Code | **VS Code 插件** | 仍可装，但官方已写更新放缓 / 停止维护 |
+| Visual Studio 2022 / 2019 | **Visual Studio 插件** | 智能会话暂仅问答 |
+
+个人版前提：已注册阿里云账号，用主账号登录个人版（[个人版快速入门](https://help.aliyun.com/zh/lingma/individual-edition-quick-start)）。
+
+## 第 1 步：装上
+
+下面安装步骤**逐字抄官方**，不改搜索词、不合成新旧品牌名。打开哪一页，就按那一页搜。
+
+### 1.1 独立 IDE
+
+营销站 [lingma.aliyun.com/download](https://lingma.aliyun.com/download) 原文：
+
+> Lingma IDE 将增强上下文工程与智能体无缝集成，全面理解代码库，轻松处理复杂任务，同时兼容 JetBrains IDEs 等主流编程工具，开发者可以自由选择。
+>
+> 全面集成智能编码助手的能力，开箱即用更简单，无需安装插件即可享受高效、智能的编程体验。
+
+该页列出的系统门槛：
+
+- **macOS** 11.0+
+- **Windows** 10/11
+- **Linux** `.deb` / `.rpm`
+
+帮助中心安装指南把同一产品写成 **Qoder CN IDE**，下载地址指向 [https://qoder.com.cn/download](https://qoder.com.cn/download)，并写：
+
+> 适用操作系统：Windows 10/11（x64）、macOS 11.0 、Linux x64 (.deb/.rpm) 或更新版本。
+
+两站都是官方入口。新品牌下载走 `qoder.com.cn/download`；旧品牌页仍挂 Lingma IDE 安装包。升级路径官方写过：卸载原 Lingma IDE，再安装 Qoder CN IDE（[计费说明](https://help.aliyun.com/zh/lingma/billing-description)）。
+
+### 1.2 JetBrains 插件
+
+营销站 [下载和安装](https://lingma.aliyun.com/download) 以 IntelliJ IDEA 为例，原文：
+
+> **方式一：从插件市场安装**
+>
+> 点击导航-插件，打开应用市场，搜索通义灵码（TONGYI Lingma），找到通义灵码后点击安装。
+>
+> **方式二：下载离线包安装**
+>
+> 1. 下载 JetBrains IDEs 的 zip 安装包；
+> 2. 点击导航-插件，点击设置图标，下拉菜单中单击从本地安装插件，选择下载的 zip 文件后安装。
+>
+> 重启 IntelliJ IDEA，重启成功后登录阿里云账号，即刻开启智能编码之旅。
+
+帮助中心同一流程改用新名，原文：
+
+> 打开 IntelliJ IDEA 设置窗口，在插件市场中搜索 Qoder CN，找到 Qoder CN 后单击安装。
+>
+> 安装完成后，请重启 IntelliJ IDEA。
+
+离线包官方链接（帮助中心）：[Qoder CN - JetBrains](https://tongyi-code.oss-cn-hangzhou.aliyuncs.com/jetbrain/tongyi-jetbrains-latest.zip)。新品牌下载页另给：[qodercn-jetbrains-latest.zip](https://qodercn-jb.oss-cn-hangzhou.aliyuncs.com/qodercn-jetbrains-latest.zip)。
+
+兼容范围见 [Cheatsheet · 兼容](./lingma-cheatsheet#兼容-ide-和系统)。帮助中心写 JetBrains IDEs **2020.3 及以上**。
+
+### 1.3 Visual Studio Code 插件
+
+先读官方态度，再决定要不要装：
+
+> 产品功能迭代将主要集中在 Qoder CN IDE 和 Qoder CN JetBrains 插件中，VSCode 插件更新节奏将会放缓。如果您在使用 VSCode 插件过程中遇到问题或不便，建议切换到 Qoder CN IDE。（[安装指南](https://help.aliyun.com/zh/lingma/installation-guide)）
+
+帮助中心安装原文：
+
+> 下载并安装 Visual Studio Code **1.68.0 及以上版本**。
+>
+> **方法 1：从插件市场安装**
+>
+> 单击 [立即安装](vscode:extension/Alibaba-Cloud.tongyi-lingma) ，唤起 Visual Studio Code 插件市场直接安装，安装后请重启 IDE，即可开启智能编码之旅。
+>
+> 打开 Visual Studio Code 扩展窗口，搜索 Qoder CN，找到 Qoder CN 后单击安装。
+>
+> **方法 2：下载安装包安装**
+>
+> 单击下方链接，下载 Visual Studio Code 的 VSIX 安装包：[Qoder CN-VS Code](https://tongyi-code.oss-cn-hangzhou.aliyuncs.com/vscode/tongyi-lingma-latest.vsix)
+>
+> 打开 Visual Studio Code 后，单击扩展，单击更多按钮，在下拉菜单中单击 **从 VSIX 安装** ，选择下载的 VSIX 文件后安装。
+>
+> 安装完成后，请重启 Visual Studio Code。
+
+市场扩展 ID 仍是 `Alibaba-Cloud.tongyi-lingma`，展示名 **Qoder CN (Formerly Lingma)**。
+
+侧栏找不到入口时，官方原文：
+
+> 如果安装后在侧边导航上找不到 Qoder CN 入口，可鼠标聚焦在侧边导航后右键查看，勾选 Qoder CN 后即可将插件入口配置在侧边导航上。
+
+### 1.4 Visual Studio
+
+帮助中心没有单独逐步截图，只写「通过插件市场或下载安装包进行安装」（[安装和登录](https://help.aliyun.com/zh/lingma/installation-and-login-guide/)）。兼容版本：Visual Studio **2022 17.3.0 及以上**，或 **2019 16.3.0 及以上**；操作系统 Windows 10 及以上（[兼容 IDE 和系统](https://help.aliyun.com/zh/lingma/compatible-ide-and-system)）。智能会话在 Visual Studio 上**暂仅支持智能问答**（[智能会话概览](https://help.aliyun.com/zh/lingma/overview-of-chat)）。
+
+逐步点选找不到官方原文，这里不编。以 [安装指南](https://help.aliyun.com/zh/lingma/installation-guide) 为准。
+
+## 第 2 步：登录
+
+个人版官方步骤（[个人版快速入门](https://help.aliyun.com/zh/lingma/individual-edition-quick-start)）：
+
+> 1. 安装完成后，选择 阿里云中国站账号登录 ，前往阿里云登录页完成登录。
+> 2. 在阿里云登录页面完成登录，后续即可看到登录成功页面。
+> 3. 回到 IDE 端即可开始使用 Qoder CN 。
+>
+> 登录成功页面将展示账号名称和 Account ID 等信息。在 IDE 中，可通过 TONGYI Lingma 插件面板右上角的账号名称确认登录状态。
+
+帮助中心还写：可通过阿里云登录页或 **AK/SK** 登录（远程开发常见）。企业标准版 / 专属版登录入口不同，见 [安装和登录](https://help.aliyun.com/zh/lingma/installation-and-login-guide/)，本教程不展开企业控制台。
+
+## 第 3 步：行间代码补全
+
+打开一个真实前端文件，开始打字。官方定义（[什么是 Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn)）：
+
+> 根据当前语法和跨文件的代码上下文，自动感知当前工程，实时生成行、函数级代码。
+>
+> 通过注释描述您想要的功能，可直接在编辑器区生成代码。
+
+接受建议用 **Tab**（[插件配置](https://help.aliyun.com/zh/lingma/plug-in-configuration-guide)）。想让补全对准意图，把目标写进注释，而不是写「处理一下」。
+
+行间建议预测（NES）是下一处修改的预测，不是同一件事，见 [Cookbook](./lingma-cookbook#打开行间建议预测-nes)。
+
+## 第 4 步：智能会话，先学会选模式
+
+唤起会话（[智能会话概览](https://help.aliyun.com/zh/lingma/overview-of-chat)）：
+
+| 操作 | macOS | Windows |
+|------|-------|---------|
+| 打开 / 关闭智能会话 | `⌘ ⇧ L`（JetBrains、VS Code）；`⌘ L`（Lingma IDE） | `Ctrl Shift L` |
+
+官方三种模式，一次会话里可切换，**不必新建会话**：
+
+| 模式 | 官方定义 | 选它的信号 |
+|------|----------|-----------|
+| **智能问答** | 纯研发问答；结合上下文给方案，**不会直接改工程文件** | 我要先搞懂 |
+| **文件编辑** | 精准多文件修改，可迭代、可审查 | 我知道改哪，要看 diff |
+| **智能体** | 自主决策、感知工程、用工具（含终端、MCP），端到端完成任务 | 我只给目标，过程交给它 |
+
+支持矩阵也是官方写死的，不要假设全家都能用三种模式：
+
+- **Visual Studio Code**：三种都支持
+- **Lingma IDE / JetBrains 插件**：智能问答 + 智能体；**不支持文件编辑**
+- **Visual Studio**：智能会话暂仅智能问答
+- 体验最新能力：VS Code / JetBrains 需升到 **2.5.0 或以上**
+
+输入需求的官方建议（不要改写成「一般可以」）：
+
+> - 结构化地描述需求：包含一个明确的目标，并通过步骤式的结构化描述。
+> - 给出相关的上下文：代码文件、图片、codebase、codeChanges 等。
+> - 明确生成要求：语言、规范、格式、变更目标。
+> - 多多互动，逐步迭代。
+
+文件编辑 / 智能体产生的改动要在 diff 里接受或拒绝。接受后才合并进原文件。
+
+## 第 5 步：让智能体干活时盯住终端确认
+
+智能体模式会自己拆任务、改多文件、跑终端。官方默认（[智能体](https://help.aliyun.com/zh/lingma/agent)）：
+
+> 默认每次执行命令前需要开发者进行确认：单击 **运行** 发送到 IDE Terminal；单击 **取消** 跳过此次命令。
+
+不要第一天就打开自动执行白名单。MCP 也是每次执行前询问。配方见 [Cookbook](./lingma-cookbook)。
+
+## 第 6 步：安全习惯
+
+- **审查生成代码**，尤其是权限、鉴权、支付、SQL 拼接。
+- 智能体跑终端时，**看不懂的命令不要点运行**。
+- 企业知识库 / 私域代码增强是企业版能力，个人版不要假设已经接上。
+- 本站不写模型内部机制；模型原理见 [Learn LLM](/zh/tech/fundamentals/LLM)。
+
+## 接下来
+
+- 选错模式、提示写不明白、要接 MCP → [Cookbook](./lingma-cookbook)
+- 查安装 URL / 快捷键 / 套餐 → [Cheatsheet](./lingma-cheatsheet)
+- 搞不清更名和「不是什么」 → [术语表](./lingma-glossary)
+
+## 参考资料
+
+- [安装指南](https://help.aliyun.com/zh/lingma/installation-guide)
+- [下载和安装（营销站）](https://lingma.aliyun.com/download)
+- [个人版快速入门](https://help.aliyun.com/zh/lingma/individual-edition-quick-start)
+- [智能会话概览](https://help.aliyun.com/zh/lingma/overview-of-chat)
+- [什么是 Qoder CN](https://help.aliyun.com/zh/lingma/what-is-qoder-cn)


### PR DESCRIPTION
Closes #84

通义灵码 / Qoder CN 编码助手手册（插件 + 独立 IDE）。先中文后英文。**未改** `products-gallery.js` 与 sidebar。

## 家族图去向

| 官方一级入口 | 本站去向 |
|---|---|
| 通义灵码 / Qoder CN（IDE + JetBrains / VS Code / Visual Studio 插件） | 独立页 |
| Qoder CN CLI / QoderWork CN / QoderWake CN / Cloud Agents / Mobile | 地图一行 |
| 通义千问 | 地图一行（#83） |
| 百炼 | 地图一行（#85） |
| 淘宝 / ECS / 支付 | 非本站 |

## 文件

- `.claude/skills/doc-research/references/lingma.md` — 形态调研先于动笔
- `docs/zh/products/lingma/` 与 `docs/products/lingma/`：index / tutorial / cookbook / cheatsheet / glossary

## 官方事实（不覆盖）

- 2026-05-20 系列名改为 **Qoder CN**；营销站仍写通义灵码 / Lingma IDE。
- VS Code 插件：帮助中心仍给安装步骤且写「更新放缓」；计费页写「停止演进」；docs.qoder.cn 写「已停止维护」。正文并列三份口径，建议切 Qoder CN IDE。
- 文件编辑模式：Lingma IDE / JetBrains 不支持。
- 安装步骤逐字抄自 https://lingma.aliyun.com/download 与 https://help.aliyun.com/zh/lingma/installation-guide。

## 验收

- [x] 维护参考里先有形态调研
- [x] 本目录不展开千问 / 百炼 / CLI / 办公助手
- [x] 家族图一级 AI 入口都有去向
- [x] `pnpm docs:build` 通过；frontmatter-audit 通过
- [x] 不改 gallery / sidebar（按本轮执行约束）