### PR TITLE
docs(minimax-code): add MiniMax Code handbook (ZH+EN) for #72

### DIFF
--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -12,5 +12,6 @@
 | Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
 | Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
 | Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| MiniMax Code | [`minimax-code.md`](./minimax-code.md) | `docs/zh/products/minimax-code/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/.claude/skills/doc-research/references/minimax-code.md
+++ b/.claude/skills/doc-research/references/minimax-code.md
@@ -1,0 +1,147 @@
+# MiniMax Code 维护参考
+
+> 复制自 [`_template.md`](./_template.md)。通用流程见 [`maintenance-workflow.md`](./maintenance-workflow.md)。读者可见的数据源写进 `docs/zh/products/minimax-code/minimax-code-cheatsheet.md` 的「高质量信息源」，不要在本文件再抄一份。
+
+## 产品形态调研结论（写教程前必须先有这一节）
+
+调研时间：2026-08-19。以下每条都来自一手官方来源，来源标在括号里。
+
+**结论一：MiniMax Code 是第一方 Coding Agent 产品，不是「只把 M3 接到 Claude Code」。**
+
+- 中文官网首页原文：「MiniMax Code / 最适配 MiniMax 模型的 Coding Agent」（[minimaxi.com](https://www.minimaxi.com/)）。
+- 国际站原文：「The coding harness built for MiniMax models」（[minimax.io](https://www.minimax.io/)）。
+- 产品文档原文：「MiniMax Code 是一款桌面端 AI Agent 应用。它把对话、项目工作区、文件操作、终端、浏览器、技能、记忆和自动化任务放在同一个本地工作环境里」（[agent.minimaxi.com/docs/code/welcome](https://agent.minimaxi.com/docs/code/welcome)）。
+- M3 发布博文原文：「As an agent product designed specifically for M3 and trained together with M3, MiniMax Code can fully leverage M3’s capabilities… making it the preferred agent to pair with MiniMax-M3。」下载入口写的是 `agent.minimaxi.com/download`（[minimax.io/blog/minimax-m3](https://www.minimax.io/blog/minimax-m3)）。
+
+**结论二：同一产品有两张使用面，不要写成两个产品。**
+
+| 使用面 | 官方入口 | 可执行文件 / 安装物 | 文档 |
+|--------|----------|---------------------|------|
+| 桌面端 | [agent.minimaxi.com/download](https://agent.minimaxi.com/download)（国内）、[agent.minimax.io/download](https://agent.minimax.io/download)（海外） | macOS `.dmg` / Windows 安装程序 | `/docs/code/*` |
+| CLI | [cli/quick-start](https://agent.minimaxi.com/docs/cli/quick-start) | 命令 **`mcode`** | `/docs/cli/*` |
+
+CLI 官方定义：「MiniMax Code CLI 是 MiniMax Code 面向开发者工作流的终端入口。它与桌面客户端互为补充」（[cli/features](https://agent.minimaxi.com/docs/cli/features)）。三种 CLI 面：交互式 TUI（`mcode`）、Headless（`mcode exec`）、ACP（`mcode acp`）。
+
+**结论三：适合本站「前端工程师 AI 编程工具」定位。**
+
+依据：桌面端 Coding 模式保留工作区 / Files / Changes / Terminal / 内置浏览器；CLI 读 `AGENTS.md`、可接 Zed 等 ACP 宿主、有 `mcode exec` 进脚本和 CI。目标读者要的是对着本地仓库干活的 Agent，不是聊天陪聊或生视频。
+
+**结论四：文档分两套站点，写作时不要混引。**
+
+- `agent.minimaxi.com/docs/code/*`（中文）/ `agent.minimax.io/docs/code/*`（英文）= 桌面端
+- `agent.minimaxi.com/docs/cli/*` / `agent.minimax.io/docs/cli/*` = CLI
+- `platform.minimaxi.com/docs/guides/text-ai-coding-tools` = 把 **MiniMax-M3** 接到 Claude Code / Cursor / TRAE 等**第三方工具**。这不是 MiniMax Code 产品手册。
+- `platform.minimax.io/docs/guides/models-intro` = 模型目录（M3 / H3 / Speech / Music），不是 Coding Agent。
+
+2026-08-19 抓到的 `agent.minimax.io/docs/llms.txt` **没有列出** `/docs/cli/*`。CLI 页是靠侧栏 / 搜索发现的，维护时不要只扫 llms.txt。
+
+**结论五：易撞名必须写清「不是什么」。**
+
+- **MiniMax Code ≠ MiniMax Agent**。桌面端在 changelog v3.0.33（2026-05-29）「正式更名为 MiniMax Code」；网页通用 Agent 仍在 [agent.minimaxi.com](https://agent.minimaxi.com/)，文档站品牌仍写「MiniMax Agent 文档」。Agent 正文归 #73。
+- **`mcode` ≠ changelog 里的 `minimax` 快捷方式**。CLI 官方命令是 `mcode`。v3.0.33 写的是桌面端「新增 minimax 命令行快捷方式」，没有给出 flag 表。不要把两者合成一条安装命令。
+- **MiniMax Code ≠ 在 Claude Code 里用 M3**。后者是开放平台「通过 AI 编程工具接入」。
+- **Mini-Agent（GitHub `MiniMax-AI/Mini-Agent`）不是本产品**。
+- **Hailuo / 海螺 / MiniMax H3** 是视频生成，不是编程 Agent。
+- **星野 / Talkie** 是角色互动应用，不是编程 Agent。
+- **MiniMax Hub 与 MiniMax Design**：国际站产品名是 MiniMax Design（[design.minimax.io](https://design.minimax.io/)）；中文 About 一级导航和正文仍写 MiniMax Hub（[minimaxi.com/about](https://www.minimaxi.com/about)）。两份官方页打架，并列引用，禁止猜哪个赢。
+
+**结论六：命令 / 包名只抄官方。没有官方 npm 包名。**
+
+CLI 官方安装只有：
+
+```bash
+curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash
+```
+
+```powershell
+irm https://filecdn.minimax.chat/public/install.ps1 | iex
+```
+
+验证：`mcode --version` / `mcode --help`。FAQ 提到安装器会访问 npm registry，**没有**给出 `npm install -g <包名>`。禁止编造包名。
+
+桌面端没有 CLI 安装命令：打开下载页 → 选 arm64 / x64 → macOS 拖进 Applications / Windows 跑安装程序 → MiniMax 账号登录。系统要求：macOS 11 Big Sur+、Windows 10+。
+
+## 基本信息
+
+- 工具名：MiniMax Code（桌面端 + CLI 可执行文件 `mcode`）
+- 官方文档根地址：<https://agent.minimaxi.com/docs/code/welcome>（中文桌面）、<https://agent.minimax.io/docs/code/welcome>（英文桌面）、<https://agent.minimaxi.com/docs/cli/quick-start>（CLI）
+- 发版节奏：桌面 changelog 以 `v3.0.x` 记；2026-08-19 打开的 changelog 头部可见区间到 v3.0.37~v3.0.40（2026-06-08）。不要写死「每几天一版」。
+- 当前覆盖版本：不锁桌面内部版本号。CLI 以读者本机 `mcode --version` 与 `/help` 为准。
+
+## 官方一级导航（产品家族）
+
+> 排轴 A/B 之前先填完。规则见 [`family-completeness.md`](./family-completeness.md)。抓页见 [`official-fetch.md`](./official-fetch.md)。
+
+来源：中文站顶栏 / About（[minimaxi.com](https://www.minimaxi.com/)、[minimaxi.com/about](https://www.minimaxi.com/about)）；国际站顶栏 / 页脚（[minimax.io](https://www.minimax.io/)）；Agent 文档站（[agent.minimaxi.com/docs/llms.txt](https://agent.minimaxi.com/docs/llms.txt)）；开放平台模型页（[platform.minimax.io/docs/guides/models-intro](https://platform.minimax.io/docs/guides/models-intro)）。
+
+| 官方一级入口 | 官方 URL | 本站去向（独立页 / 地图一行 / 缺失） | 不拆页理由（若一行） |
+|--------------|----------|--------------------------------------|----------------------|
+| MiniMax Code | [docs/code/welcome](https://agent.minimaxi.com/docs/code/welcome)、[download](https://agent.minimaxi.com/download) | 独立页（本目录） | — |
+| MiniMax Agent | [agent.minimaxi.com](https://agent.minimaxi.com/) | 地图一行 | 网页通用 Agent；正文归 #73 |
+| MiniMax Design | [design.minimax.io](https://design.minimax.io/) | 地图一行 | 商业内容 / 多模态创作，不是编程 Agent |
+| MiniMax Hub | 中文 About 一级导航仍用此名（[about](https://www.minimaxi.com/about)） | 地图一行 | 与 Design 撞名；不写第二份教程 |
+| MiniMax Audio / 语音 | [minimax.io/audio](https://www.minimax.io/audio) | 地图一行 | 语音与音乐产品 |
+| 星野 | [xingyeai.com](https://www.xingyeai.com/) | 地图一行 | 角色互动社区，非本目录 |
+| Talkie | 国际站 Product 一级（[minimax.io](https://www.minimax.io/)） | 地图一行 | 星野的国际名；专用落地页 URL 未在本次抓到独立文档树 |
+| Hailuo / 海螺 / MiniMax H3 | [hailuoai.video](https://hailuoai.video/)、模型表 [models-intro](https://platform.minimax.io/docs/guides/models-intro) | 地图一行 | 视频生成；非编程 Agent |
+| MiniMax M3 / M2.7 / … | [models-intro](https://platform.minimax.io/docs/guides/models-intro) | 地图一行 | 模型，不是产品教程；机制链 Learn LLM |
+| Token Plan / API / 开放平台 | [platform.minimaxi.com](https://platform.minimaxi.com/)、[platform.minimax.io](https://platform.minimax.io/) | 地图一行 | 开发者平台；把 M3 接到第三方工具走 text-ai-coding-tools |
+| 通过 AI 编程工具接入 | [text-ai-coding-tools](https://platform.minimaxi.com/docs/guides/text-ai-coding-tools) | 地图一行 | 第三方 IDE/CLI 配 M3，不是 MiniMax Code |
+
+易撞名（可执行文件名 ≠ 营销名 / Mode ≠ 同名产品）：见结论五。MiniMax Code 的 Coding / Work 是桌面模式，不是独立产品。CLI 的 Plan Mode 与 Ask / Auto / Full access 是两套开关。
+
+非本站：微信 / 飞书只作为 MiniMax Code 的 IM 连接出现，不写即时通讯产品教程。
+
+## 文档文件结构（Diátaxis）
+
+官方桌面树约 25 页、CLI 另有 quick-start / features / faq，密度够四象限。本站只收 MiniMax Code，同厂其它 AI 产品不拆页。
+
+```
+docs/zh/products/minimax-code/
+├── index.md                      # 🗺️ 学习地图 + Retrieve 家族表
+├── minimax-code.md               # 📘 Tutorial — 桌面安装、第一次任务、CLI `mcode`
+├── minimax-code-cookbook.md      # 🔧 How-to — Agent Team、exec、ACP、API Key
+├── minimax-code-cheatsheet.md    # 📐 Reference — 命令 / slash / 权限 / 数据源
+└── minimax-code-glossary.md      # 📖 Explanation — 撞名、两张脸、模式正交
+docs/products/minimax-code/       # 英文同构
+```
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 + 速查 | 家族表、决策树、两张使用面 | 具体点击步骤 |
+| `minimax-code.md` | Tutorial | 下载 / `mcode` 安装、登录、第一次任务、Coding/Work、工作区 | 完整 flag 表、模型内部 |
+| `minimax-code-cookbook.md` | How-to | Agent Team、headless、ACP、自备 Key | 基础安装 |
+| `minimax-code-cheatsheet.md` | Reference | 命令、slash、权限档、信息源 | 概念散文 |
+| `minimax-code-glossary.md` | Explanation | 是什么 / 不是什么 | 操作步骤 |
+
+跨页顺序：`index` → `minimax-code` → cookbook → cheatsheet → glossary。
+
+## 监控页面
+
+- 桌面 changelog：<https://agent.minimaxi.com/docs/changelog>
+- 桌面欢迎页：<https://agent.minimaxi.com/docs/code/welcome>
+- 桌面下载文档：<https://agent.minimaxi.com/docs/code/get-started/download>
+- CLI 快速开始：<https://agent.minimaxi.com/docs/cli/quick-start>
+- CLI 功能：<https://agent.minimaxi.com/docs/cli/features>
+- 用量 / Token Plan（产品内）：<https://agent.minimaxi.com/docs/code/account/usage>
+- 模型目录：<https://platform.minimax.io/docs/guides/models-intro>
+- 第三方工具接 M3：<https://platform.minimaxi.com/docs/guides/text-ai-coding-tools>
+- 中文 / 国际官网：<https://www.minimaxi.com/>、<https://www.minimax.io/>
+- llms.txt（桌面树；缺 CLI）：<https://agent.minimaxi.com/docs/llms.txt>
+
+## Git 提交 scope
+
+```
+docs(minimax-code): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+1. **两套安装原文不要混。** 桌面是下载页 + `.dmg` / 安装程序；CLI 才是 `filecdn.minimax.chat/public/install.sh`。
+2. **`agent.*.com/docs/llms.txt` 漏 CLI。** 审计家族图时必须再打开 `/docs/cli/quick-start`。
+3. **中英产品名不完全对齐。** 国际站 Design / Talkie / Audio；中文站 Hub / 星野 / 语音。Hub↔Design、星野↔Talkie 只并列，不裁定。
+4. **下载页套餐（Plus / Max / Ultra）≠ Token Plan 美元档。** 2026-08-19 国内下载页见到 ¥49 / ¥119 / ¥469；M3 博文 Token Plan 是 $20 / $50 / $120。不要合成一张价目表。用量页写「具体计费和额度规则以产品内展示为准」。
+5. **`mcode --session` 官方 quick-start 两行示例都没写出 session id**；FAQ 才写「已知 ID 时使用 `mcode --session <id>`」。引用时写清出处。
+6. **CLI 不继承桌面 Browser / Computer Use。** FAQ 原文：这些能力「只有在当前宿主明确提供时才会出现」。
+7. **开放平台 `text-ai-coding-tools` 里的 Grok CLI 包名是 `@vibe-kit/grok-cli`，且标注「不推荐」。** 那是第三方工具接 M3，禁止写进 MiniMax Code 安装节。
+8. **模型内部（MSA、训练数据、benchmark 数字）不写进本站产品教程。** 链 Learn LLM / 官方博文。

--- a/docs/products/minimax-code/index.md
+++ b/docs/products/minimax-code/index.md
@@ -1,0 +1,125 @@
+---
+title: MiniMax Code learning map
+description: MiniMax Code is MiniMax's first-party coding agent. This directory covers Code only. Agent, Hailuo, and Talkie stay as one-line map entries.
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# MiniMax Code learning map
+
+> **MiniMax Code** is MiniMax's first-party coding agent. The international homepage calls it "The coding harness built for MiniMax models" ([minimax.io](https://www.minimax.io/)). The product docs say: "MiniMax Code is a desktop AI Agent app that brings chat, project context, file operations, terminal sessions, browser previews, skills, memory, and automation into one local workspace" ([Welcome](https://agent.minimax.io/docs/code/welcome)).
+>
+> The same product also ships as **MiniMax Code CLI**. The executable is `mcode` ([CLI Quick Start](https://agent.minimax.io/docs/cli/quick-start)). That is not a second product.
+
+## Product family (Retrieve)
+
+List official first-level entries first, then decide what this site writes. Every row comes from the homepage nav, About, footer, or docs index opened on 2026-08-19.
+
+| Official first-level entry | Official URL | This site |
+|----------------------------|--------------|-----------|
+| **MiniMax Code** | [Welcome](https://agent.minimax.io/docs/code/welcome), [Download](https://agent.minimax.io/download), [CLI](https://agent.minimax.io/docs/cli/quick-start) | **Standalone pages** (this directory) |
+| MiniMax Agent | [agent.minimax.io](https://agent.minimax.io/) / [agent.minimaxi.com](https://agent.minimaxi.com/) | One map line. Web general agent; full write-up is [#73](https://github.com/zenHeart/learn-ai/issues/73) |
+| MiniMax Design | [design.minimax.io](https://design.minimax.io/) | One map line. Commercial content, not a coding agent |
+| MiniMax Hub | Still used on the CN About nav ([about](https://www.minimaxi.com/about)) | One map line. Name collision with Design; no second tutorial |
+| MiniMax Audio | [minimax.io/audio](https://www.minimax.io/audio) | One map line. Speech and music |
+| Hailuo / MiniMax H3 | [hailuoai.video](https://hailuoai.video/), [models intro](https://platform.minimax.io/docs/guides/models-intro) | One map line. Video generation |
+| Talkie | International Product nav ([minimax.io](https://www.minimax.io/)) | One map line. Character / companion app |
+| 星野 (Xingye) | [xingyeai.com](https://www.xingyeai.com/) | One map line. CN counterpart of Talkie |
+| MiniMax M3 and other models | [models-intro](https://platform.minimax.io/docs/guides/models-intro) | One map line. Models are not a product tutorial |
+| Token Plan / API | [platform.minimax.io](https://platform.minimax.io/) | One map line. Developer platform |
+| Use MiniMax in AI coding tools | [text-ai-coding-tools](https://platform.minimax.io/docs/guides/text-ai-coding-tools) (CN twin: [minimaxi.com](https://platform.minimaxi.com/docs/guides/text-ai-coding-tools)) | One map line. Point M3 at Claude Code / Cursor. **Not** MiniMax Code |
+
+Sources: [minimax.io](https://www.minimax.io/), [minimaxi.com](https://www.minimaxi.com/), [minimaxi.com/about](https://www.minimaxi.com/about), [agent.minimax.io/docs/llms.txt](https://agent.minimax.io/docs/llms.txt), [models-intro](https://platform.minimax.io/docs/guides/models-intro).
+
+**This directory's job:** MiniMax Code only. Other MiniMax AI products do not get full tutorials here.
+
+**Names that collide:**
+
+- **MiniMax Code ≠ MiniMax Agent.** Changelog v3.0.33 renamed the desktop app to MiniMax Code. The web product is still Agent. The docs site is still branded "MiniMax Agent Docs".
+- **`mcode` ≠ the `minimax` shortcut in that changelog.** The official CLI command is `mcode`.
+- **Putting MiniMax-M3 inside Claude Code ≠ installing MiniMax Code.**
+- **Coding / Work are desktop modes, not products.**
+
+See the [glossary](./minimax-code-glossary.md).
+
+### Decision tree
+
+```
+What do you need?
+├── Edit a local repo / fix bugs / inspect diffs / run commands
+│   └── → MiniMax Code
+│       ├── GUI, browser preview, schedules, phone remote?
+│       │     → Desktop app (download page)
+│       ├── Terminal TUI / scripts / CI / editor ACP?
+│       │     → CLI (`mcode`)
+│       └── Split work across specialist agents?
+│             → Agent Team inside the same product
+├── Long-horizon work in the browser, not necessarily a local repo
+│   └── → MiniMax Agent (#73; not this directory)
+├── Keep Claude Code / Cursor and only swap in MiniMax-M3
+│   └── → Open Platform "AI coding tools" guide, not this product
+├── Video
+│   └── → Hailuo / MiniMax H3 / MiniMax Design
+├── Speech / music
+│   └── → MiniMax Audio
+└── Character chat
+    └── → Talkie (intl) or 星野 (CN)
+```
+
+## Two surfaces
+
+Official CLI docs: the desktop client is for "graphical task management and result review"; the CLI is closer to "repositories, the terminal, scripts, CI, and editors" ([Features](https://agent.minimax.io/docs/cli/features)).
+
+| Surface | Entry | Use when |
+|---------|-------|----------|
+| Desktop | [International download](https://agent.minimax.io/download) / [CN download](https://agent.minimaxi.com/download) | Tasks, workspace, browser, schedules, Remote Control |
+| CLI · TUI | `mcode` | Ongoing repo work in a terminal |
+| CLI · Headless | `mcode exec` | Scripts and CI |
+| CLI · ACP | `mcode acp` | Embed in an ACP host such as Zed |
+
+The desktop app also has Coding / Work **modes** (same agent, different tool exposure). See the [tutorial](./minimax-code.md).
+
+## When it is worth trying
+
+**Try it if**
+
+- You want a first-party agent, not just another model plugged into a third-party tool.
+- You want one desktop workspace for the repo, terminal, browser, skills, and memory.
+- You want `mcode` in the terminal: TUI, `exec`, ACP.
+- You already have a MiniMax account or a Token Plan. The M3 post says: "MiniMax Code can be used with MiniMax Token Plans."
+
+**Wait if**
+
+- You only want MiniMax-M3 inside Claude Code / Cursor — use the [Open Platform guide](https://platform.minimax.io/docs/guides/text-ai-coding-tools).
+- You want the web general agent — that is MiniMax Agent (#73).
+- You want video or character chat — Hailuo / Talkie, not Code.
+- You need a Linux desktop client — official desktop docs list macOS and Windows only. The CLI supports macOS, Windows, common Linux distros, and WSL. Alpine / musl is not supported.
+
+## Learning path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Install | [Tutorial](./minimax-code.md) desktop or CLI install | Send the first task after sign-in |
+| 2. Modes and workspace | Tutorial: Coding / Work, workspace, permissions | Let it edit local code |
+| 3. Workflows | [Cookbook](./minimax-code-cookbook.md) | Agent Team, `mcode exec`, ACP |
+| 4. Look up | [Cheatsheet](./minimax-code-cheatsheet.md) | Commands, slash, permission tiers, official links |
+| 5. Names | [Glossary](./minimax-code-glossary.md) | Code vs Agent, desktop vs CLI, orthogonal modes |
+
+## Feature index
+
+Only capabilities that have official doc pages.
+
+| Capability | One line | Official page |
+|------------|----------|---------------|
+| Coding / Work | Same agent, different tool exposure | [modes](https://agent.minimax.io/docs/code/workflows/modes) |
+| Workspace | Attach a local project directory | [workspace](https://agent.minimax.io/docs/code/workflows/workspace) |
+| Permissions | Confirm file, command, and external actions | [permissions](https://agent.minimax.io/docs/code/workflows/permissions) |
+| Agent Team | Split complex work across specialist agents | [team](https://agent.minimax.io/docs/code/agents/team) |
+| Skills / memory / custom agents | Reuse workflows and keep preferences | [llms.txt desktop tree](https://agent.minimax.io/docs/llms.txt) |
+| Schedules / Remote Control / IM | Recurring jobs, phone remote, chat apps | Desktop `/docs/code/automation/*` |
+| CLI TUI / exec / acp | Terminal, scripts, editors | [features](https://agent.minimax.io/docs/cli/features) |
+| Token Plan and check-in credits | See in-product usage | [usage](https://agent.minimax.io/docs/code/account/usage) |
+
+Model internals (MSA, training, benchmarks) stay out of this directory. See [Learn LLM](/tech/fundamentals/LLM) and the [M3 post](https://www.minimax.io/blog/minimax-m3).

--- a/docs/products/minimax-code/minimax-code-cheatsheet.md
+++ b/docs/products/minimax-code/minimax-code-cheatsheet.md
@@ -1,0 +1,205 @@
+---
+title: MiniMax Code cheatsheet
+description: Lookup only. Commands come from official pages and mcode --help. No unofficial package names.
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# MiniMax Code cheatsheet
+
+Lookup only. Treat `mcode --help` and `mcode <command> --help` as the live CLI contract.
+
+## Install
+
+### Desktop
+
+Source: [Download and Install](https://agent.minimax.io/docs/code/get-started/download)
+
+| Item | Value |
+|------|-------|
+| International | [agent.minimax.io/download](https://agent.minimax.io/download) |
+| Mainland China | [agent.minimaxi.com/download](https://agent.minimaxi.com/download) |
+| macOS | 11 Big Sur or later; `.dmg` → Applications; Apple silicon arm64, Intel x64 |
+| Windows | 10 or later; run the installer |
+| Auth | MiniMax account |
+
+### CLI
+
+Source: [quick-start](https://agent.minimax.io/docs/cli/quick-start)
+
+```bash
+curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash
+```
+
+```powershell
+irm https://filecdn.minimax.chat/public/install.ps1 | iex
+```
+
+```bash
+mcode --version
+mcode --help
+mcode update
+```
+
+<!-- TODO: 待核实 —— no official npm package name. -->
+
+## CLI commands
+
+Source: [Features](https://agent.minimax.io/docs/cli/features)
+
+| Command | Purpose |
+|---------|---------|
+| `mcode [prompt]` | Interactive TUI; optional first task |
+| `mcode init [directory]` | Analyze the repo; create or update `AGENTS.md` |
+| `mcode exec [prompt]` | One headless run |
+| `mcode acp` | ACP stdio server |
+| `mcode login` / `mcode logout` | Auth |
+| `mcode login --region global` | Global account |
+| `mcode provider` | Providers and API keys |
+| `mcode plugin` | Agent plugins |
+| `mcode update` | Update from the current install source |
+| `mcode --continue` | Resume the latest session in this workspace |
+| `mcode --session` | Session manager |
+
+`mcode exec` flags: [cookbook](./minimax-code-cookbook.md).
+
+## CLI keys and slash commands
+
+Source: [quick-start](https://agent.minimax.io/docs/cli/quick-start)
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Send; extra messages queue |
+| `Shift+Enter` | New line |
+| `@` | Reference a file or directory |
+| `Ctrl+V` | Paste an image or video file |
+| `Shift+Tab` | Default ↔ Plan Mode |
+| `Alt+M` | Ask / Auto / Full access |
+| `Ctrl+O` | Expand or collapse Thinking, tool output, diffs |
+| `Ctrl+T` | Expand or collapse the todo list |
+| `PgUp` / `PgDn` / `End` | History / jump to latest |
+| `Esc` | Close a panel or interrupt |
+
+| Slash | Purpose |
+|-------|---------|
+| `/help` | Commands and shortcuts |
+| `/status` | Account, model, runtime |
+| `/model` | Pick a model |
+| `/sessions [query]` | Sessions |
+| `/context` | Context budget and sources |
+| `/compact` | Compact the current thread |
+| `/new` | New session in this project |
+| `/init` | Create or update project instructions |
+| `/quit` | Exit |
+| `/plan` | Plan Mode ([FAQ](https://agent.minimax.io/docs/cli/faq)) |
+| `/permission` | Permission mode (FAQ) |
+| `/goal <goal>` | Pausable goal ([features](https://agent.minimax.io/docs/cli/features)) |
+| `/update` | Update |
+
+## Decision table
+
+| Situation | Choose |
+|-----------|--------|
+| Edit a local repo; need diffs / terminal / browser | Desktop Coding mode |
+| Care about the result, not the implementation | Desktop Work mode |
+| Stay in the terminal | `mcode` |
+| CI / scripts | `mcode exec` |
+| ACP host such as Zed | `mcode acp` |
+| Complex split-and-verify work | Agent Team |
+| Only want M3 inside Claude Code | Open Platform guide, not this product |
+| Web general agent | MiniMax Agent (#73) |
+
+## Permission tiers
+
+Desktop: confirm before risky actions. Keep a human on delete / overwrite / upload / send ([permissions](https://agent.minimax.io/docs/code/workflows/permissions)).
+
+CLI TUI: `Ask` / `Auto` / `Full access` (`Alt+M`). Independent from Plan Mode.
+
+`mcode exec --permission`: `ask` / `smart` / `full` / `off`.
+
+## Usage (only numbers on an official page)
+
+Source: [usage](https://agent.minimax.io/docs/code/account/usage) (checked 2026-08-19)
+
+| Item | Official text |
+|------|----------------|
+| Daily check-in | 400 credits |
+| Streak day 4 and day 7 | 1000 credits that day |
+| Full week | 4000 credits total |
+| Validity | 30 days after credit |
+
+On 2026-08-19 the CN [download page](https://agent.minimaxi.com/download) showed Plus ¥49 / Max ¥119 / Ultra ¥469 per month. The [M3 post](https://www.minimax.io/blog/minimax-m3) Token Plan is Plus $20 / Max $50 / Ultra $120. Do not merge those tables.
+
+<!-- TODO: 待核实 —— no official conversion between desktop plans and Token Plan quotas. -->
+
+## Glossary index
+
+One-line hooks. Definitions: [glossary](./minimax-code-glossary.md).
+
+| Term | Hook |
+|------|------|
+| MiniMax Code | First-party coding agent; desktop + `mcode` |
+| MiniMax Agent | Web general agent; not this product |
+| `mcode` | CLI executable |
+| Coding / Work | Desktop modes |
+| Plan Mode | CLI: plan first or act now |
+| Ask / Auto / Full access | CLI permission tiers |
+| Agent Team | Multi-agent split |
+| Token Plan | Open Platform subscription; usable with Code |
+
+## Sources
+
+Method: repo [`sources/_template.md`](https://github.com/zenHeart/learn-ai/blob/master/.claude/skills/doc-research/references/sources/_template.md). Last systematic check: 2026-08-19.
+
+### Official docs
+
+| URL | Use |
+|-----|-----|
+| [agent.minimax.io/docs/code/welcome](https://agent.minimax.io/docs/code/welcome) | Desktop definition |
+| [agent.minimax.io/docs/code/get-started/download](https://agent.minimax.io/docs/code/get-started/download) | Desktop install |
+| [agent.minimax.io/docs/code/get-started/first-task](https://agent.minimax.io/docs/code/get-started/first-task) | First task |
+| [agent.minimax.io/docs/code/workflows/modes](https://agent.minimax.io/docs/code/workflows/modes) | Coding / Work |
+| [agent.minimax.io/docs/code/workflows/workspace](https://agent.minimax.io/docs/code/workflows/workspace) | Workspace |
+| [agent.minimax.io/docs/code/workflows/permissions](https://agent.minimax.io/docs/code/workflows/permissions) | Desktop permissions |
+| [agent.minimax.io/docs/code/agents/team](https://agent.minimax.io/docs/code/agents/team) | Agent Team |
+| [agent.minimax.io/docs/code/account/usage](https://agent.minimax.io/docs/code/account/usage) | Usage and check-in |
+| [agent.minimax.io/docs/code/account/minimax-api](https://agent.minimax.io/docs/code/account/minimax-api) | Your MiniMax key |
+| [agent.minimax.io/docs/cli/quick-start](https://agent.minimax.io/docs/cli/quick-start) | CLI install |
+| [agent.minimax.io/docs/cli/features](https://agent.minimax.io/docs/cli/features) | TUI / exec / acp |
+| [agent.minimax.io/docs/cli/faq](https://agent.minimax.io/docs/cli/faq) | CLI troubleshooting |
+| [agent.minimax.io/docs/changelog](https://agent.minimax.io/docs/changelog) | Desktop changelog (includes rename) |
+| [agent.minimax.io/docs/llms.txt](https://agent.minimax.io/docs/llms.txt) | Desktop tree (2026-08-19 **omits** CLI) |
+| [platform.minimax.io/docs/guides/models-intro](https://platform.minimax.io/docs/guides/models-intro) | Models |
+| [platform.minimax.io/docs/guides/text-ai-coding-tools](https://platform.minimax.io/docs/guides/text-ai-coding-tools) | Third-party tools + M3 |
+
+CN hosts: `agent.minimaxi.com`, `platform.minimaxi.com`.
+
+### Product homes
+
+| URL | Use |
+|-----|-----|
+| [minimax.io](https://www.minimax.io/) | International first-level products |
+| [minimaxi.com](https://www.minimaxi.com/) | CN homepage |
+| [minimaxi.com/about](https://www.minimaxi.com/about) | CN family wording (still Hub / 星野) |
+| [agent.minimax.io/download](https://agent.minimax.io/download) | Desktop download |
+| [design.minimax.io](https://design.minimax.io/) | MiniMax Design |
+| [hailuoai.video](https://hailuoai.video/) | Hailuo |
+| [xingyeai.com](https://www.xingyeai.com/) | 星野 |
+| [minimax.io/blog/minimax-m3](https://www.minimax.io/blog/minimax-m3) | Code + Token Plan claims |
+
+### Shortcuts for maintainers
+
+| Trick | Note |
+|-------|------|
+| Append `.md` | Mintlify markdown mirrors |
+| `docs/llms.txt` | Desktop only; also open `/docs/cli/quick-start` |
+| `/status` and `mcode --version` | Trust the machine, not a pinned tutorial version |
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./minimax-code.md)
+- [Cookbook](./minimax-code-cookbook.md)
+- [Glossary](./minimax-code-glossary.md)

--- a/docs/products/minimax-code/minimax-code-cookbook.md
+++ b/docs/products/minimax-code/minimax-code-cookbook.md
@@ -1,0 +1,139 @@
+---
+title: MiniMax Code cookbook
+description: Official recipes only: Agent Team, your own API key, headless exec, ACP, check-in credits.
+domain: product
+tags:
+  - coding-agent
+role: cookbook
+---
+
+# MiniMax Code cookbook
+
+Skip around. Install and the first conversation live in the [tutorial](./minimax-code.md). This page is "I need to do X".
+
+## 1. Use Agent Team on a complex task
+
+Source: [Agent Team](https://agent.minimax.io/docs/code/agents/team).
+
+Official text: Agent Team "introduces multiple specialist Agents based on task complexity. You still only describe the goal"; MiniMax Code handles decomposition, assignment, progress, and the summary.
+
+Use it when the work:
+
+- Mixes code, design, docs, and tests
+- Must run for a long time
+- Needs split execution plus verification
+- Needs parallel exploration
+
+Write a clear goal, acceptance bar, and constraints. You can add instructions mid-flight; the official page says Agent Team folds them into later steps.
+
+The M3 post describes a Producer + Verifier loop and multi-day unattended runs ([minimax-m3](https://www.minimax.io/blog/minimax-m3)). Treat that as product language, not an SLA. Queue limits stay on the [team](https://agent.minimax.io/docs/code/agents/team) page and in the app.
+
+Skip Team for a one-file edit.
+
+## 2. Use your own MiniMax API key
+
+Source: [MiniMax API Key](https://agent.minimax.io/docs/code/account/minimax-api).
+
+1. Open usage / model settings.
+2. Choose MiniMax API, paste the key, save.
+3. Run the connection test.
+
+Official warning: do not put the key in chat, a repo, or a public doc. Use the in-product field only.
+
+On the CLI, run `mcode provider` or `mcode provider --help` ([CLI FAQ](https://agent.minimax.io/docs/cli/faq)).
+
+Custom providers (base URL, API format, model name) use [BYOK](https://agent.minimax.io/docs/code/account/byok). Do not merge that flow with the official MiniMax key.
+
+## 3. Run one headless CLI task
+
+Source: [Features](https://agent.minimax.io/docs/cli/features).
+
+`mcode exec` does not start the TUI.
+
+```bash
+mcode exec "Fix the failing tests"
+
+mcode exec \
+  --cwd ./repo \
+  --file error.log \
+  --output-format json \
+  "Analyze the error log, fix the issue, and run the related tests"
+```
+
+Official flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--cwd` | Workspace directory |
+| `--file` | Attachment; repeatable |
+| `--model` | Model for this run only |
+| `--session` / `--continue` | Existing session |
+| `--permission` | `ask`, `smart`, `full`, or `off` |
+| `--timeout` | e.g. `30s`, `2m` |
+| `--max-steps` | Cap assistant steps |
+| `--output-format` | `text`, `json`, or `stream-json` |
+| `--output-schema` | JSON Schema for the final JSON |
+
+Task output goes to `stdout`. Diagnostics go to `stderr`. stdin is read only with explicit `--input -`, so CI does not hang.
+
+## 4. Attach `mcode` to Zed (ACP)
+
+Source: [Features](https://agent.minimax.io/docs/cli/features).
+
+`mcode acp` runs as an ACP v1 agent server over stdin/stdout NDJSON. Official text: no extra HTTP server, and the editor does not need a MiniMax-only plugin.
+
+Zed External Agents example (official):
+
+```json
+{
+  "agent_servers": {
+    "minimax-code": {
+      "type": "custom",
+      "command": "mcode",
+      "args": ["acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+If the editor cannot find the binary, set `command` to the absolute path of `mcode`. Official constraint: `stdout` is protocol-only. Do not type natural language into that stream. Do not let a wrapper log to `stdout`.
+
+Do not invent an official VS Code plugin.
+
+## 5. Usage and check-in credits
+
+Source: [Token Plan and Credits](https://agent.minimax.io/docs/code/account/usage).
+
+The usage page shows plan status, Token Plan validity, credit balance, quotas, and the subscribe / top-up / invoice / check-in entries.
+
+Official check-in numbers on that page:
+
+- Daily check-in: **400** credits
+- Day 4 and day 7 streaks: **1000** credits that day
+- Full week: **4000** credits total
+- Credits expire **30 days** after they land
+
+Same page: "Follow the in-product display for specific billing and quota rules." (CN twin: 「具体计费和额度规则以产品内展示为准。」)
+
+Desktop Plus / Max / Ultra list prices and Open Platform Token Plan USD tiers are **not** one table. See the [cheatsheet](./minimax-code-cheatsheet.md).
+
+## 6. A scheduled task did not run
+
+Source: [desktop FAQ](https://agent.minimax.io/docs/code/help/faq).
+
+Confirm the machine is awake, MiniMax Code is running, and the task is enabled.
+
+The CLI does not host the desktop scheduler. Official FAQ: Browser and Computer Use appear only when the current host actually provides them. Do not assume the CLI has every desktop capability.
+
+## 7. Install failures
+
+| Symptom | Official fix |
+|---------|--------------|
+| `mcode: command not found` | Reopen the terminal; check `PATH`; fully quit VS Code ([CLI FAQ](https://agent.minimax.io/docs/cli/faq)) |
+| Installer fails | Reach the MiniMax file CDN, Node.js.org, and the npm registry; native deps may also hit GitHub. Set `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `NO_PROXY` first |
+| Alpine / musl | Not supported |
+| Windows desktop will not install | OS version, install-path permissions, corporate proxy ([download](https://agent.minimax.io/docs/code/get-started/download)) |
+| Custom model will not connect | Base URL, API key, model name, network, API format ([desktop FAQ](https://agent.minimax.io/docs/code/help/faq)) |
+
+Steps for pointing MiniMax-M3 at Claude Code / Cursor live on [text-ai-coding-tools](https://platform.minimax.io/docs/guides/text-ai-coding-tools). They are not MiniMax Code recipes.

--- a/docs/products/minimax-code/minimax-code-glossary.md
+++ b/docs/products/minimax-code/minimax-code-glossary.md
@@ -1,0 +1,78 @@
+---
+title: MiniMax Code glossary
+description: No procedures. Separate Code, Agent, Hailuo, and Talkie, then desktop, CLI, and the two mode axes.
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# MiniMax Code glossary
+
+No procedures. These names collide. Pick a door on the [learning map](./index.md).
+
+## Everything named MiniMax
+
+| Name | What it is | Where |
+|------|------------|-------|
+| **MiniMax Code** | First-party coding agent. Desktop app + CLI `mcode` | [welcome](https://agent.minimax.io/docs/code/welcome), [download](https://agent.minimax.io/download), [CLI](https://agent.minimax.io/docs/cli/quick-start) |
+| MiniMax Agent | Web general agent. Desktop was renamed to Code; the web product is still Agent | [agent.minimax.io](https://agent.minimax.io/), site issue #73 |
+| MiniMax Design | Commercial content agent platform | [design.minimax.io](https://design.minimax.io/) |
+| MiniMax Hub | Name still used on the CN About nav | [about](https://www.minimaxi.com/about). Same family as Design; no second tutorial |
+| MiniMax Audio | Speech and music | [minimax.io/audio](https://www.minimax.io/audio) |
+| Hailuo / MiniMax H3 | Video brand and model | [hailuoai.video](https://hailuoai.video/) |
+| Talkie | International character product on the Product nav | [minimax.io](https://www.minimax.io/) |
+| 星野 (Xingye) | CN character community | [xingyeai.com](https://www.xingyeai.com/) |
+| MiniMax M3 | Coding / agentic model, 1M context | [models-intro](https://platform.minimax.io/docs/guides/models-intro) |
+| Token Plan | Open Platform subscription | [platform](https://platform.minimax.io/) |
+| AI coding tools guide | Point M3 at Claude Code / Cursor | [text-ai-coding-tools](https://platform.minimax.io/docs/guides/text-ai-coding-tools) |
+
+**Do not write as fact:**
+
+- MiniMax Code is "just the M3 API wrapper".
+- The CLI command is `minimax`. Official CLI command is `mcode`. Changelog v3.0.33's "minimax CLI shortcut" has no standalone flag page.
+- An official npm package name. None found on 2026-08-19.
+- GitHub `MiniMax-AI/Mini-Agent` is MiniMax Code.
+- An official VS Code plugin. Official editor integration is ACP plus a Zed example.
+
+## One product, two faces
+
+Official: "MiniMax Code CLI is the terminal entry for MiniMax Code developer workflows. It complements the desktop client."
+
+| Face | Entry | Typical use |
+|------|-------|-------------|
+| Desktop | Downloadable installer | Graphical tasks, browser, schedules, Remote Control |
+| CLI TUI | `mcode` | Humans editing a repo in a terminal |
+| CLI Headless | `mcode exec` | CI and scripts |
+| CLI ACP | `mcode acp` | Embed in an editor |
+
+The CLI does **not** depend on desktop Electron / IPC. Do not assume Browser or Computer Use exist in the CLI.
+
+## Two orthogonal mode axes
+
+Desktop **Coding / Work**: same agent, different tool exposure. Use Coding to change a repo.
+
+CLI **Plan Mode**: plan the next message or act now. `Shift+Tab` / `/plan`.
+
+CLI **permission mode**: whether tools ask you. `Alt+M` / `/permission` → Ask / Auto / Full access.
+
+`mcode exec --permission` uses `ask` / `smart` / `full` / `off`. That is not the same enum as the TUI labels.
+
+## Agent Team
+
+Official: extra specialist agents appear when the task is complex. You describe the goal; the product splits, assigns, tracks, and summarizes.
+
+This is a MiniMax Code capability, not a separate product, and not the web MiniMax Agent.
+
+## Workspace, skills, memory
+
+- **Workspace**: a local project directory. The agent reads, runs commands, and reports changes there.
+- **Skills**: reusable workflows. The first-task page says you can invoke them with `/`.
+- **Memory**: preferences, project conventions, long-term patterns (standalone desktop docs page).
+- **`AGENTS.md`**: project instructions that `mcode init` creates or updates.
+
+## Accounts and quotas
+
+Sign in with a MiniMax account on the desktop or via `mcode login`. Your own MiniMax API key goes through in-product settings or `mcode provider`.
+
+Token Plan is an Open Platform subscription. The M3 post says Code can use Token Plan. Do not treat desktop Plus / Max / Ultra list prices and Token Plan USD tiers as one price list. Usage page: follow the in-product display.

--- a/docs/products/minimax-code/minimax-code.md
+++ b/docs/products/minimax-code/minimax-code.md
@@ -1,0 +1,201 @@
+---
+title: MiniMax Code tutorial
+description: Install the desktop app from the download page. The official CLI command is mcode. Copy only official install text.
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# MiniMax Code tutorial
+
+> This page goes from install to the first local-repo task. Flags live in the [cheatsheet](./minimax-code-cheatsheet.md), recipes in the [cookbook](./minimax-code-cookbook.md), and names in the [glossary](./minimax-code-glossary.md).
+>
+> MiniMax Code has a desktop face and a CLI face. Official text: it "complements the desktop client" ([CLI Features](https://agent.minimax.io/docs/cli/features)). Install one face first.
+
+## 1. Pick a face
+
+| Where you work | Install | Official entry |
+|----------------|---------|----------------|
+| Window, browser preview, schedules, phone remote | Desktop | [International download](https://agent.minimax.io/download) / [CN download](https://agent.minimaxi.com/download) |
+| Terminal, scripts, CI, editor ACP | CLI (`mcode`) | [CLI Quick Start](https://agent.minimax.io/docs/cli/quick-start) |
+
+You can install both. They are one product.
+
+## 2. Install the desktop app
+
+From [Download and Install](https://agent.minimax.io/docs/code/get-started/download):
+
+> MiniMax Code supports macOS and Windows. After installation, sign in with your MiniMax account to start creating tasks.
+
+| Platform | Requirement |
+|----------|-------------|
+| macOS | macOS 11 Big Sur or later |
+| Windows | Windows 10 or later |
+
+Official steps (same page):
+
+1. Open the download page and pick the package for your device. **Use arm64 for Apple silicon Macs and x64 for Intel Macs.**
+2. On macOS, open the `.dmg` and drag the app into Applications. On Windows, run the installer.
+3. Launch MiniMax Code and sign in with your MiniMax account.
+4. The app notifies you about updates. You can also check from settings.
+
+International build: [agent.minimax.io/download](https://agent.minimax.io/download). Mainland China build: [agent.minimaxi.com/download](https://agent.minimaxi.com/download).
+
+The desktop app has **no** official one-line `curl` installer. Do not use the CLI script in the next section to install the GUI.
+
+## 3. Install the CLI
+
+From [CLI Quick Start](https://agent.minimax.io/docs/cli/quick-start):
+
+> The installer reuses a compatible Node.js installation when available. If your system does not have a compatible version, it installs a self-contained runtime in your user directory. The entire process requires neither `sudo` nor administrator privileges.
+
+::: code-group
+
+```bash [macOS / Linux / WSL]
+curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash
+```
+
+```powershell [Windows PowerShell]
+irm https://filecdn.minimax.chat/public/install.ps1 | iex
+```
+
+:::
+
+Then reopen the terminal:
+
+```bash
+mcode --version
+mcode --help
+```
+
+Official support: macOS, Windows, common Linux distributions, and WSL. **Alpine and other musl-based Linux distributions are not currently supported.**
+
+<!-- TODO: 待核实 —— official docs do not publish an npm package name. The FAQ only says the installer may reach the npm registry. -->
+
+If the command is missing: close and reopen the terminal, then run `mcode --version`. On Windows, a VS Code that was already open can keep a stale `PATH`; quit VS Code entirely ([CLI FAQ](https://agent.minimax.io/docs/cli/faq)).
+
+Update with `mcode update` or `/update` in the TUI.
+
+## 4. Sign in
+
+### Desktop
+
+Sign in with your MiniMax account after launch ([Download](https://agent.minimax.io/docs/code/get-started/download)). For your own API key, see the [cookbook](./minimax-code-cookbook.md).
+
+### CLI
+
+Sign in before using MiniMax-hosted models or a Token Plan ([quick-start](https://agent.minimax.io/docs/cli/quick-start)):
+
+```bash
+mcode login
+```
+
+For a Global account:
+
+```bash
+mcode login --region global
+```
+
+Sign-in finishes in the browser. Back in the TUI, run `/status`. Configure a custom provider or API key with `mcode provider`.
+
+Mainland China accounts use `mcode login`. Global accounts use `mcode login --region global` ([CLI FAQ](https://agent.minimax.io/docs/cli/faq)). Sign out with `mcode logout`.
+
+WSL / SSH callback steps belong on the [CLI FAQ](https://agent.minimax.io/docs/cli/faq). The callback URL contains a temporary credential. Do not paste it into chat or a repo.
+
+## 5. First desktop task
+
+Source: [Create Your First Task](https://agent.minimax.io/docs/code/get-started/first-task).
+
+1. Start from the home composer or create a new task.
+2. Describe the outcome in natural language. Official examples include fixing a bug, building a page, writing a report, or analyzing files.
+3. Attach files, pick a workspace, `@` project files, or `/` a skill.
+4. Keep adding instructions while it runs. Answer permission prompts when they appear.
+
+Official writing tips: state the outcome, not only the process. For code, state the stack, constraints, and how you will accept the work. If the approach is unclear, ask it to plan first.
+
+To edit an existing repo, attach a workspace first. Official text: after you choose a project directory, the agent can read files, run commands, produce artifacts, and report changes in that directory. Pick only the directory that belongs to the task ([Workspace](https://agent.minimax.io/docs/code/workflows/workspace)).
+
+## 6. First CLI task
+
+```bash
+cd /path/to/your/project
+mcode
+```
+
+Or submit on launch:
+
+```bash
+mcode "Inspect the failing tests in this project, fix them, and run the relevant tests to verify the changes"
+```
+
+On a new repo, generate project instructions (officially creates or updates `AGENTS.md`):
+
+```bash
+mcode init .
+```
+
+Include the expected outcome, change boundaries, and validation method ([quick-start](https://agent.minimax.io/docs/cli/quick-start)).
+
+Resume:
+
+```bash
+mcode --continue
+mcode --session
+```
+
+In the TUI, use `/sessions [query]`. The [CLI FAQ](https://agent.minimax.io/docs/cli/faq) says to pass a known session id to `mcode --session`.
+
+<!-- TODO: 待核实 —— the quick-start page repeats `mcode --session` without an id; the FAQ is the source for "known ID". -->
+
+Starter keys (same page):
+
+| Key | Purpose |
+|-----|---------|
+| `Enter` | Send; extra messages queue while a task runs |
+| `Shift+Enter` | New line |
+| `@` | Reference a file or directory |
+| `Shift+Tab` | Default ↔ Plan Mode |
+| `Alt+M` | Ask, Auto, Full access |
+| `Esc` | Close a panel or interrupt |
+
+Starter slash commands: `/help`, `/status`, `/model`, `/sessions`, `/context`, `/compact`, `/new`, `/init`, `/quit`. Treat `/help` as the live list.
+
+## 7. Coding mode or Work mode
+
+Desktop only. Official text: they "use the same Agent capabilities" with different UI and tool exposure ([Modes](https://agent.minimax.io/docs/code/workflows/modes)).
+
+| Situation | Mode |
+|-----------|------|
+| Read or edit a code repo | Coding |
+| Need the terminal, browser, or file panels | Coding |
+| You care about the deliverable, not the implementation | Work |
+| Multi-step work with no local code | Work |
+
+Coding: new features, bug fixes, tests, diffs, web / HTML debugging. Work: docs, research, spreadsheets, writing, office automation.
+
+## 8. Permissions
+
+The desktop app confirms before it ([Permissions](https://agent.minimax.io/docs/code/workflows/permissions)):
+
+- Reads files outside the workspace
+- Modifies or deletes files
+- Runs commands
+- Uses tools with external effects
+- Handles actions that arrived through Remote Control or IM
+
+Official advice: stay conservative on a new project; lower the prompt frequency for familiar low-risk repeats; keep a human in the loop for delete, overwrite, upload, and sending messages.
+
+On the CLI, Plan Mode and permission mode are **separate** ([CLI FAQ](https://agent.minimax.io/docs/cli/faq)):
+
+- Plan Mode: execute the next message or plan first. `Shift+Tab` or `/plan`.
+- Permission mode: how tools are confirmed. `Alt+M` or `/permission` → Ask, Auto, Full access.
+
+`mcode exec` accepts `--permission` with `ask`, `smart`, `full`, or `off` ([features](https://agent.minimax.io/docs/cli/features)). Do not merge the TUI names and the exec names into one enum.
+
+## 9. Next
+
+- Split hard work: [Cookbook · Agent Team](./minimax-code-cookbook.md)
+- Scripts / CI: `mcode exec`
+- Editors: `mcode acp` (official Zed snippet)
+- Lookup: [cheatsheet](./minimax-code-cheatsheet.md)

--- a/docs/zh/products/minimax-code/index.md
+++ b/docs/zh/products/minimax-code/index.md
@@ -1,0 +1,125 @@
+---
+title: MiniMax Code 学习地图
+description: MiniMax Code 是最适配 MiniMax 模型的第一方 Coding Agent。本目录只写 Code。Agent / Hailuo / 星野只在家族表占一行。
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# MiniMax Code 学习地图
+
+> **MiniMax Code** 是 MiniMax 的第一方 Coding Agent。官网原文：「最适配 MiniMax 模型的 Coding Agent」（[minimaxi.com](https://www.minimaxi.com/)）。产品文档原文：「MiniMax Code 是一款桌面端 AI Agent 应用。它把对话、项目工作区、文件操作、终端、浏览器、技能、记忆和自动化任务放在同一个本地工作环境里」（[欢迎使用](https://agent.minimaxi.com/docs/code/welcome)）。
+>
+> 同一产品还有终端入口 **MiniMax Code CLI**，命令是 `mcode`（[CLI 快速开始](https://agent.minimaxi.com/docs/cli/quick-start)）。它不是另一个产品。
+
+## 产品家族（Retrieve）
+
+先对官方一级入口，再决定本站写哪一页。表里每一行都来自 2026-08-19 打开的官网顶栏、About、页脚或文档站，不是搜索摘要。
+
+| 官方一级入口 | 官方 URL | 本站去向 |
+|--------------|----------|----------|
+| **MiniMax Code** | [欢迎使用](https://agent.minimaxi.com/docs/code/welcome)、[下载](https://agent.minimaxi.com/download)、[CLI](https://agent.minimaxi.com/docs/cli/quick-start) | **独立页**（本目录） |
+| MiniMax Agent | [agent.minimaxi.com](https://agent.minimaxi.com/) | 地图一行。网页通用 Agent，正文归 [#73](https://github.com/zenHeart/learn-ai/issues/73) |
+| MiniMax Design | [design.minimax.io](https://design.minimax.io/) | 地图一行。商业内容生产，不是编程 Agent |
+| MiniMax Hub | 中文 About 一级导航仍用此名（[about](https://www.minimaxi.com/about)） | 地图一行。与 Design 撞名，不写第二份教程 |
+| MiniMax Audio / 语音 | [minimax.io/audio](https://www.minimax.io/audio) | 地图一行。语音与音乐 |
+| Hailuo / 海螺 / MiniMax H3 | [hailuoai.video](https://hailuoai.video/)、[模型介绍](https://platform.minimax.io/docs/guides/models-intro) | 地图一行。视频生成，不是编程 Agent |
+| 星野 | [xingyeai.com](https://www.xingyeai.com/) | 地图一行。角色互动社区 |
+| Talkie | 国际站 Product 一级（[minimax.io](https://www.minimax.io/)） | 地图一行。星野的国际名 |
+| MiniMax M3 等模型 | [models-intro](https://platform.minimax.io/docs/guides/models-intro) | 地图一行。模型不是产品教程 |
+| Token Plan / API | [platform.minimaxi.com](https://platform.minimaxi.com/)、[platform.minimax.io](https://platform.minimax.io/) | 地图一行。开发者平台 |
+| 通过 AI 编程工具接入 | [text-ai-coding-tools](https://platform.minimaxi.com/docs/guides/text-ai-coding-tools) | 地图一行。把 M3 接到 Claude Code / Cursor 等，**不是** MiniMax Code |
+
+来源：[minimaxi.com](https://www.minimaxi.com/)、[minimaxi.com/about](https://www.minimaxi.com/about)、[minimax.io](https://www.minimax.io/)、[agent.minimaxi.com/docs/llms.txt](https://agent.minimaxi.com/docs/llms.txt)、[models-intro](https://platform.minimax.io/docs/guides/models-intro)。
+
+**本目录目标：** 只写 MiniMax Code。同厂其它 AI 产品不在这里展开。
+
+**容易撞名：**
+
+- **MiniMax Code ≠ MiniMax Agent。** 桌面端在 changelog v3.0.33 正式更名为 MiniMax Code；网页 Agent 仍在 `agent.minimaxi.com`。文档站品牌仍写「MiniMax Agent 文档」。
+- **`mcode` ≠ changelog 里的 `minimax` 快捷方式。** CLI 官方命令是 `mcode`。
+- **在 Claude Code 里配 MiniMax-M3 ≠ 安装 MiniMax Code。** 前者是开放平台接入指南。
+- **Coding / Work 是桌面模式，不是两个产品。**
+
+细节见 [术语表](./minimax-code-glossary.md)。
+
+### 快速决策：我该用哪个？
+
+```
+我要做什么？
+├── 对着本地仓库写代码 / 改 bug / 看 diff / 跑命令
+│   └── → MiniMax Code
+│       ├── 要图形界面、浏览器预览、定时任务、手机遥控？
+│       │     → 桌面端（下载页）
+│       ├── 要终端 TUI / 脚本 / CI / 编辑器 ACP？
+│       │     → CLI（命令 mcode）
+│       └── 任务要拆给多个专家 Agent？
+│             → 同一产品里的 Agent Team
+├── 在浏览器里做通用长任务，不一定绑本地仓库
+│   └── → MiniMax Agent（#73，本目录不写）
+├── 只要把 MiniMax-M3 接到已经在用的 Claude Code / Cursor
+│   └── → 开放平台「通过 AI 编程工具接入」，不是本产品
+├── 生视频 / 改视频
+│   └── → Hailuo / MiniMax H3 / MiniMax Design
+├── 语音 / 音乐
+│   └── → MiniMax Audio
+└── 角色扮演 / 陪伴
+    └── → 星野（国内）或 Talkie（国际）
+```
+
+## MiniMax Code 的两张使用面
+
+官方 CLI 文档原文：「客户端适合图形化任务管理和结果查看，CLI 更贴近代码仓库、终端、脚本、CI 与编辑器。」（[功能介绍](https://agent.minimaxi.com/docs/cli/features)）
+
+| 使用面 | 入口 | 用在哪 |
+|--------|------|--------|
+| 桌面端 | [国内下载](https://agent.minimaxi.com/download) / [海外下载](https://agent.minimax.io/download) | 任务、工作区、浏览器、定时任务、Remote Control |
+| CLI · TUI | `mcode` | 终端里对着仓库持续对话 |
+| CLI · Headless | `mcode exec` | 脚本、CI |
+| CLI · ACP | `mcode acp` | 被 Zed 等 ACP 宿主嵌入 |
+
+桌面端另有 Coding / Work 两种**模式**（同一套 Agent 能力，界面暴露不同）。见 [教程](./minimax-code.md)。
+
+## 什么时候值得试
+
+**值得试**
+
+- 你要第一方 Agent，而不是只在别的工具里换一个 MiniMax 模型。
+- 你需要桌面端把仓库、终端、浏览器、技能、记忆放在同一工作区。
+- 你需要终端里的 `mcode`：TUI、`exec`、ACP。
+- 你已经有 MiniMax 账号或 Token Plan。M3 博文原文：「MiniMax Code can be used with MiniMax Token Plans。」
+
+**先别急**
+
+- 你只要在已有 Claude Code / Cursor 里调用 M3 —— 走 [开放平台接入](https://platform.minimaxi.com/docs/guides/text-ai-coding-tools)，不要装本产品。
+- 你要的是网页通用 Agent —— 那是 MiniMax Agent（#73）。
+- 你要生视频或角色陪伴 —— Hailuo / 星野，不是 Code。
+- 你需要 Linux 桌面客户端 —— 官方桌面文档只写 macOS 和 Windows。CLI 支持 macOS、Windows、常见 Linux 和 WSL，暂不支持 Alpine / musl。
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 装上能跑 | [教程](./minimax-code.md) 的桌面或 CLI 安装 | 登录后发出第一条任务 |
+| 2. 会选模式和工作区 | [教程](./minimax-code.md) 的 Coding / Work、工作区、权限 | 敢让它改本地代码 |
+| 3. 接进工作流 | [Cookbook](./minimax-code-cookbook.md) | Agent Team、`mcode exec`、ACP |
+| 4. 回查参数 | [速查表](./minimax-code-cheatsheet.md) | 命令、slash、权限档、官方链接 |
+| 5. 理清名字 | [术语表](./minimax-code-glossary.md) | Code vs Agent、桌面 vs CLI、模式正交 |
+
+## 功能速查
+
+下表只列官方文档页里出现的能力。
+
+| 能力 | 一句话 | 官方文档 |
+|------|--------|----------|
+| Coding / Work | 同一套 Agent，开发工具暴露程度不同 | [modes](https://agent.minimaxi.com/docs/code/workflows/modes) |
+| 工作区 | 选本地项目目录，再读文件、跑命令 | [workspace](https://agent.minimaxi.com/docs/code/workflows/workspace) |
+| 权限确认 | 改文件、跑命令、外部工具前先问你 | [permissions](https://agent.minimaxi.com/docs/code/workflows/permissions) |
+| Agent Team | 按复杂度拆给多个专家 Agent | [team](https://agent.minimaxi.com/docs/code/agents/team) |
+| 技能 / 记忆 / 自定义 Agent | 复用流程，沉淀偏好 | [llms.txt 桌面树](https://agent.minimaxi.com/docs/llms.txt) |
+| 定时任务 / Remote Control / IM | 计划执行、手机遥控、微信飞书 Telegram | 桌面 `/docs/code/automation/*` |
+| CLI TUI / exec / acp | 终端、脚本、编辑器 | [features](https://agent.minimaxi.com/docs/cli/features) |
+| Token Plan 与签到积分 | 产品内查看；签到数字见用量页 | [usage](https://agent.minimaxi.com/docs/code/account/usage) |
+
+模型机制（MSA、训练、benchmark）不在本目录展开，见 [Learn LLM](/zh/tech/fundamentals/LLM) 和 [M3 博文](https://www.minimax.io/blog/minimax-m3)。

--- a/docs/zh/products/minimax-code/minimax-code-cheatsheet.md
+++ b/docs/zh/products/minimax-code/minimax-code-cheatsheet.md
@@ -1,0 +1,205 @@
+---
+title: MiniMax Code 速查表
+description: 只查不学。命令以官方页和 mcode --help 为准。没有官方原文的包名不写。
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# MiniMax Code 速查表
+
+只查不学。CLI 完整参数以 `mcode --help` 和 `mcode <command> --help` 为准。
+
+## 安装
+
+### 桌面端
+
+来源：[下载与安装](https://agent.minimaxi.com/docs/code/get-started/download)
+
+| 项 | 值 |
+|----|----|
+| 国内下载 | [agent.minimaxi.com/download](https://agent.minimaxi.com/download) |
+| 海外下载 | [agent.minimax.io/download](https://agent.minimax.io/download) |
+| macOS | 11 Big Sur 及以上；`.dmg` 拖进 Applications；Apple 芯片 arm64，Intel x64 |
+| Windows | 10 及以上；运行安装程序 |
+| 登录 | MiniMax 账号 |
+
+### CLI
+
+来源：[quick-start](https://agent.minimaxi.com/docs/cli/quick-start)
+
+```bash
+curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash
+```
+
+```powershell
+irm https://filecdn.minimax.chat/public/install.ps1 | iex
+```
+
+```bash
+mcode --version
+mcode --help
+mcode update
+```
+
+<!-- TODO: 待核实 —— 官方未公布 npm 包名。 -->
+
+## CLI 命令
+
+来源：[功能介绍](https://agent.minimaxi.com/docs/cli/features)
+
+| 命令 | 用途 |
+|------|------|
+| `mcode [prompt]` | 交互式 TUI，可直接提交第一条任务 |
+| `mcode init [directory]` | 分析仓库，生成或更新 `AGENTS.md` |
+| `mcode exec [prompt]` | 一次 Headless 任务 |
+| `mcode acp` | ACP stdio server |
+| `mcode login` / `mcode logout` | 登录 / 登出 |
+| `mcode login --region global` | Global 账号 |
+| `mcode provider` | Provider 与 API Key |
+| `mcode plugin` | Agent Plugin |
+| `mcode update` | 按当前安装来源更新 |
+| `mcode --continue` | 继续当前工作区最近 Session |
+| `mcode --session` | Session 管理器 |
+
+`mcode exec` 常用 flag 见 [Cookbook](./minimax-code-cookbook.md)。
+
+## CLI 键位与 slash
+
+来源：[quick-start](https://agent.minimaxi.com/docs/cli/quick-start)
+
+| 键 | 作用 |
+|----|------|
+| `Enter` | 发送；运行中再发进队列 |
+| `Shift+Enter` | 换行 |
+| `@` | 引用文件或目录 |
+| `Ctrl+V` | 粘贴剪贴板图片或视频文件 |
+| `Shift+Tab` | Default ↔ Plan Mode |
+| `Alt+M` | Ask / Auto / Full access |
+| `Ctrl+O` | 展开或收起 Thinking、工具输出、Diff |
+| `Ctrl+T` | 展开或收起 Todo |
+| `PgUp` / `PgDn` / `End` | 浏览历史 / 回到最新 |
+| `Esc` | 关面板或中断任务 |
+
+| slash | 用途 |
+|-------|------|
+| `/help` | 命令与快捷键 |
+| `/status` | 账号、模型、运行状态 |
+| `/model` | 选模型 |
+| `/sessions [query]` | Session |
+| `/context` | 上下文预算和来源 |
+| `/compact` | 压缩当前对话 |
+| `/new` | 当前项目新建 Session |
+| `/init` | 生成或更新项目指导 |
+| `/quit` | 退出 |
+| `/plan` | 切换 Plan Mode（[FAQ](https://agent.minimaxi.com/docs/cli/faq)） |
+| `/permission` | 切换权限模式（FAQ） |
+| `/goal <目标>` | 可暂停、可恢复的目标（[features](https://agent.minimaxi.com/docs/cli/features)） |
+| `/update` | 更新 |
+
+## 决策表
+
+| 场景 | 选 |
+|------|----|
+| 改本地仓库、要看 diff / 终端 / 浏览器 | 桌面 Coding 模式 |
+| 只要结果，不看实现细节 | 桌面 Work 模式 |
+| 终端里持续改仓库 | `mcode` |
+| CI / 脚本 | `mcode exec` |
+| Zed 等 ACP 宿主 | `mcode acp` |
+| 复杂、要拆解校验 | Agent Team |
+| 只要在 Claude Code 里用 M3 | 开放平台接入，不是本产品 |
+| 网页通用 Agent | MiniMax Agent（#73） |
+
+## 权限档
+
+桌面：关键操作前确认。官方建议对删除 / 覆盖 / 上传 / 发消息保留人工确认（[permissions](https://agent.minimaxi.com/docs/code/workflows/permissions)）。
+
+CLI TUI：`Ask` / `Auto` / `Full access`（`Alt+M`）。与 Plan Mode 独立。
+
+`mcode exec --permission`：`ask` / `smart` / `full` / `off`。
+
+## 用量（只抄能打开的数字）
+
+来源：[usage](https://agent.minimaxi.com/docs/code/account/usage)（2026-08-19）
+
+| 项 | 官方原文 |
+|----|----------|
+| 每日签到 | 400 积分 |
+| 连续第 4、第 7 天 | 单日 1000 积分 |
+| 一周签满 | 累计 4000 积分 |
+| 有效期 | 到账起 30 天 |
+
+2026-08-19 国内[下载页](https://agent.minimaxi.com/download)展示过 Plus ¥49 / Max ¥119 / Ultra ¥469（每月）。[M3 博文](https://www.minimax.io/blog/minimax-m3) Token Plan 是 Plus $20 / Max $50 / Ultra $120。两套不要合成一张价目表。
+
+<!-- TODO: 待核实 —— 下载页套餐与 Token Plan 的额度换算、是否共享积分池；官方没有给出对照表。 -->
+
+## 术语索引
+
+一行钩子，定义在 [术语表](./minimax-code-glossary.md)。
+
+| 术语 | 钩子 |
+|------|------|
+| MiniMax Code | 第一方 Coding Agent，桌面 + `mcode` |
+| MiniMax Agent | 网页通用 Agent，不是本产品 |
+| `mcode` | CLI 可执行文件名 |
+| Coding / Work | 桌面两种模式 |
+| Plan Mode | CLI：先规划还是直接做 |
+| Ask / Auto / Full access | CLI 权限档 |
+| Agent Team | 多专家拆任务 |
+| Token Plan | 开放平台订阅，可与 Code 共用 |
+
+## 高质量信息源
+
+整理方法见仓库 [`sources/_template.md`](https://github.com/zenHeart/learn-ai/blob/master/.claude/skills/doc-research/references/sources/_template.md)。最后系统核对：2026-08-19。
+
+### 官方文档
+
+| URL | 用途 |
+|-----|------|
+| [agent.minimaxi.com/docs/code/welcome](https://agent.minimaxi.com/docs/code/welcome) | 桌面定义 |
+| [agent.minimaxi.com/docs/code/get-started/download](https://agent.minimaxi.com/docs/code/get-started/download) | 桌面安装 |
+| [agent.minimaxi.com/docs/code/get-started/first-task](https://agent.minimaxi.com/docs/code/get-started/first-task) | 第一次任务 |
+| [agent.minimaxi.com/docs/code/workflows/modes](https://agent.minimaxi.com/docs/code/workflows/modes) | Coding / Work |
+| [agent.minimaxi.com/docs/code/workflows/workspace](https://agent.minimaxi.com/docs/code/workflows/workspace) | 工作区 |
+| [agent.minimaxi.com/docs/code/workflows/permissions](https://agent.minimaxi.com/docs/code/workflows/permissions) | 桌面权限 |
+| [agent.minimaxi.com/docs/code/agents/team](https://agent.minimaxi.com/docs/code/agents/team) | Agent Team |
+| [agent.minimaxi.com/docs/code/account/usage](https://agent.minimaxi.com/docs/code/account/usage) | 用量与签到 |
+| [agent.minimaxi.com/docs/code/account/minimax-api](https://agent.minimaxi.com/docs/code/account/minimax-api) | 自备 MiniMax Key |
+| [agent.minimaxi.com/docs/cli/quick-start](https://agent.minimaxi.com/docs/cli/quick-start) | CLI 安装与第一跑 |
+| [agent.minimaxi.com/docs/cli/features](https://agent.minimaxi.com/docs/cli/features) | TUI / exec / acp |
+| [agent.minimaxi.com/docs/cli/faq](https://agent.minimaxi.com/docs/cli/faq) | CLI 排障 |
+| [agent.minimaxi.com/docs/changelog](https://agent.minimaxi.com/docs/changelog) | 桌面更新（含更名） |
+| [agent.minimaxi.com/docs/llms.txt](https://agent.minimaxi.com/docs/llms.txt) | 桌面文档树（2026-08-19 **不含** CLI） |
+| [platform.minimax.io/docs/guides/models-intro](https://platform.minimax.io/docs/guides/models-intro) | 模型目录 |
+| [platform.minimaxi.com/docs/guides/text-ai-coding-tools](https://platform.minimaxi.com/docs/guides/text-ai-coding-tools) | 第三方工具接 M3 |
+
+英文镜像把主机换成 `agent.minimax.io` / `platform.minimax.io`。
+
+### 官网与产品入口
+
+| URL | 用途 |
+|-----|------|
+| [minimaxi.com](https://www.minimaxi.com/) | 中文官网；Code 定位句 |
+| [minimax.io](https://www.minimax.io/) | 国际站一级产品 |
+| [minimaxi.com/about](https://www.minimaxi.com/about) | 中文家族表述（仍写 Hub / 星野） |
+| [agent.minimaxi.com/download](https://agent.minimaxi.com/download) | 桌面下载（国内） |
+| [design.minimax.io](https://design.minimax.io/) | MiniMax Design |
+| [hailuoai.video](https://hailuoai.video/) | Hailuo |
+| [xingyeai.com](https://www.xingyeai.com/) | 星野 |
+| [minimax.io/blog/minimax-m3](https://www.minimax.io/blog/minimax-m3) | Code 与 Token Plan 产品声明 |
+
+### 效率技巧
+
+| 技巧 | 说明 |
+|------|------|
+| 同路径加 `.md` | Mintlify 文档可抓 Markdown 镜像 |
+| `agent.*/docs/llms.txt` | 只覆盖桌面树，CLI 要另开 `/docs/cli/quick-start` |
+| `/status` 与 `mcode --version` | 查本机账号和二进制，不要死记教程版本号 |
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./minimax-code.md)
+- [Cookbook](./minimax-code-cookbook.md)
+- [术语表](./minimax-code-glossary.md)

--- a/docs/zh/products/minimax-code/minimax-code-cookbook.md
+++ b/docs/zh/products/minimax-code/minimax-code-cookbook.md
@@ -1,0 +1,139 @@
+---
+title: MiniMax Code 实战 Cookbook
+description: 只收官方步骤能覆盖的配方：Agent Team、自备 Key、headless、ACP、签到积分。
+domain: product
+tags:
+  - coding-agent
+role: cookbook
+---
+
+# MiniMax Code 实战 Cookbook
+
+跳着读。安装和第一次对话在 [教程](./minimax-code.md)。这里只写「我要解决 X」。
+
+## 1. 让 Agent Team 拆复杂任务
+
+来源：[Agent Team](https://agent.minimaxi.com/docs/code/agents/team)。
+
+官方：「Agent Team 会根据任务复杂度引入多个专家 Agent 协作。你仍然只需要描述目标，MiniMax Code 会负责拆解任务、分配执行、跟踪进度和汇总结果。」
+
+适合：
+
+- 同时涉及代码、设计、文档、测试
+- 需要长时间运行并持续跟进
+- 需要分工执行和结果校验
+- 需要多个方向并行探索
+
+写法：给出清晰目标、验收标准和限制条件。进行中可以继续补充信息；官方写 Agent Team 会把新要求纳入后续执行。
+
+M3 博文补充过 Producer + Verifier 对抗循环和「可连续跑数天」的产品声明（[minimax-m3](https://www.minimax.io/blog/minimax-m3)）。具体排队策略、并发上限以产品内和 [team](https://agent.minimaxi.com/docs/code/agents/team) 为准，不要把博文修辞抄成操作保证。
+
+简单单文件修改不必开 Team。
+
+## 2. 在 MiniMax Code 里用自己的 MiniMax API Key
+
+来源：[MiniMax API Key](https://agent.minimaxi.com/docs/code/account/minimax-api)。
+
+1. 进入用量与模型相关设置。
+2. 选择 MiniMax API，输入 API Key 并保存。
+3. 使用连接测试确认 Key 可用。
+
+官方 Warning：「不要把 API Key 写进对话正文、代码仓库或公开文档。请只通过产品内的安全配置入口保存。」
+
+CLI 侧用 `mcode provider`，或 `mcode provider --help` 看命令行配置（[CLI FAQ](https://agent.minimaxi.com/docs/cli/faq)）。
+
+自定义供应商（Base URL、API Format、模型名）走 [BYOK](https://agent.minimaxi.com/docs/code/account/byok)，不要和 MiniMax 官方 Key 混成同一步。
+
+## 3. 用 CLI 跑一次 Headless 任务
+
+来源：[功能介绍](https://agent.minimaxi.com/docs/cli/features)。
+
+`mcode exec` 不启动 TUI。
+
+```bash
+mcode exec "修复失败的测试"
+
+mcode exec \
+  --cwd ./repo \
+  --file error.log \
+  --output-format json \
+  "分析错误日志，修复问题并运行相关测试"
+```
+
+官方参数：
+
+| 参数 | 用途 |
+|------|------|
+| `--cwd` | 指定工作区目录 |
+| `--file` | 添加附件，可重复 |
+| `--model` | 仅本次指定模型 |
+| `--session` / `--continue` | 在已有 Session 中跑 |
+| `--permission` | `ask`、`smart`、`full` 或 `off` |
+| `--timeout` | 如 `30s`、`2m` |
+| `--max-steps` | 限制 Assistant 步数 |
+| `--output-format` | `text`、`json` 或 `stream-json` |
+| `--output-schema` | 用 JSON Schema 校验最终 JSON |
+
+机器输出写 `stdout`，诊断写 `stderr`。只有显式 `--input -` 时才读标准输入，避免 CI 空等。
+
+## 4. 把 `mcode` 接到 Zed（ACP）
+
+来源：[功能介绍](https://agent.minimaxi.com/docs/cli/features)。
+
+`mcode acp` 作为 ACP v1 Agent server，经 `stdin/stdout` 传 NDJSON。官方说不需要额外 HTTP 服务，也不要求编辑器安装 MCode 专用插件。
+
+Zed External Agents 示例（官方原文）：
+
+```json
+{
+  "agent_servers": {
+    "minimax-code": {
+      "type": "custom",
+      "command": "mcode",
+      "args": ["acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+编辑器找不到命令时，把 `command` 改成 `mcode` 的绝对路径。官方约束：`mcode acp` 的 `stdout` 只用于协议消息，不要直接往里打自然语言，也不要让包装脚本把日志写进 `stdout`。
+
+其它 ACP 宿主没有官方逐步截图时，不要编「官方 VS Code 插件」。
+
+## 5. 看用量和签到积分
+
+来源：[Token Plan 与积分](https://agent.minimaxi.com/docs/code/account/usage)。
+
+设置的用量页可看：当前订阅、Token Plan 有效期、积分余额、用量额度、订阅 / 充值 / 发票 / 签到入口。
+
+官方签到数字（同一页）：
+
+- 每日签到 **400 积分**
+- 连续第 4 天、第 7 天单日 **1000 积分**
+- 完成一周累计 **4000 积分**
+- 自到账之日起 **30 天内**有效
+
+同一页最后一句：「具体计费和额度规则以产品内展示为准。」
+
+下载页上的 Plus / Max / Ultra 月费和开放平台 Token Plan 美元档**不是同一张表**。不要在配方里合并报价。见 [速查表](./minimax-code-cheatsheet.md)。
+
+## 6. 定时任务不跑时先查这三件事
+
+来源：[桌面 FAQ](https://agent.minimaxi.com/docs/code/help/faq)。
+
+「请确认电脑处于唤醒状态、MiniMax Code 正在运行，并且任务处于启用状态。」
+
+CLI 没有桌面那套定时任务宿主。FAQ 原文：Browser、Computer Use「只有在当前宿主明确提供时才会出现；不能仅因为桌面端支持就假定 CLI 环境也支持。」
+
+## 7. 常见安装翻车
+
+| 症状 | 官方处理 |
+|------|----------|
+| `mcode: command not found` | 重开终端；查 `PATH`；VS Code 要整进程退出（[CLI FAQ](https://agent.minimaxi.com/docs/cli/faq)） |
+| 安装失败 | 确认能访问 MiniMax 文件 CDN、Node.js 官网、npm registry；原生依赖还可能访问 GitHub。代理先设 `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `NO_PROXY` |
+| Alpine / musl | 官方暂不支持 |
+| Windows 桌面装不上 | 查系统版本、安装路径权限、企业代理（[download](https://agent.minimaxi.com/docs/code/get-started/download)） |
+| 自定义模型连不上 | 查 Base URL、API Key、模型名、网络、API Format（[桌面 FAQ](https://agent.minimaxi.com/docs/code/help/faq)） |
+
+把 MiniMax-M3 接到 Claude Code / Cursor 的步骤在 [text-ai-coding-tools](https://platform.minimaxi.com/docs/guides/text-ai-coding-tools)，不要写进本页当 MiniMax Code 配方。

--- a/docs/zh/products/minimax-code/minimax-code-glossary.md
+++ b/docs/zh/products/minimax-code/minimax-code-glossary.md
@@ -1,0 +1,78 @@
+---
+title: MiniMax Code 术语表
+description: 不教操作。先分清 Code / Agent / Hailuo / 星野，再分清桌面、CLI 和两种模式。
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# MiniMax Code 术语表
+
+不教操作，只解释这些名字为什么容易撞车。选哪张门看 [学习地图](./index.md)。
+
+## 都叫 MiniMax 的东西
+
+| 名字 | 是什么 | 在哪 |
+|------|--------|------|
+| **MiniMax Code** | 第一方 Coding Agent。桌面应用 + CLI `mcode` | [welcome](https://agent.minimaxi.com/docs/code/welcome)、[download](https://agent.minimaxi.com/download)、[CLI](https://agent.minimaxi.com/docs/cli/quick-start) |
+| MiniMax Agent | 网页通用 Agent。changelog 里桌面端已更名为 Code，网页产品仍叫 Agent | [agent.minimaxi.com](https://agent.minimaxi.com/)，本站 #73 |
+| MiniMax Design | 商业内容生产 Agent 平台 | [design.minimax.io](https://design.minimax.io/) |
+| MiniMax Hub | 中文 About 一级导航仍用的名字 | [about](https://www.minimaxi.com/about)。与 Design 对账，不另开教程 |
+| MiniMax Audio | 语音与音乐产品 | [minimax.io/audio](https://www.minimax.io/audio) |
+| Hailuo / 海螺 / MiniMax H3 | 视频生成品牌与模型 | [hailuoai.video](https://hailuoai.video/) |
+| 星野 | 国内角色互动应用 | [xingyeai.com](https://www.xingyeai.com/) |
+| Talkie | 国际站 Product 一级里的角色产品 | [minimax.io](https://www.minimax.io/) |
+| MiniMax M3 | Coding / Agentic 模型，1M 上下文 | [models-intro](https://platform.minimax.io/docs/guides/models-intro) |
+| Token Plan | 开放平台订阅 | [platform](https://platform.minimax.io/) |
+| 通过 AI 编程工具接入 | 把 M3 接到 Claude Code / Cursor 等 | [text-ai-coding-tools](https://platform.minimaxi.com/docs/guides/text-ai-coding-tools) |
+
+**不要当事实写：**
+
+- 把 MiniMax Code 写成「只是 M3 的 API 包装」。
+- 把 `minimax` 当成 CLI 主命令。官方 CLI 命令是 `mcode`。changelog v3.0.33 的「minimax 命令行快捷方式」没有独立 flag 页。
+- 官方 npm 包名。2026-08-19 找不到原文。
+- Mini-Agent（`MiniMax-AI/Mini-Agent`）等于 MiniMax Code。
+- 官方 VS Code 插件。编辑器集成官方只给了 ACP + Zed 示例。
+
+## 一个产品，两张脸
+
+官方：「MiniMax Code CLI 是 MiniMax Code 面向开发者工作流的终端入口。它与桌面客户端互为补充。」
+
+| 脸 | 入口 | 典型用途 |
+|----|------|----------|
+| 桌面 | 下载页安装包 | 图形任务、浏览器、定时任务、Remote Control |
+| CLI TUI | `mcode` | 人在终端里改仓库 |
+| CLI Headless | `mcode exec` | CI、脚本 |
+| CLI ACP | `mcode acp` | 嵌进编辑器 |
+
+CLI **不依赖**桌面 Electron / IPC。桌面有的 Browser / Computer Use，不能假定 CLI 里一定有。
+
+## 模式是两套正交开关
+
+桌面 **Coding / Work**：同一套 Agent，开发工具露多少不同。改仓库用 Coding。
+
+CLI **Plan Mode**：下一条消息先规划还是直接做。`Shift+Tab` / `/plan`。
+
+CLI **权限模式**：工具要不要问你。`Alt+M` / `/permission` → Ask / Auto / Full access。
+
+`mcode exec --permission` 用 `ask` / `smart` / `full` / `off`。和 TUI 档名不是同一张枚举，不要合并成一列。
+
+## Agent Team
+
+官方：按任务复杂度引入多个专家 Agent；你只描述目标，产品负责拆解、分配、跟踪、汇总。
+
+它是 MiniMax Code 里的能力，不是独立产品，也不是网页 MiniMax Agent。
+
+## 工作区、技能、记忆
+
+- **工作区**：本地项目目录。Agent 在该目录内读文件、跑命令、汇报变更。
+- **技能**：可复用工作流。输入框可用 `/` 调用（桌面第一次任务页）。
+- **记忆**：沉淀偏好、项目约定、长期经验（桌面文档树有独立页）。
+- **`AGENTS.md`**：`mcode init` 会生成或更新的项目指导。
+
+## 账号与额度
+
+MiniMax 账号登录桌面或 `mcode login`。自备 MiniMax API Key 走产品内设置或 `mcode provider`。
+
+Token Plan 是开放平台订阅；M3 博文写 Code 可以用 Token Plan。下载页 Plus / Max / Ultra 与 Token Plan 美元档不要当成同一价目。用量页：「具体计费和额度规则以产品内展示为准。」

--- a/docs/zh/products/minimax-code/minimax-code.md
+++ b/docs/zh/products/minimax-code/minimax-code.md
@@ -1,0 +1,207 @@
+---
+title: MiniMax Code 教程
+description: 桌面端从下载页安装；CLI 官方命令是 mcode。两条通道都只抄官方原文。
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# MiniMax Code 教程
+
+> 本页带你从安装走到第一次对着本地仓库干活。参数清单见 [速查表](./minimax-code-cheatsheet.md)，场景配方见 [Cookbook](./minimax-code-cookbook.md)，名字辨析见 [术语表](./minimax-code-glossary.md)。
+>
+> MiniMax Code 有桌面端和 CLI 两张脸。官方原文：「它与桌面客户端互为补充」（[CLI 功能介绍](https://agent.minimaxi.com/docs/cli/features)）。先选一张脸装完，再学另一张。
+
+## 1. 先选哪张脸
+
+| 你在哪干活 | 装什么 | 官方入口 |
+|------------|--------|----------|
+| 要窗口、浏览器预览、定时任务、手机遥控 | 桌面端 | [国内下载](https://agent.minimaxi.com/download) / [海外下载](https://agent.minimax.io/download) |
+| 要终端、脚本、CI、编辑器 ACP | CLI（`mcode`） | [CLI 快速开始](https://agent.minimaxi.com/docs/cli/quick-start) |
+
+两张都可以装。它们不是两个产品。
+
+## 2. 安装桌面端
+
+原文来自 [下载与安装](https://agent.minimaxi.com/docs/code/get-started/download)：
+
+> MiniMax Code 支持 macOS 和 Windows。安装完成后，使用 MiniMax 账号登录即可开始创建任务。
+
+| 平台 | 要求 |
+|------|------|
+| macOS | macOS 11 Big Sur 及以上 |
+| Windows | Windows 10 及以上 |
+
+官方步骤（同一页）：
+
+1. 打开下载页，选择与设备匹配的安装包。**Apple 芯片 Mac 选 arm64，Intel Mac 选 x64。**
+2. macOS 打开 `.dmg` 并拖入 Applications；Windows 运行安装程序并按提示完成。
+3. 启动 MiniMax Code，使用 MiniMax 账号登录。
+4. 后续有新版本时应用会提示更新；也可以在设置中手动检查。
+
+国内版：[agent.minimaxi.com/download](https://agent.minimaxi.com/download)。海外版：[agent.minimax.io/download](https://agent.minimax.io/download)。
+
+官方 Note：「如果 Windows 安装或启动遇到问题，请先确认系统版本、安装路径权限和企业网络代理设置。」
+
+桌面端**没有**官方一键 `curl` 安装命令。不要把下一节的 CLI 脚本拿来装桌面应用。
+
+## 3. 安装 CLI
+
+原文来自 [CLI 快速开始](https://agent.minimaxi.com/docs/cli/quick-start)：
+
+> 安装器会优先复用兼容的 Node.js；本机没有兼容版本时，会在用户目录中安装独立运行时。整个过程不需要 `sudo` 或管理员权限。
+
+::: code-group
+
+```bash [macOS / Linux / WSL]
+curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash
+```
+
+```powershell [Windows PowerShell]
+irm https://filecdn.minimax.chat/public/install.ps1 | iex
+```
+
+:::
+
+安装完成后，重新打开终端：
+
+```bash
+mcode --version
+mcode --help
+```
+
+官方范围：macOS、Windows、常见 Linux 发行版和 WSL。**暂不支持 Alpine / musl Linux。**
+
+<!-- TODO: 待核实 —— 官方未给出 npm 包名。FAQ 只说安装器可能访问 npm registry，没有 `npm install -g …` 原文。 -->
+
+找不到命令时：先关终端再开，再跑 `mcode --version`。Windows 上已经打开的 VS Code 可能保留旧 `PATH`，需要完整退出 VS Code，而不是只新建终端标签（[CLI FAQ](https://agent.minimaxi.com/docs/cli/faq)）。
+
+更新：`mcode update`，或在 TUI 里 `/update`。
+
+## 4. 登录
+
+### 桌面端
+
+启动后用 MiniMax 账号登录（[下载与安装](https://agent.minimaxi.com/docs/code/get-started/download)）。自备 Key 走设置里的 MiniMax API，见 [Cookbook](./minimax-code-cookbook.md)。
+
+### CLI
+
+使用官方模型或 Token Plan 前先登录（[quick-start](https://agent.minimaxi.com/docs/cli/quick-start)）：
+
+```bash
+mcode login
+```
+
+Global 账号：
+
+```bash
+mcode login --region global
+```
+
+登录在浏览器中完成。回到终端后，在 TUI 里跑 `/status` 检查账号、模型与运行状态。自定义 Provider 或 API Key 用 `mcode provider`。
+
+中国大陆账号跑 `mcode login`，Global 账号跑 `mcode login --region global`（[CLI FAQ](https://agent.minimaxi.com/docs/cli/faq)）。登出：`mcode logout`。
+
+WSL / SSH 回调步骤只抄 [CLI FAQ](https://agent.minimaxi.com/docs/cli/faq)，不要在本页展开。回调 URL 含临时凭证，不要发进聊天或仓库。
+
+## 5. 第一次任务：桌面端
+
+来源：[创建第一个任务](https://agent.minimaxi.com/docs/code/get-started/first-task)。
+
+1. 左侧导航点新建任务，或直接在首页输入框开始。
+2. 用自然语言说明要完成的事。官方举例：修复 bug、实现页面、整理报告、分析文件。
+3. 可以拖入文件、选择工作区、用 `@` 引用项目文件，或用 `/` 调用技能。
+4. Agent 开始执行后继续补充要求；需要权限确认时再选。
+
+官方写任务的建议：
+
+- 说明目标结果，而不只是说明过程。
+- 对代码任务，说明期望技术栈、限制条件和验收方式。
+- 还不确定方案时，先让它进入规划讨论，再决定是否执行。
+
+需要改已有仓库时，先绑工作区。官方：「选择项目目录后，Agent 可以在该目录内读取文件、执行命令、生成产物并汇报变更。」只选与任务相关的目录（[工作区](https://agent.minimaxi.com/docs/code/workflows/workspace)）。
+
+## 6. 第一次任务：CLI
+
+```bash
+cd /path/to/your/project
+mcode
+```
+
+启动时直接提交：
+
+```bash
+mcode "检查当前项目中失败的测试，修复后运行相关测试验证"
+```
+
+第一次进仓库可以先生成项目指导（官方会写或更新 `AGENTS.md`）：
+
+```bash
+mcode init .
+```
+
+官方建议任务里同时写期望结果、修改边界和验证方式（[quick-start](https://agent.minimaxi.com/docs/cli/quick-start)）。
+
+继续上次：
+
+```bash
+mcode --continue
+mcode --session
+```
+
+TUI 内用 `/sessions [query]` 搜索和管理。已知 Session ID 时，[CLI FAQ](https://agent.minimaxi.com/docs/cli/faq) 写的是 `mcode --session` 加上该 ID。
+
+<!-- TODO: 待核实 —— quick-start 里两条 `mcode --session` 示例都没有写出 session id；以 FAQ 的「已知 ID」表述为准，不要补造 flag。 -->
+
+入门键位（同一页）：
+
+| 操作 | 用途 |
+|------|------|
+| `Enter` | 发送；任务运行中再发会进等待队列 |
+| `Shift+Enter` | 换行 |
+| `@` | 引用工作区文件或目录 |
+| `Shift+Tab` | Default 与 Plan Mode 之间切换 |
+| `Alt+M` | Ask、Auto、Full access 之间切换 |
+| `Esc` | 关面板，或中断正在跑的任务 |
+
+常用 slash：`/help`、`/status`、`/model`、`/sessions`、`/context`、`/compact`、`/new`、`/init`、`/quit`。完整集合以 TUI 里 `/help` 为准。
+
+## 7. Coding 模式还是 Work 模式
+
+只存在于**桌面端**。官方原文：「它们使用同一套 Agent 能力，但界面和工具暴露程度不同。」（[Coding 与 Work 模式](https://agent.minimaxi.com/docs/code/workflows/modes)）
+
+| 场景 | 推荐模式 |
+|------|----------|
+| 需要读取或修改代码仓库 | Coding |
+| 需要打开终端、浏览器或文件面板 | Coding |
+| 主要关注结果，不关心实现细节 | Work |
+| 任务跨多个步骤但不涉及本地代码 | Work |
+
+Coding 适合：开发新功能、修 bug、跑测试和命令、审查 diff、调试网页或 HTML。Work 适合：文档、研究、表格、内容创作、日常办公自动化。
+
+## 8. 权限：先确认再改机器
+
+桌面端（[权限与安全确认](https://agent.minimaxi.com/docs/code/workflows/permissions)）会在这些操作前确认：
+
+- 读取工作区外的文件
+- 修改或删除文件
+- 执行命令
+- 使用可能产生外部影响的工具
+- 处理远程控制或 IM 入口发来的操作
+
+官方建议：第一次用某个项目时保持较保守的授权；熟悉的低风险重复操作可以降低确认频率；对删除、覆盖、上传、发送消息保留人工确认。
+
+CLI 里权限模式与 Plan Mode **不是同一开关**（[CLI FAQ](https://agent.minimaxi.com/docs/cli/faq)）：
+
+- Plan Mode：下一条消息是直接执行还是先规划。`Shift+Tab` 或 `/plan`。
+- 权限模式：工具操作如何确认。`Alt+M` 或 `/permission`，档位是 Ask、Auto、Full access。
+
+`mcode exec` 可用 `--permission`，官方列出的值是 `ask`、`smart`、`full` 或 `off`（[features](https://agent.minimaxi.com/docs/cli/features)）。TUI 档名和 exec 档名不要混写成一张表的同一列。
+
+## 9. 接下来做什么
+
+- 复杂任务拆给多个 Agent：[Cookbook · Agent Team](./minimax-code-cookbook.md)
+- 脚本 / CI：`mcode exec`
+- 编辑器：`mcode acp`（官方给了 Zed 配置）
+- 回查命令：[速查表](./minimax-code-cheatsheet.md)


### PR DESCRIPTION
Closes #72

## Summary

First-party MiniMax Code handbook (ZH + EN). Retrieve family table lives on the ZH map: `docs/zh/products/minimax-code/index.md`.

MiniMax Code is a desktop + CLI coding agent (`mcode`). It is suitable for this site: local workspace, diffs/terminal/browser, `mcode exec` / ACP. Same-vendor Agent / Hailuo / 星野 stay one map line each (Agent body is #73).

**Not in this PR (explicit task override):** no `products-gallery.js`, no sidebar, no `config.mjs`.

## Official install (copied, not invented)

Desktop ([download docs](https://agent.minimaxi.com/docs/code/get-started/download)):
- CN https://agent.minimaxi.com/download · intl https://agent.minimax.io/download
- macOS 11 Big Sur+ / Windows 10+
- Apple silicon arm64, Intel x64; `.dmg` → Applications or Windows installer
- Sign in with MiniMax account

CLI ([quick-start](https://agent.minimaxi.com/docs/cli/quick-start)):

```bash
curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash
```

```powershell
irm https://filecdn.minimax.chat/public/install.ps1 | iex
```

```bash
mcode --version
mcode --help
```

No official npm package name found — marked `<!-- TODO: 待核实 -->`.

## Files

- `.claude/skills/doc-research/references/minimax-code.md` (family research first)
- `docs/zh/products/minimax-code/` and `docs/products/minimax-code/` (index + tutorial + cookbook + cheatsheet + glossary)
- Path is flattened `docs/products/minimax-code/`, not `ai-coding/`