### PR TITLE
docs(glm-coding): add GLM Coding Plan handbook (ZH+EN)

### DIFF
--- a/.claude/skills/doc-research/references/glm-coding.md
+++ b/.claude/skills/doc-research/references/glm-coding.md
@@ -1,0 +1,143 @@
+# GLM Coding Plan 维护参考
+
+> 通用维护流程见 [`maintenance-workflow.md`](./maintenance-workflow.md)；高质量数据源清单发布在 `docs/zh/products/glm-coding/glm-coding-cheatsheet.md` 的「高质量信息源」。架构见 [`documentation-architecture.md`](./documentation-architecture.md)。
+
+## 产品形态调研结论（写教程前必须先有这一节）
+
+调研时间：2026-08-19。以下每条都来自一手官方来源，来源标在括号里。
+
+**结论一：GLM Coding Plan 是订阅套餐，不是聊天产品，也不是智谱第一方编码 Agent。**
+
+- `docs.bigmodel.cn/cn/coding-plan/overview` 原文：「GLM Coding Plan 是专为 AI 编码打造的订阅套餐」。
+- 本站正文只写：买套餐 → 拿专属 Key → 接到官方指定工具。不要写成「又一个 Claude.ai / 清言」。
+- 一键装载入口是 Coding Tool Helper：`npx @z_ai/coding-helper`（[coding-tool-helper](https://docs.bigmodel.cn/cn/coding-plan/extension/coding-tool-helper)）。npm 包名必须写成 `@z_ai/coding-helper`，不要猜 `@zai/` 或 `@zhipu/`。
+
+**结论二：额度只在官方指定工具里生效。错端点 / 自建应用走标准 API，不吃套餐。**
+
+- overview / usage-notes / FAQ 同一口径：仅限 [指定工具与产品环境](https://docs.bigmodel.cn/cn/coding-plan/tool/others#%E4%B8%80%E3%80%81%E9%80%82%E7%94%A8%E5%B7%A5%E5%85%B7)。
+- FAQ 原文：在自建应用、网站、机器人、SaaS 里调模型，用标准 API 并按协议计费。
+- 额度耗尽后等下一个 5 小时周期，**不会**继续扣资源包 / 账户余额（overview、FAQ）。
+- 报错 `1113 余额不足` 或扣账户余额：几乎总是工具不在名单里，或 Base URL 配成了标准 API。
+
+**结论三：国内站与海外站是两套域名、两套端点，不要混引。**
+
+| 区域 | 文档 | 订阅 / 控制台 | Anthropic | OpenAI Compatible |
+|------|------|---------------|-----------|-------------------|
+| 国内 | `docs.bigmodel.cn/cn/coding-plan/*` | `bigmodel.cn` / `open.bigmodel.cn` | `https://open.bigmodel.cn/api/anthropic` | `https://open.bigmodel.cn/api/coding/paas/v4` |
+| 海外 | `docs.z.ai/devpack/*` | `z.ai` | `https://api.z.ai/api/anthropic` | `https://api.z.ai/api/coding/paas/v4` |
+
+- Helper 国内命令：`coding-helper auth glm_coding_plan_china <token>`。
+- Helper 海外命令：`coding-helper auth glm_coding_plan_global <token>`。
+- 海外另有 OpenAI Responses：`https://api.z.ai/api/v1`（[docs.z.ai/devpack/tool/others](https://docs.z.ai/devpack/tool/others)）。国内 `latest-model` 给 Codex 的是 `https://open.bigmodel.cn/api/v1`；**国内适用工具卡未列入 Codex**，写正文时不要把 Codex 塞进国内指定工具名单。
+
+**结论四：Helper 自动装载的工具 ≠ 套餐适用工具全集。**
+
+Helper 当前只自动装：**Claude Code / OpenCode / Crush / Factory Droid**。Cursor、Cline、TRAE、ZCode 等在 `tool/others` 有接入页，但要按各工具页手配。Cursor **不在** Helper 列表里。
+
+国内 Coding Agent 名单（[tool/others](https://docs.bigmodel.cn/cn/coding-plan/tool/others)，2026-08-19）：Claude Code、Claude for IDE、OpenCode、ZCode、TRAE、CodeBuddy、Lingma、Qoder、Kilo、MonkeyCode、Cline、Droid、Roo、Crush、Goose、Cursor。
+
+国内通用 Agent（次级调度 / 尽力交付）：OpenClaw、Cherry Studio、Hermes Agent。
+
+海外名单与国内不完全相同（多 Codex / Pi / Eigent / SillyTavern，少 Lingma / CodeBuddy / Cherry Studio 等）。两站各抄各的表。
+
+**结论五：官方页之间会打架。以 overview + latest-model 为套餐事实源，工具页只当该工具的配置原文。**
+
+| 事实 | 以谁为准 | 滞后页 |
+|------|----------|--------|
+| 当前可用模型 | overview / FAQ：所有套餐 **GLM-5.3**、GLM-5-Turbo、GLM-4.7；调用 GLM-5.2/5.1 自动切到 5.3 | `tool/claude` FAQ 仍写 GLM-4.7 默认映射；`tool/cursor` 示例仍是 `GLM-5.2`；海外 Cursor 页示例仍是 `GLM-4.7` |
+| 个人积分与抵扣系数 | overview（模型行是 GLM-5.3） | team.md 抵扣表仍写 GLM-5.2 |
+| 团队积分 | team.md：标准版 15,000 / 66,000；高级版 35,000 / 155,000 | — |
+| Cursor 资格与模型写法 | 该区域的 `tool/cursor` 原文 | 不要把国内「高级会员」和海外「Cursor Pro and higher」合成一句 |
+
+**结论六：同厂其它 AI 产品本目录不写正文。**
+
+智谱一级产品来自 [zhipuai.cn](https://www.zhipuai.cn/) 顶栏 / 页脚「产品」：z.ai、AutoClaw、智谱清言、AutoGLM、Zread.ai、AMiner，另有智谱学习中心、智谱AI输入法。MaaS 入口是 Bigmodel。清言 / Z.ai 正文归 #74。非 AI 或非本站读者对象标「非本站」。
+
+## 基本信息
+
+- 工具名：GLM Coding Plan（国内亦称 GLM 编码套餐 / 编程套餐）
+- 官方文档根：<https://docs.bigmodel.cn/cn/coding-plan/overview>（国内）、<https://docs.z.ai/devpack/overview>（海外）
+- 订阅落地页：<https://bigmodel.cn/glm-coding>、<https://open.bigmodel.cn/glm-coding>、<https://z.ai/subscribe>
+- 发版节奏：模型与积分表会改；不要写死人民币价。刊例价只链官方订阅页。海外 overview 可引用原文 “Starting at just 18 USD per month”。
+- 当前覆盖：2026-08-19 打开的 overview / latest-model / tool/others / coding-tool-helper / usage-notes / faq / team / MCP 页。
+
+## 官方一级导航（产品家族）
+
+| 官方一级入口 | 官方 URL | 本站去向 | 不拆页理由（若一行） |
+|--------------|----------|----------|----------------------|
+| GLM Coding Plan | https://bigmodel.cn/glm-coding 、https://docs.bigmodel.cn/cn/coding-plan/overview | 本目录独立页 | — |
+| 智谱清言 | https://chatglm.cn/ | 地图一行 | 聊天 / Agent 助手，#74 |
+| Z.ai | https://z.ai/ | 地图一行 | 海外聊天 / Agent，#74 |
+| BigModel 开放平台 | https://bigmodel.cn/ 、https://docs.bigmodel.cn/cn/guide/start/introduction | 地图一行 | 标准按量 API，不是本套餐 |
+| ZCode | https://docs.bigmodel.cn/cn/coding-plan/tool/zcode | 地图一行 | 指定工具，本目录不写 Agent 教程 |
+| AutoGLM | https://www.zhipuai.cn/ | 地图一行 | 同厂 Agent，非本 issue |
+| AutoClaw | https://autoglm.zhipuai.cn/autoclaw | 地图一行 | 本地 OpenClaw 客户端，非本 issue |
+| Zread.ai | https://zread.ai | 地图一行 | 开源仓库产品；套餐侧只写 Zread MCP |
+| AMiner | https://www.zhipuai.cn/ | 非本站 | 学术检索 |
+| 智谱学习中心 | https://www.zhipuai.cn/ | 非本站 | 教育 |
+| 智谱AI输入法 | https://www.zhipuai.cn/ | 非本站 | 输入法 |
+
+易撞名：
+
+- **GLM Coding Plan ≠ 智谱清言 / Z.ai**：前者是指定工具里的订阅额度，后者是聊天产品。
+- **套餐 Key ≠ 平台其它 API Key**：团队套餐 Key 不通用。
+- **Coding 端点 ≠ 标准 API**：`/api/coding/paas/v4` 与 `/api/paas/v4` 不是同一个。
+- **Coding Tool Helper ≠ 智谱第一方编码 Agent**：Helper 只装载套餐。
+- **ZCode ≠ GLM Coding Plan**：ZCode 是可用本套餐的工具。
+- **Helper 支持的 4 个工具 ≠ 适用工具全集**。
+
+## 文档文件结构（Diataxis）
+
+官方编码套餐树 dense（overview / quick-start / usage-notes / faq / team / latest-model / tool/* / mcp/* / extension/*），本站收成 5 文件，不按 Claude/Grok 的 CLI 产品同构去写 TUI。
+
+```
+docs/zh/products/glm-coding/
+├── index.md                    # 学习地图 + 家族图
+├── glm-coding.md               # Tutorial：订阅、Helper、Claude Code、Cursor
+├── glm-coding-cookbook.md      # How-to：切模型、MCP、1113、团队 Key
+├── glm-coding-cheatsheet.md    # Reference：端点、积分、工具名单、命令、数据源
+└── glm-coding-glossary.md      # Explanation：套餐 vs API vs 聊天、积分、次级调度
+
+docs/products/glm-coding/       # 英文同构；端点与工具名单抄 docs.z.ai/devpack
+```
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 + 速查 | 家族表、决策树、套餐边界 | 逐步配置 |
+| `glm-coding.md` | Tutorial | 订阅、取 Key、Helper、Claude Code、Cursor | 全工具清单细节、MCP 全配置 |
+| `glm-coding-cookbook.md` | How-to | 切模型、MCP、报错、团队席位 | 基础安装、概念长文 |
+| `glm-coding-cheatsheet.md` | Reference | 端点、积分、名单、命令、数据源 | 学习路径 |
+| `glm-coding-glossary.md` | Explanation | 是什么 / 不是什么 | 参数逐步操作 |
+
+跨页：`index` → `glm-coding` → `cookbook` → `cheatsheet` → `glossary`。
+
+## 监控页面
+
+- 套餐概览：<https://docs.bigmodel.cn/cn/coding-plan/overview>
+- 快速开始：<https://docs.bigmodel.cn/cn/coding-plan/quick-start>
+- 适用工具：<https://docs.bigmodel.cn/cn/coding-plan/tool/others>
+- 一键安装助手：<https://docs.bigmodel.cn/cn/coding-plan/extension/coding-tool-helper>
+- 如何切换模型：<https://docs.bigmodel.cn/cn/coding-plan/latest-model>
+- 使用须知：<https://docs.bigmodel.cn/cn/coding-plan/usage-notes>
+- FAQ：<https://docs.bigmodel.cn/cn/coding-plan/faq>
+- 团队版：<https://docs.bigmodel.cn/cn/coding-plan/team>
+- 海外镜像：<https://docs.z.ai/devpack/overview>
+- npm：<https://www.npmjs.com/package/@z_ai/coding-helper>
+- 文档索引：<https://docs.bigmodel.cn/llms.txt>、<https://docs.z.ai/llms.txt>
+
+## Git 提交 scope
+
+```
+docs(glm-coding): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+1. **不要改 gallery / sidebar**（本 issue 执行约束）。文件放扁平目录 `docs/products/glm-coding/` 与 `docs/zh/products/glm-coding/`。
+2. **命令与包名只抄官方原文。** `npx @z_ai/coding-helper`、`npm install -g @anthropic-ai/claude-code`、`@z_ai/mcp-server`。
+3. **Cursor 国内页**：仅「高级会员及以上」可自定义模型；模型名要**大写**，官方示例 `GLM-5.2`。海外页写 Cursor Pro and higher，示例 `GLM-4.7`。不要发明 `GLM-5.3` 的 Cursor 写法。
+4. **人民币刊例价不要从营销页摘要回填。** 文档站 overview 不写人民币价；链订阅页。
+5. **国内 `tool/claude` 与 `latest-model` 模型映射不一致。** 教程切模型抄 `latest-model`；安装环境变量抄 `tool/claude`。
+6. **OpenClaw 是次级调度**，高负载可排队 / 限流。不要写成与 Claude Code 同等保障。
+7. **`bigmodel.cn/glm-coding` 营销页是 SPA**，无头抓取经常只看到 loading。事实以 `docs.bigmodel.cn` 的 `.md` 为准。
+8. 本目录禁止展开清言 / Z.ai / AutoGLM 教程。

--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -12,5 +12,6 @@
 | Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
 | Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
 | Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| GLM Coding Plan | [`glm-coding.md`](./glm-coding.md) | `docs/zh/products/glm-coding/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/docs/products/glm-coding/glm-coding-cheatsheet.md
+++ b/docs/products/glm-coding/glm-coding-cheatsheet.md
@@ -1,0 +1,149 @@
+---
+title: GLM Coding Plan cheatsheet
+description: Global endpoints, credits, supported-tool list, and the official npx @z_ai/coding-helper commands.
+domain: product
+tags:
+  - coding-plan
+role: cheatsheet
+---
+
+# GLM Coding Plan cheatsheet
+
+Look up, do not study. Default region: **global** (`api.z.ai`). China hosts live in the Chinese handbook under `docs/zh/products/glm-coding/`.
+
+Last verified: 2026-08-19.
+
+## Endpoints
+
+Source: [Quick Start](https://docs.z.ai/devpack/quick-start), [Tool Integration](https://docs.z.ai/devpack/tool/others).
+
+| Protocol | Base URL |
+|----------|----------|
+| Anthropic Messages | `https://api.z.ai/api/anthropic` |
+| OpenAI Chat Completions | `https://api.z.ai/api/coding/paas/v4` |
+| OpenAI Responses | `https://api.z.ai/api/v1` |
+| General API (not the plan) | `https://api.z.ai/api/paas/v4` |
+
+Wrong host → plan quota does not apply.
+
+## Individual credits
+
+Source: [Overview](https://docs.z.ai/devpack/overview).
+
+| Plan | 5-hour credits | Weekly credits |
+|------|----------------|----------------|
+| Lite | 2,000 | 10,000 |
+| Pro | 12,000 | 60,000 |
+| Max | 28,000 | 140,000 |
+
+- 5-hour credits reset 5 hours after consumption.
+- Weekly credits reset every 7 days from subscribe time.
+- Model credits = (input × input multiplier + cached input × cached multiplier + output × output multiplier) / 10,000
+- MCP credits = calls × output multiplier
+- Off-peak model usage is **50%** of the standard credit rate. Peak: Monday–Friday 14:00–18:00 Singapore Time (UTC+8).
+
+| Product | Input | Cached input | Output |
+|---------|-------|--------------|--------|
+| GLM-5.3 | 6.9 | 1.7 | 24 |
+| GLM-5-Turbo | 5.7 | 1.5 | 21 |
+| GLM-4.7 | 4.6 | 1.2 | 16 |
+| GLM-4.6V (Vision MCP) | 1.2 | 0.3 | 2.7 |
+| Web Search / Web Reader / Zread MCP | — | — | 1.2 |
+
+Estimated weekly tokens on GLM-5.3 at 90.9% cache hit: Lite 43–87M; Pro 263–526M; Max 613–1226M.
+
+Overview list price quote: “Starting at just 18 USD per month”. Current SKUs: [z.ai/subscribe](https://z.ai/subscribe).
+
+## Supported tools (global)
+
+Source: [tool/others](https://docs.z.ai/devpack/tool/others), 2026-08-19.
+
+**Coding Agent:** ZCode, Claude Code, Claude for IDE, Codex, OpenCode, Pi, Cursor, Cline, TRAE, Qoder, Droid, Kilo Code, Roo Code, Crush, Goose, Eigent.
+
+**General-purpose (best-effort):** OpenClaw, Hermes Agent, SillyTavern.
+
+This list is **not** identical to the China allow-list (China has Lingma / CodeBuddy / Cherry Studio / MonkeyCode; global has Codex / Pi / Eigent / SillyTavern).
+
+Helper auto-load only: Claude Code, OpenCode, Crush, Factory Droid.
+
+## Coding Tool Helper
+
+Package: [`@z_ai/coding-helper`](https://www.npmjs.com/package/@z_ai/coding-helper). Node.js >= v18.0.0. Bins: `coding-helper`, `chelper`.
+
+```bash
+npx @z_ai/coding-helper
+npm install -g @z_ai/coding-helper
+coding-helper
+coding-helper init
+coding-helper lang show
+coding-helper lang set en_US
+coding-helper auth
+coding-helper auth glm_coding_plan_global <token>
+coding-helper auth revoke
+coding-helper auth reload claude
+coding-helper doctor
+coding-helper --help
+coding-helper --version
+```
+
+China auth flag is `glm_coding_plan_china` (do not use it on a global key).
+
+## Claude Code
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude --version
+claude
+claude update
+curl -O "https://cdn.bigmodel.cn/install/claude_code_zai_env.sh" && bash ./claude_code_zai_env.sh
+```
+
+The curl installer is **macOS / Linux only** on the China twin page; the global Claude page publishes the same script URL.
+
+`settings.json` env from [tool/claude](https://docs.z.ai/devpack/tool/claude): `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`, `API_TIMEOUT_MS=3000000`.
+
+## Cursor
+
+| Item | Global official text |
+|------|----------------------|
+| Eligibility | Cursor Pro and higher |
+| Protocol | OpenAI |
+| Base URL | `https://api.z.ai/api/coding/paas/v4` (not `/api/paas/v4`) |
+| Model name | Uppercase; examples `GLM-4.7`, `GLM-4.5-air` |
+
+## Glossary index
+
+| Term | Hook |
+|------|------|
+| [GLM Coding Plan](./glm-coding-glossary.md#glm-coding-plan) | Subscription, not a chat product |
+| [Supported tools](./glm-coding-glossary.md#supported-tools) | Off-list calls do not use plan quota |
+| [Coding endpoint](./glm-coding-glossary.md#coding-endpoint) | Not the general `/api/paas/v4` |
+| [Credits](./glm-coding-glossary.md#credits) | 5-hour + weekly caps |
+| [Best-effort / secondary scheduling](./glm-coding-glossary.md#best-effort-agents) | OpenClaw-class tools |
+| [Team Plan key](./glm-coding-glossary.md#team-plan-key) | Not interchangeable |
+| [Coding Tool Helper](./glm-coding-glossary.md#coding-tool-helper) | Loader, not an agent |
+
+## High-quality sources
+
+Last verified: 2026-08-19.
+
+| Source | Why |
+|--------|-----|
+| [docs.z.ai/devpack/overview](https://docs.z.ai/devpack/overview) | Models, credits, price quote |
+| [docs.z.ai/devpack/quick-start](https://docs.z.ai/devpack/quick-start) | Subscribe + keys |
+| [docs.z.ai/devpack/tool/others](https://docs.z.ai/devpack/tool/others) | Allow-list + endpoints |
+| [docs.z.ai/devpack/tool/claude](https://docs.z.ai/devpack/tool/claude) | Claude Code env |
+| [docs.z.ai/devpack/tool/cursor](https://docs.z.ai/devpack/tool/cursor) | Cursor custom model |
+| [docs.z.ai/devpack/extension/coding-tool-helper](https://docs.z.ai/devpack/extension/coding-tool-helper) | Helper commands |
+| [docs.z.ai/devpack/usage-policy](https://docs.z.ai/devpack/usage-policy) | Account rules |
+| [docs.z.ai/llms.txt](https://docs.z.ai/llms.txt) | Full docs index |
+| [npm @z_ai/coding-helper](https://www.npmjs.com/package/@z_ai/coding-helper) | Package name + bins |
+| [China overview](https://docs.bigmodel.cn/cn/coding-plan/overview) | CN credits + designated tools |
+| [z.ai/subscribe](https://z.ai/subscribe) | Live SKUs |
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./glm-coding.md)
+- [Cookbook](./glm-coding-cookbook.md)
+- [Glossary](./glm-coding-glossary.md)

--- a/docs/products/glm-coding/glm-coding-cookbook.md
+++ b/docs/products/glm-coding/glm-coding-cookbook.md
@@ -1,0 +1,127 @@
+---
+title: GLM Coding Plan cookbook
+description: After the global plan is live: switch models, add plan MCP servers, and debug the wrong endpoint.
+domain: product
+tags:
+  - coding-plan
+role: cookbook
+---
+
+# GLM Coding Plan cookbook
+
+For readers who already subscribed and can reach a listed tool. Each recipe is one job. Not wired yet? Start with the [tutorial](./glm-coding.md).
+
+## 1. Point the tool at the current plan models
+
+[Overview](https://docs.z.ai/devpack/overview): all plans support **GLM-5.3**, GLM-5-Turbo, and GLM-4.7. Older GLM-5.2 / GLM-5.1 calls route to GLM-5.3.
+
+The Claude Code tool page still shows GLM-4.7 / GLM-5.2 mappings. **Do not treat that FAQ as the current default.** Prefer [latest-model](https://docs.z.ai/devpack/latest-model). The China twin of that page ([latest-model](https://docs.bigmodel.cn/cn/coding-plan/latest-model)) publishes this `settings.json` fragment for GLM-5.3:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.3[1m]",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.3[1m]"
+  }
+}
+```
+
+Keep the global Anthropic base URL:
+
+`https://api.z.ai/api/anthropic`
+
+The `[1m]` suffix plus `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is required for 1M context. If the client says the model does not exist, `claude update` first.
+
+Open a new terminal, run `claude`, then `/status`. You want Model = `glm-5.3` or `glm-5.3[1m]`.
+
+Cline-style OpenAI-compatible tools (China `latest-model` example; use the global base URL):
+
+- API Provider: `OpenAI Compatible`
+- Base URL: `https://api.z.ai/api/coding/paas/v4`
+- Custom model: e.g. `glm-5.3`
+- Uncheck Support Images
+- Context Window Size: `1000000`
+
+If the agent cannot set a custom model, the official note is: wait for later support.
+
+## 2. Add plan MCP servers
+
+Overview: every plan includes Vision, Web Search, Web Reader, and Zread MCP. They share plan credits.
+
+Vision is a **local** server: `@z_ai/mcp-server` (China vision page; same package). Search / Zread are **remote** HTTP MCP. China one-liners (swap the host to `api.z.ai` only when the global MCP page shows that host; if you have not opened the global MCP page, copy the URL from [docs.z.ai/devpack/mcp](https://docs.z.ai/devpack/mcp/vision-mcp-server) instead of guessing).
+
+China Claude Code commands that are on the official CN MCP pages:
+
+```bash
+claude mcp add -s user zai-mcp-server --env Z_AI_API_KEY=YOUR_API_KEY -- npx -y "@z_ai/mcp-server"
+```
+
+Set `Z_AI_MODE=ZAI` when the key is a global Z.AI key (`Z_AI_MODE` is `ZHIPU` or `ZAI`).
+
+```bash
+claude mcp add -s user -t http web-search-prime https://open.bigmodel.cn/api/mcp/web_search_prime/mcp --header "Authorization: Bearer YOUR_API_KEY"
+claude mcp add -s user -t http zread https://open.bigmodel.cn/api/mcp/zread/mcp --header "Authorization: Bearer YOUR_API_KEY"
+```
+
+Those two URLs are the **China** hosts from `docs.bigmodel.cn`. For a global key, open the matching [docs.z.ai MCP](https://docs.z.ai/devpack/mcp/search-mcp-server) page and copy its URL. Do not assume the path is identical.
+
+Best practice from the vision page: put the image in the working directory and name the path. Pasting a bitmap into most clients skips this MCP.
+
+Web Reader: follow [reader-mcp-server](https://docs.z.ai/devpack/mcp/reader-mcp-server); this page does not invent its command.
+
+## 3. Requests bill the general API (or fail with insufficient balance)
+
+Wrong tool or wrong base URL is the usual cause.
+
+Global Cursor page: Coding API `https://api.z.ai/api/coding/paas/v4`, **not** General API `https://api.z.ai/api/paas/v4`.
+
+China FAQ (same failure mode, China hosts):
+
+| Client | Required base URL |
+|--------|-------------------|
+| Claude Code | `https://open.bigmodel.cn/api/anthropic` |
+| Cherry Studio | `https://open.bigmodel.cn/api/coding/paas/v4/` |
+| Other listed tools | `https://open.bigmodel.cn/api/coding/paas/v4` |
+
+Global equivalents:
+
+| Client | Required base URL |
+|--------|-------------------|
+| Claude Code | `https://api.z.ai/api/anthropic` |
+| OpenAI-compatible tools | `https://api.z.ai/api/coding/paas/v4` |
+| OpenAI Responses | `https://api.z.ai/api/v1` |
+
+If usage still hits wallet balance after the plan quota is gone, the request is not on the coding endpoint. China Overview: exhausted plan quota waits for the next 5-hour window and does **not** keep draining other packs.
+
+## 4. Helper will not start
+
+From [coding-tool-helper](https://docs.z.ai/devpack/extension/coding-tool-helper):
+
+```bash
+coding-helper doctor
+```
+
+| Symptom | Official fix |
+|---------|----------------|
+| `Network Error` | Check the network. Node.js does **not** pick up the system proxy; set `HTTP_PROXY` and `HTTPS_PROXY` |
+| Install timeout | Network / proxy |
+| `EACCES: permission denied` | sudo, Administrator terminal, `npx @z_ai/coding-helper`, or nvm |
+| Marketplace plugin status wrong | `claude update` to **2.0.70+** |
+| Invalid API key | Re-copy the key; official text also says check account balance |
+
+```bash
+export HTTP_PROXY=http://your.proxy.server:port
+export HTTPS_PROXY=http://your.proxy.server:port
+```
+
+## 5. Cursor rejects the custom model
+
+[Cursor page](https://docs.z.ai/devpack/tool/cursor): custom models need **Cursor Pro and higher**. Model id must be uppercase (`GLM-4.7`). Base URL must be the Coding API, not `/api/paas/v4`.
+
+## 6. Team keys
+
+[Global Quick Start](https://docs.z.ai/devpack/quick-start): Team Plan members take the key from Team Coding Plan > My Plan. That key is not interchangeable with other Z.AI keys.
+
+China [team](https://docs.bigmodel.cn/cn/coding-plan/team) adds (do not assume every line is mirrored on docs.z.ai): seats start at 2; no seat sharing; personal + team plans can coexist; the buyer admin does not consume a seat unless they assign one to themselves.

--- a/docs/products/glm-coding/glm-coding-glossary.md
+++ b/docs/products/glm-coding/glm-coding-glossary.md
@@ -1,0 +1,97 @@
+---
+title: GLM Coding Plan glossary
+description: What the plan is and is not: subscription vs chat vs metered API, credits, and the coding endpoint.
+domain: product
+tags:
+  - coding-plan
+role: glossary
+---
+
+# GLM Coding Plan glossary
+
+No steps. Split the colliding names, then the cheatsheet rows make sense. Which door to open: [learning map](./index.md).
+
+## How the pieces sit
+
+```
+Z.ai / ChatGLM          chat products (#74)
+        │
+Standard Model API      /api/paas/v4, your own apps
+        │
+GLM Coding Plan         subscription: GLM only inside listed tools
+        ├── Coding agents (Claude Code, Cursor, …)
+        ├── General-purpose agents (OpenClaw, …) best-effort
+        └── Coding Tool Helper     loader, not an agent
+```
+
+## GLM Coding Plan
+
+**What it is:** “A subscription package designed specifically for AI-powered coding” ([Overview](https://docs.z.ai/devpack/overview)).
+
+**Why it exists:** Use GLM inside Claude Code / Cursor / other listed agents under a credit cap, instead of paying the general API per token.
+
+**What it is not:** Z.ai chat, ChatGLM, a first-party terminal agent, or a general-purpose API pack.
+
+## Supported tools
+
+**What it is:** The official Coding Agent and general-purpose lists on [tool/others](https://docs.z.ai/devpack/tool/others). Off-list use does not get plan benefits.
+
+**Why it exists:** Coding agents are expensive. The vendor keeps plan capacity on named clients plus dedicated endpoints.
+
+**What it is not:** “Any client that accepts a Base URL.” The China and global lists differ. Do not copy one onto the other.
+
+## Coding endpoint
+
+**What it is:** Plan-only Anthropic / OpenAI URLs on `api.z.ai` (`/api/anthropic`, `/api/coding/paas/v4`, `/api/v1`).
+
+**Why it exists:** The same key aimed at `/api/paas/v4` is the general API. The Cursor page calls that out explicitly.
+
+**What it is not:** `open.bigmodel.cn`. That is the China twin. Keys and hosts stay in their region.
+
+## Credits
+
+**What it is:** A 5-hour cap and a weekly cap. Models burn credits from tokens × multipliers / 10,000. MCP burns credits per call.
+
+**Why it exists:** One ledger across peak / off-peak, several models, and MCP.
+
+**What it is not:** Wallet cash. China Overview: when plan credits run out, wait for the next 5-hour window; other packs / balance are not drained.
+
+## Best-effort agents
+
+**What it is:** General-purpose tools (OpenClaw, Hermes Agent, SillyTavern on the global list). Official: served on a best-effort basis; high load may rate-limit. China Overview names this **secondary scheduling** and gives Coding Agent preemption.
+
+**Why it exists:** Most plan traffic is coding. Shared capacity prefers coding agents.
+
+**What it is not:** “OpenClaw is unsupported.” It is listed; it is not first-class.
+
+## Team Plan key
+
+**What it is:** The credential Team members copy from Team Coding Plan > My Plan. “Not interchangeable with other Z.AI's API Keys” ([Quick Start](https://docs.z.ai/devpack/quick-start)).
+
+**Why it exists:** Seats and org billing must not mix with a personal key.
+
+**What it is not:** The platform key the admin already had before buying seats.
+
+## Coding Tool Helper
+
+**What it is:** CLI `@z_ai/coding-helper` (`coding-helper` / `chelper`). Loads the plan into Claude Code, OpenCode, Crush, and Factory Droid.
+
+**Why it exists:** Avoid hand-editing `settings.json` and MCP.
+
+**What it is not:** A coding agent. It does not auto-wire Cursor.
+
+## Server-side model mapping
+
+**What it is:** After Claude Code is pointed at the plan, the UI may still show Opus / Sonnet / Haiku while the server maps them to GLM (China Claude page; global page documents the env mapping).
+
+**Why it exists:** Keep the Claude Code UI. Hard-coded mappings go stale when the plan default model changes.
+
+**What it is not:** Anthropic inference. `/status` should show `glm-*`.
+
+## Global site vs China site
+
+**What it is:** Global = `docs.z.ai/devpack` + `api.z.ai` + `glm_coding_plan_global`. China = `docs.bigmodel.cn/cn/coding-plan` + `open.bigmodel.cn` + `glm_coding_plan_china`.
+
+**Why it exists:** Different keys, hosts, and allow-lists.
+
+**What it is not:** Two skins of Z.ai chat.

--- a/docs/products/glm-coding/glm-coding.md
+++ b/docs/products/glm-coding/glm-coding.md
@@ -1,0 +1,181 @@
+---
+title: GLM Coding Plan tutorial
+description: Subscribe to the global GLM Coding Plan and load it into Claude Code or Cursor with the official npx @z_ai/coding-helper command.
+domain: product
+tags:
+  - coding-plan
+role: tutorial
+---
+
+# GLM Coding Plan tutorial
+
+This page takes you from subscribe → first working turn in **Claude Code** or **Cursor**. Numbers and allow-lists live on the [cheatsheet](./glm-coding-cheatsheet.md). Model switch / MCP / errors live in the [cookbook](./glm-coding-cookbook.md).
+
+Official path: [Quick Start](https://docs.z.ai/devpack/quick-start). Endpoints here are **global** (`api.z.ai`). China uses `open.bigmodel.cn` — see the Chinese tutorial.
+
+## 1. Confirm you bought the right thing
+
+You bought **quota for listed coding tools**, not Z.ai chat and not a general API pack.
+
+- The plan is limited to [supported tools and products](https://docs.z.ai/devpack/tool/others#step-1-supported-tools).
+- China FAQ (same vendor rule): calling the model from a self-built app, site, bot, or SaaS uses the standard API and does **not** consume Coding Plan quota.
+
+## 2. Subscribe and get a plan key
+
+1. Open [Z.AI Open Platform](https://z.ai/model-api) and sign in.
+2. Pick a plan on [GLM Coding Plan](https://z.ai/subscribe).
+3. Get a key ([Quick Start](https://docs.z.ai/devpack/quick-start)):
+   - **Individual:** [Individual Coding Plan > Plan Overview](https://z.ai/manage-apikey/apikey-list)
+   - **Team:** [Team Coding Plan > My Plan](https://z.ai/manage-apikey/coding-plan/team/my-plan)
+
+> **The Team Plan key is not interchangeable with other Z.AI API keys.** Use the Team Plan key if you want Team quota.
+
+Do not commit the key.
+
+## 3. Preferred path: Coding Tool Helper
+
+Official page: [Coding Tool Helper](https://docs.z.ai/devpack/extension/coding-tool-helper). Prerequisite: **Node.js >= v18.0.0**.
+
+Helper currently auto-manages only:
+
+- Claude Code
+- OpenCode
+- Crush
+- Factory Droid
+
+Cursor, Cline, TRAE, and the rest of the allow-list are **not** on that list. Skip to section 5 for Cursor.
+
+### Method 1 (official recommended: npx)
+
+```bash
+npx @z_ai/coding-helper
+```
+
+### Method 2: global install
+
+```bash
+npm install -g @z_ai/coding-helper
+coding-helper
+```
+
+The binary is also `chelper`. If `npm install` hits `permission denied`, the official example is `sudo npm install -g @z_ai/coding-helper`, or go back to npx.
+
+Wizard order (official): UI language → coding plan → API key → tools to manage → auto-install if needed → tool menu → load plan → optional MCP → launch.
+
+Non-interactive commands are on the [cheatsheet](./glm-coding-cheatsheet.md). Global auth:
+
+```bash
+coding-helper auth glm_coding_plan_global <token>
+```
+
+If anything fails:
+
+```bash
+coding-helper doctor
+```
+
+## 4. Wire Claude Code
+
+Official page: [devpack/tool/claude](https://docs.z.ai/devpack/tool/claude).
+
+Prerequisites: Node.js 18+. Windows also needs [Git for Windows](https://git-scm.com/download/win). macOS: prefer nvm.
+
+```bash
+npm install -g @anthropic-ai/claude-code
+cd your-awesome-project
+```
+
+Do not treat a bare `claude` launch as “done” until the plan env is set.
+
+### 4.1 Helper (preferred)
+
+```bash
+npx @z_ai/coding-helper
+```
+
+Choose Claude Code and load the plan.
+
+### 4.2 Install script (macOS / Linux only)
+
+```bash
+curl -O "https://cdn.bigmodel.cn/install/claude_code_zai_env.sh" && bash ./claude_code_zai_env.sh
+```
+
+The script writes `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "your_zai_api_key",
+    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+    "API_TIMEOUT_MS": "3000000"
+  }
+}
+```
+
+### 4.3 Manual `settings.json` (macOS / Linux / Windows)
+
+Official global example (includes model mapping — this page still shows GLM-5.2; current plan-wide default is GLM-5.3 on [Overview](https://docs.z.ai/devpack/overview). Prefer [latest-model](https://docs.z.ai/devpack/latest-model) when you switch):
+
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "your_zai_api_key",
+    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.2[1m]",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.2[1m]",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": 1,
+    "API_TIMEOUT_MS": "3000000"
+  }
+}
+```
+
+Open a **new** terminal:
+
+```bash
+cd your-project-directory
+claude
+```
+
+If asked “Do you want to use this API key,” choose Yes. Official note: they verified Claude Code **2.0.14** and similar. Upgrade with `claude --version` and `claude update`.
+
+The tool page still documents default Opus/Sonnet/Haiku → GLM-4.7. Overview says all plans now serve **GLM-5.3**. Do not invent a third mapping. To switch, copy [latest-model](https://docs.z.ai/devpack/latest-model) (China mirror of the same guide: [latest-model](https://docs.bigmodel.cn/cn/coding-plan/latest-model) uses `glm-5.3[1m]`).
+
+## 5. Wire Cursor
+
+Official page: [devpack/tool/cursor](https://docs.z.ai/devpack/tool/cursor). **Helper does not configure Cursor.**
+
+> Custom configuration is only supported in **Cursor Pro and higher**.
+
+You must use the dedicated Coding API `https://api.z.ai/api/coding/paas/v4`, **not** the General API `https://api.z.ai/api/paas/v4`.
+
+1. Install Cursor from the Cursor site.
+2. **Models** → **Add Custom Model**.
+3. Select the **OpenAI Protocol**.
+4. Paste your Z.AI plan key.
+5. **Override OpenAI Base URL** → `https://api.z.ai/api/coding/paas/v4`.
+6. Enter the model in **uppercase**. The Cursor page examples are `GLM-4.7` and `GLM-4.5-air`. “The model name must be entered in uppercase, such as `GLM-4.7`.”
+
+This handbook does not invent a `GLM-5.3` Cursor spelling. Overview lists GLM-5.3 as the current plan model; the Cursor page examples lag. Use the string that page shows, or the uppercase form of a model the Overview still lists.
+
+Save, then pick the new provider on the home screen.
+
+## 6. First prompts
+
+From [Quick Start](https://docs.z.ai/devpack/quick-start):
+
+```text
+Please create a React component containing a user login form
+```
+
+```text
+My API request returns a 404 error. Please help me check the code.
+```
+
+```text
+This function performs poorly. Please optimize it for me.
+```
+
+Next: model switch, MCP, and failures → [cookbook](./glm-coding-cookbook.md).

--- a/docs/products/glm-coding/index.md
+++ b/docs/products/glm-coding/index.md
@@ -1,0 +1,109 @@
+---
+title: GLM Coding Plan learning map
+description: GLM Coding Plan is Zhipu / Z.AI’s subscription for designated coding tools. It is not Z.ai chat and not another chatbot tutorial.
+domain: product
+tags:
+  - coding-plan
+role: map
+---
+
+# GLM Coding Plan learning map
+
+> **GLM Coding Plan** is a **subscription**. It sells quota so you can call GLM from officially listed tools such as Claude Code and Cursor. It is **not** a chat app and **not** Z.AI’s own terminal agent.
+>
+> Official definition ([Overview](https://docs.z.ai/devpack/overview)):
+> “The GLM Coding Plan is a subscription package designed specifically for AI-powered coding.”
+
+This English handbook follows the **global** docs (`docs.z.ai/devpack`, endpoints on `api.z.ai`). China uses `docs.bigmodel.cn` and `open.bigmodel.cn` — see the Chinese pages.
+
+## Product landscape
+
+Zhipu ships chat products, a metered API platform, and this “fuel for the coding assistant you already use” plan. **This directory only covers GLM Coding Plan.** ChatGLM / Z.ai chat belong in [#74](https://github.com/zenHeart/learn-ai/issues/74).
+
+```
+Zhipu / Z.AI
+├── ChatGLM (Qingyan) — chatglm.cn (chat / Agent, #74)
+├── Z.ai — z.ai (global chat / Agent, #74)
+├── BigModel / Z.AI Model API — metered standard API
+├── GLM Coding Plan — coding subscription inside listed tools (this directory)
+│   ├── Individual: Lite / Pro / Max
+│   ├── Team: Standard / Premium (China team docs; global Team Plan)
+│   └── Loader: npx @z_ai/coding-helper (subset of CLIs only)
+└── Other first-party surfaces — AutoGLM / AutoClaw / ZCode / Zread.ai …
+```
+
+| Official entry | What it is | Official URL | This site |
+|----------------|------------|--------------|-----------|
+| **GLM Coding Plan** | Subscription quota for listed coding tools | [z.ai/subscribe](https://z.ai/subscribe), [Overview](https://docs.z.ai/devpack/overview) | This directory |
+| ChatGLM (Qingyan) | Consumer chat / Agent | [chatglm.cn](https://chatglm.cn/) | One map row; [#74](https://github.com/zenHeart/learn-ai/issues/74) |
+| Z.ai | Global chat / Agent and API door | [z.ai](https://z.ai/) | One map row; [#74](https://github.com/zenHeart/learn-ai/issues/74) |
+| Z.AI / BigModel API | Metered model API | [z.ai/model-api](https://z.ai/model-api), [bigmodel.cn](https://bigmodel.cn/) | One map row; not this plan’s quota |
+| ZCode | First-party tool that can consume the plan | [devpack/tool/zcode](https://docs.z.ai/devpack/tool/zcode) | One map row; no agent tutorial here |
+| AutoGLM | Same-vendor Agent | [zhipuai.cn](https://www.zhipuai.cn/) | One map row |
+| AutoClaw | Local OpenClaw client | [autoglm.zhipuai.cn/autoclaw](https://autoglm.zhipuai.cn/autoclaw) | One map row |
+| Zread.ai | Open-source repo reader | [zread.ai](https://zread.ai) | One map row; plan side is Zread MCP only |
+| AMiner | Academic search | [zhipuai.cn](https://www.zhipuai.cn/) | Out of scope |
+| Zhipu Learning Center | Education | [zhipuai.cn](https://www.zhipuai.cn/) | Out of scope |
+| Zhipu IME | Input method | [zhipuai.cn](https://www.zhipuai.cn/) | Out of scope |
+
+Sources: [zhipuai.cn](https://www.zhipuai.cn/) product nav / footer; [docs.z.ai/devpack/overview](https://docs.z.ai/devpack/overview).
+
+**Names that collide:**
+
+- **Plan ≠ Z.ai / ChatGLM chat.** Chat is the assistant. The plan is GLM quota inside Claude Code / Cursor.
+- **Plan key ≠ other platform API keys.** Team Plan keys are not interchangeable ([Quick Start](https://docs.z.ai/devpack/quick-start)).
+- **`/api/coding/paas/v4` ≠ `/api/paas/v4`.** The global Cursor page says you must use the dedicated Coding API, not the General API.
+- **Coding Tool Helper ≠ a coding agent.** `npx @z_ai/coding-helper` only installs tools and loads the plan.
+- **Helper’s 4 tools ≠ the full allow-list.** Helper currently covers Claude Code, OpenCode, Crush, and Factory Droid ([Helper](https://docs.z.ai/devpack/extension/coding-tool-helper)). Cursor is configured by hand.
+
+### Decision tree
+
+```
+What do you need?
+├── Put GLM into Claude Code / Cursor / Cline you already use
+│   └── → this directory
+├── Chat / writing / a general assistant
+│   └── → Z.ai / ChatGLM (#74), not this plan
+├── GLM inside your own app / site / bot / SaaS
+│   └── → standard Model API (China FAQ: the coding plan does not apply)
+├── Team seats, billing, org controls
+│   └── → Team Plan
+└── A first-party Z.AI IDE
+    └── → ZCode is a listed tool; follow official tool/zcode, not this handbook
+```
+
+## Plan boundary
+
+| Item | Official wording (global Overview unless noted) |
+|------|--------------------------------------------------|
+| Models | All plans: **GLM-5.3**, GLM-5-Turbo, GLM-4.7. GLM-5.2 / GLM-5.1 requests route to GLM-5.3 |
+| Where it works | Only [supported tools](https://docs.z.ai/devpack/tool/others#step-1-supported-tools) |
+| Anthropic | `https://api.z.ai/api/anthropic` |
+| OpenAI Chat Completions | `https://api.z.ai/api/coding/paas/v4` |
+| OpenAI Responses | `https://api.z.ai/api/v1` |
+| Individual credits | Lite 2,000 / 10,000; Pro 12,000 / 60,000; Max 28,000 / 140,000 (5-hour / weekly) |
+| Peak hours | Monday–Friday 14:00–18:00 Singapore Time (UTC+8); off-peak model usage at **50%** credits |
+| General-purpose agents | Best-effort; may rate-limit under load |
+| List price | Overview: “Starting at just 18 USD per month”. Current SKUs: [z.ai/subscribe](https://z.ai/subscribe) |
+
+## Learning path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Pick the door | This map | Do not open Z.ai chat or the general API |
+| 2. Subscribe and wire a tool | [Tutorial](./glm-coding.md) | Helper or manual Claude Code / Cursor |
+| 3. Switch models, MCP, errors | [Cookbook](./glm-coding-cookbook.md) | GLM-5.3, vision / search MCP |
+| 4. Look up numbers | [Cheatsheet](./glm-coding-cheatsheet.md) | Endpoints, credits, commands |
+| 5. Untangle names | [Glossary](./glm-coding-glossary.md) | Plan vs API vs chat |
+
+## Feature index
+
+| Capability | One line | Official page |
+|------------|----------|---------------|
+| Overview | Models, credits, scope | [overview](https://docs.z.ai/devpack/overview) |
+| Quick Start | Subscribe, key, pick a tool | [quick-start](https://docs.z.ai/devpack/quick-start) |
+| Coding Tool Helper | `npx @z_ai/coding-helper` | [coding-tool-helper](https://docs.z.ai/devpack/extension/coding-tool-helper) |
+| Supported tools | Coding Agent + general-purpose lists | [tool/others](https://docs.z.ai/devpack/tool/others) |
+| Vision / Search / Reader / Zread MCP | Plan-only MCP servers | [vision](https://docs.z.ai/devpack/mcp/vision-mcp-server) |
+| Usage policy | Account rules, refunds | [usage-policy](https://docs.z.ai/devpack/usage-policy) |
+| FAQ | Subscription and usage | [faq](https://docs.z.ai/devpack/faq) |

--- a/docs/zh/products/glm-coding/glm-coding-cheatsheet.md
+++ b/docs/zh/products/glm-coding/glm-coding-cheatsheet.md
@@ -1,0 +1,210 @@
+---
+title: GLM Coding Plan 速查表
+description: 国内端点、积分、指定工具名单、npx @z_ai/coding-helper 原文命令。只查不学。
+domain: product
+tags:
+  - coding-plan
+role: cheatsheet
+---
+
+# GLM Coding Plan 速查表
+
+只查不学。命令与数字以能打开的官方页为准。本页默认**国内**。海外端点见 [docs.z.ai/devpack/tool/others](https://docs.z.ai/devpack/tool/others)。
+
+最后核实：2026-08-19。
+
+## 端点
+
+来源：[quick-start](https://docs.bigmodel.cn/cn/coding-plan/quick-start)、[tool/others](https://docs.bigmodel.cn/cn/coding-plan/tool/others)、[FAQ](https://docs.bigmodel.cn/cn/coding-plan/faq)、[latest-model](https://docs.bigmodel.cn/cn/coding-plan/latest-model)。
+
+| 协议 / 场景 | Base URL |
+|-------------|----------|
+| Anthropic Message | `https://open.bigmodel.cn/api/anthropic` |
+| OpenAI Chat Completion | `https://open.bigmodel.cn/api/coding/paas/v4` |
+| Cherry Studio（FAQ 单独写出带尾斜杠） | `https://open.bigmodel.cn/api/coding/paas/v4/` |
+| Codex（仅 `latest-model`；国内适用工具卡未列入） | `https://open.bigmodel.cn/api/v1` |
+| 套餐过期后其它工具走资源包（FAQ） | `https://open.bigmodel.cn/api/paas/v4` |
+
+错端点 = 套餐额度用不上。
+
+## 个人积分
+
+来源：[overview](https://docs.bigmodel.cn/cn/coding-plan/overview)。
+
+| 套餐 | 5 小时积分 | 每周积分 |
+|------|------------|----------|
+| Lite | 2,000 | 10,000 |
+| Pro | 12,000 | 60,000 |
+| Max | 28,000 | 140,000 |
+
+- 5 小时：请求消耗 5 小时后动态刷新。
+- 周积分：自下单起每 7 天刷新。
+- 模型积分 =（输入 Token × Input 系数 + 缓存命中 Token × Cached Input 系数 + 输出 Token × Output 系数）/ 10000
+- MCP 积分 = 调用次数 × Output 系数
+- 非高峰模型调用按基础积分 **50%** 抵扣。高峰：周一至周五 14:00–18:00（UTC+8）。
+
+| 产品 | Input | Cached Input | Output |
+|------|-------|--------------|--------|
+| GLM-5.3 | 6.9 | 1.7 | 24 |
+| GLM-5-Turbo | 5.7 | 1.5 | 21 |
+| GLM-4.7 | 4.6 | 1.2 | 16 |
+| GLM-4.6V（视觉 MCP） | 1.2 | 0.3 | 2.7 |
+| 联网搜索 / 网页读取 / 开源仓库 MCP | — | — | 1.2 |
+
+overview 用 GLM-5.3、缓存命中 90.9% 估算每周 Token：Lite 0.43～0.87 亿；Pro 2.63～5.26 亿；Max 6.13～12.26 亿。上沿 = 全部非高峰 0.5×；下沿 = 全部高峰 1×。
+
+团队积分见 [team](https://docs.bigmodel.cn/cn/coding-plan/team)：标准版 15,000 / 66,000；高级版 35,000 / 155,000。团队页抵扣表仍写 GLM-5.2，与 overview 的 GLM-5.3 表并存；系数数字相同，模型行名不同。
+
+刊例价只看 [订阅页](https://bigmodel.cn/glm-coding)，本表不抄人民币。
+
+## 指定工具（国内）
+
+来源：[tool/others](https://docs.bigmodel.cn/cn/coding-plan/tool/others)，2026-08-19。
+
+**Coding Agent：** Claude Code、Claude for IDE、OpenCode、ZCode、TRAE、CodeBuddy、Lingma、Qoder、Kilo、MonkeyCode、Cline、Droid、Roo、Crush、Goose、Cursor。
+
+**通用 Agent（次级调度 / 尽力交付）：** OpenClaw、Cherry Studio、Hermes Agent。
+
+Helper **自动装载**只有：Claude Code、OpenCode、Crush、Factory Droid（[coding-tool-helper](https://docs.bigmodel.cn/cn/coding-plan/extension/coding-tool-helper)）。
+
+各工具配置页：`https://docs.bigmodel.cn/cn/coding-plan/tool/<slug>`。MonkeyCode 在 `https://docs.bigmodel.cn/cn/guide/develop/monkeycode`。
+
+## Coding Tool Helper
+
+包名：[`@z_ai/coding-helper`](https://www.npmjs.com/package/@z_ai/coding-helper)。前提：Node.js >= v18.0.0。二进制：`coding-helper` / `chelper`。
+
+```bash
+npx @z_ai/coding-helper
+npm install -g @z_ai/coding-helper
+coding-helper
+coding-helper init
+coding-helper lang show
+coding-helper lang set zh_CN
+coding-helper auth
+coding-helper auth glm_coding_plan_china <token>
+coding-helper auth revoke
+coding-helper auth reload claude
+coding-helper doctor
+coding-helper --help
+coding-helper --version
+```
+
+海外对应 auth：`coding-helper auth glm_coding_plan_global <token>`；语言：`coding-helper lang set en_US`（[docs.z.ai helper](https://docs.z.ai/devpack/extension/coding-tool-helper)）。
+
+## Claude Code 安装与套餐环境变量
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude --version
+claude
+claude update
+```
+
+国内脚本（仅 macOS / Linux）：
+
+```bash
+curl -O "https://cdn.bigmodel.cn/install/claude_code_env.sh" && bash ./claude_code_env.sh
+```
+
+`settings.json` 的 `env`（[tool/claude](https://docs.bigmodel.cn/cn/coding-plan/tool/claude)）：
+
+| 键 | 值 |
+|----|-----|
+| `ANTHROPIC_AUTH_TOKEN` | 套餐 API Key |
+| `ANTHROPIC_BASE_URL` | `https://open.bigmodel.cn/api/anthropic` |
+| `API_TIMEOUT_MS` | `3000000` |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `1` |
+
+切到 GLM-5.3 的映射抄 [latest-model](https://docs.bigmodel.cn/cn/coding-plan/latest-model)，不要抄 `tool/claude` FAQ 旧表。
+
+## Cursor
+
+| 项 | 国内官方原文 |
+|----|----------------|
+| 资格 | 高级会员及以上，否则 `The model GLM does not work with your current plan or api key` |
+| 协议 | OpenAI |
+| Base URL | `https://open.bigmodel.cn/api/coding/paas/v4` |
+| 模型名 | **大写**，官方示例 `GLM-5.2` |
+
+## 套餐 MCP（Claude Code 一键）
+
+```bash
+claude mcp add -s user zai-mcp-server --env Z_AI_API_KEY=YOUR_API_KEY -- npx -y "@z_ai/mcp-server"
+claude mcp add -s user -t http web-search-prime https://open.bigmodel.cn/api/mcp/web_search_prime/mcp --header "Authorization: Bearer YOUR_API_KEY"
+claude mcp add -s user -t http zread https://open.bigmodel.cn/api/mcp/zread/mcp --header "Authorization: Bearer YOUR_API_KEY"
+```
+
+视觉环境变量：`Z_AI_API_KEY`（必需）、`Z_AI_MODE`（`ZHIPU` 或 `ZAI`，默认 `ZHIPU`）。网页读取见 [reader](https://docs.bigmodel.cn/cn/coding-plan/mcp/reader-mcp-server)。
+
+## 常见错误
+
+| 症状 | 先查 |
+|------|------|
+| `1113 余额不足` / 扣账户余额 | 工具名单 + Base URL（FAQ） |
+| Cursor 自定义模型失败 | Cursor 会员档 + 大写模型名 |
+| Helper `Network Error` | `HTTP_PROXY` / `HTTPS_PROXY` |
+| `EACCES` | nvm / npx / sudo |
+| MCP 连不上 | Node 18+、`Z_AI_API_KEY`、`Z_AI_MODE` 与 Key 区域一致 |
+
+## 术语索引
+
+一行钩子，解释在 [术语表](./glm-coding-glossary.md)。
+
+| 术语 | 钩子 |
+|------|------|
+| [GLM Coding Plan](./glm-coding-glossary.md#glm-coding-plan) | 指定工具订阅，不是聊天产品 |
+| [指定工具](./glm-coding-glossary.md#指定工具) | 名单外调用不吃套餐 |
+| [Coding 端点](./glm-coding-glossary.md#coding-端点) | 与 `/api/paas/v4` 不是同一口 |
+| [积分](./glm-coding-glossary.md#积分) | 5 小时 + 每周双上限 |
+| [次级调度](./glm-coding-glossary.md#次级调度) | OpenClaw 等通用 Agent 的尽力交付 |
+| [团队套餐 Key](./glm-coding-glossary.md#团队套餐-key) | 与平台其它 Key 不通用 |
+| [Coding Tool Helper](./glm-coding-glossary.md#coding-tool-helper) | 装载器，不是 Agent |
+
+## 高质量信息源
+
+最后核实：2026-08-19。只收录亲自打开过的页。
+
+### 一手官方（国内）
+
+| 来源 | 用途 |
+|------|------|
+| [套餐概览](https://docs.bigmodel.cn/cn/coding-plan/overview) | 模型、积分、边界 |
+| [快速开始](https://docs.bigmodel.cn/cn/coding-plan/quick-start) | 订阅与选工具 |
+| [使用须知](https://docs.bigmodel.cn/cn/coding-plan/usage-notes) | 并发、共享、退款 |
+| [FAQ](https://docs.bigmodel.cn/cn/coding-plan/faq) | `1113`、升级、MCP |
+| [适用工具](https://docs.bigmodel.cn/cn/coding-plan/tool/others) | 指定名单与端点 |
+| [Claude Code](https://docs.bigmodel.cn/cn/coding-plan/tool/claude) | 安装与 `settings.json` |
+| [Cursor](https://docs.bigmodel.cn/cn/coding-plan/tool/cursor) | 自定义模型 |
+| [一键安装助手](https://docs.bigmodel.cn/cn/coding-plan/extension/coding-tool-helper) | Helper 命令 |
+| [如何切换模型](https://docs.bigmodel.cn/cn/coding-plan/latest-model) | GLM-5.3 映射 |
+| [团队版](https://docs.bigmodel.cn/cn/coding-plan/team) | 席位与团队积分 |
+| [视觉 / 搜索 / 读取 / Zread MCP](https://docs.bigmodel.cn/cn/coding-plan/mcp/vision-mcp-server) | 套餐 MCP |
+| [订阅协议](https://docs.bigmodel.cn/cn/terms/subscription-agreement) | 使用规范 |
+| [llms.txt](https://docs.bigmodel.cn/llms.txt) | 文档站全文索引 |
+| [npm @z_ai/coding-helper](https://www.npmjs.com/package/@z_ai/coding-helper) | 包名与 bin |
+
+### 海外镜像
+
+| 来源 | 用途 |
+|------|------|
+| [docs.z.ai/devpack/overview](https://docs.z.ai/devpack/overview) | 海外套餐总览（含 “Starting at just 18 USD per month”） |
+| [docs.z.ai/devpack/tool/others](https://docs.z.ai/devpack/tool/others) | 海外工具名单与 `api.z.ai` 端点 |
+| [docs.z.ai/devpack/extension/coding-tool-helper](https://docs.z.ai/devpack/extension/coding-tool-helper) | `glm_coding_plan_global` |
+| [z.ai/subscribe](https://z.ai/subscribe) | 海外订阅页 |
+
+### 控制台
+
+| 来源 | 用途 |
+|------|------|
+| [个人套餐概览](https://www.bigmodel.cn/coding-plan/personal/overview) | Key、续订、风控申诉 |
+| [用量统计](https://www.bigmodel.cn/coding-plan/personal/usage) | 5 小时 / 周额度 |
+| [费用明细](https://www.bigmodel.cn/finance-center/bill/expensebill/list) | 是否扣的是编码套餐 |
+
+**访问提示**：`bigmodel.cn/glm-coding` 是 SPA，无头抓取常只有 loading。事实以 `docs.bigmodel.cn` 的 `.md` 为准。
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./glm-coding.md)
+- [Cookbook](./glm-coding-cookbook.md)
+- [术语表](./glm-coding-glossary.md)

--- a/docs/zh/products/glm-coding/glm-coding-cookbook.md
+++ b/docs/zh/products/glm-coding/glm-coding-cookbook.md
@@ -1,0 +1,162 @@
+---
+title: GLM Coding Plan 实战手册
+description: 已经订好套餐之后：按官方原文切换 GLM-5.3、加套餐 MCP、处理 1113 与团队 Key。
+domain: product
+tags:
+  - coding-plan
+role: cookbook
+---
+
+# GLM Coding Plan 实战手册
+
+面向已经订上套餐、工具能连上的读者。每个配方只解决一个问题。还没接到工具，先看 [教程](./glm-coding.md)。
+
+## 1. 切到当前套餐模型（GLM-5.3）
+
+事实源：[如何切换模型](https://docs.bigmodel.cn/cn/coding-plan/latest-model)。overview / FAQ：所有套餐已支持 **GLM-5.3**、GLM-5-Turbo、GLM-4.7。
+
+`tool/claude` 的 FAQ 仍写 GLM-4.7 / GLM-4.5-Air 映射。**切模型不要抄那张旧表。**
+
+开始前确认：
+
+1. 套餐有效，Key 能用。
+2. 端点正确：
+   - Claude Code / Goose（Anthropic）：`https://open.bigmodel.cn/api/anthropic`
+   - Codex：`https://open.bigmodel.cn/api/v1`（`latest-model` 原文；国内 [适用工具](https://docs.bigmodel.cn/cn/coding-plan/tool/others) 卡未列入 Codex）
+   - 其它 OpenAI 兼容：`https://open.bigmodel.cn/api/coding/paas/v4`
+
+### Claude Code
+
+在 `~/.claude/settings.json`（Windows：`%USERPROFILE%\.claude\settings.json`）加入或替换：
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.3[1m]",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.3[1m]"
+  }
+}
+```
+
+1M 上下文必须带 `[1m]` 后缀，并设置上面的 `CLAUDE_CODE_AUTO_COMPACT_WINDOW`。若提示模型不存在，先 `claude update`。
+
+新开终端，跑 `claude`，输入 `/status`：Settings source 应指向你的 `settings.json`，Model 显示 `glm-5.3` 或 `glm-5.3[1m]`。
+
+会话里用 `/effort` 切思考强度，默认 max。关闭思考会被转成 low，**不会**换模型（`latest-model` 原文）。
+
+### Cline 一类自定义模型工具
+
+`latest-model` 以 Cline 为例：
+
+- API Provider：`OpenAI Compatible`
+- Base URL：`https://open.bigmodel.cn/api/coding/paas/v4`
+- 模型：自定义，如 `glm-5.3`
+- 取消勾选 Support Images
+- Context Window Size：`1000000`
+
+不能自定义模型的 Agent：官方写明只能等后续支持。
+
+## 2. 给 Claude Code 加套餐 MCP
+
+所有档位都支持视觉、联网搜索、网页读取、开源仓库 MCP，与模型**共享**套餐积分（[FAQ](https://docs.bigmodel.cn/cn/coding-plan/faq)）。除套餐包外，官方暂未提供其它调用这些 MCP 的接入方案。
+
+个人用套餐概览里的 Key；团队必须用团队套餐 Key。
+
+### 视觉理解（本地 `@z_ai/mcp-server`）
+
+来源：[vision-mcp-server](https://docs.bigmodel.cn/cn/coding-plan/mcp/vision-mcp-server)。需要 `>= 0.1.2`。老缓存可删 npx cache，或强制 `@z_ai/mcp-server@latest`。
+
+Claude Code 用套餐时，服务端已内置 `image_analysis`。要全套视觉工具再装：
+
+```bash
+claude mcp add -s user zai-mcp-server --env Z_AI_API_KEY=YOUR_API_KEY -- npx -y "@z_ai/mcp-server"
+```
+
+重装前：
+
+```bash
+claude mcp list
+claude mcp remove zai-mcp-server
+```
+
+国内手配时设 `Z_AI_MODE=ZHIPU`。`Z_AI_MODE` 可选 `ZHIPU` 或 `ZAI`。
+
+官方原文：除 Claude Code 外，「直接在客户端粘贴图片无法调用此 MCP Server」；最佳实践是把图片放在当前目录，用路径点名（例如 `What does demo.png describe?`）。
+
+### 联网搜索（Remote）
+
+来源：[search-mcp-server](https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server)。Claude Code 用套餐时服务端已内置搜索；给其它模型再用：
+
+```bash
+claude mcp add -s user -t http web-search-prime https://open.bigmodel.cn/api/mcp/web_search_prime/mcp --header "Authorization: Bearer YOUR_API_KEY"
+```
+
+### 开源仓库 Zread（Remote）
+
+来源：[zread-mcp-server](https://docs.bigmodel.cn/cn/coding-plan/mcp/zread-mcp-server)。
+
+```bash
+claude mcp add -s user -t http zread https://open.bigmodel.cn/api/mcp/zread/mcp --header "Authorization: Bearer YOUR_API_KEY"
+```
+
+网页读取 MCP 的命令以 [reader-mcp-server](https://docs.bigmodel.cn/cn/coding-plan/mcp/reader-mcp-server) 为准，本页不另抄。
+
+## 3. 报错 `1113 余额不足` 或开始扣账户余额
+
+来源：[FAQ](https://docs.bigmodel.cn/cn/coding-plan/faq)。官方把这类报错归为**未满足套餐使用条件**：
+
+1. 工具必须在 [指定名单](https://docs.bigmodel.cn/cn/coding-plan/tool/others#%E4%B8%80%E3%80%81%E9%80%82%E7%94%A8%E5%B7%A5%E5%85%B7) 里。
+2. Base URL 必须是套餐端点：
+   - Claude Code：`https://open.bigmodel.cn/api/anthropic`
+   - Cherry Studio：`https://open.bigmodel.cn/api/coding/paas/v4/`
+   - 其它工具：`https://open.bigmodel.cn/api/coding/paas/v4`
+3. 官网体验中心不支持编码套餐。
+
+是否扣的是编码套餐：到 [费用明细](https://bigmodel.cn/finance/expensebill/list) 看抵扣资源包。
+
+额度耗尽后应等待下一个 5 小时周期，系统**不会**自动改扣资源包 / 余额。若仍在扣余额，先查端点，不要加钱试。
+
+套餐过期后：Claude Code **暂不支持**其它资源包；其它编码工具把 Base URL 改成 `https://open.bigmodel.cn/api/paas/v4` 才能走资源包（FAQ 原文）。那已经不是套餐额度。
+
+## 4. Helper 装不上 / 网络错误
+
+来源：[coding-tool-helper](https://docs.bigmodel.cn/cn/coding-plan/extension/coding-tool-helper)。
+
+```bash
+coding-helper doctor
+```
+
+| 症状 | 官方做法 |
+|------|----------|
+| `Network Error` | 查网络；Node **不会**自动用系统代理，要设 `HTTP_PROXY` / `HTTPS_PROXY` |
+| 安装超时 | 查网络 / 代理，或换国内 npm 源 |
+| `EACCES: permission denied` | `sudo`、管理员终端、改用 `npx @z_ai/coding-helper`、或 nvm |
+| `droid: command not found` | 把 Factory Droid 可执行路径加进 PATH |
+| Claude Code 插件市场状态不对 | `claude update` 到 **2.0.70+** |
+| API Key 无效 | 核对复制；官方还写了检查账户余额 |
+
+代理示例（官方原文结构）：
+
+```bash
+export HTTP_PROXY=http://your.proxy.server:port
+export HTTPS_PROXY=http://your.proxy.server:port
+```
+
+## 5. 团队席位与两把 Key
+
+来源：[team](https://docs.bigmodel.cn/cn/coding-plan/team)。
+
+- 每位成员加入团队后，在「团队编程套餐」取**自己的**团队套餐 Key。
+- 个人套餐和团队套餐可以同时存在；同一团队里一人同时只有一个生效席位。
+- 主管理员默认**不占席位**。要用席位额度，给自己分配一个席位。
+- 2 席起购；不可多人共用同一席位；标准版与高级版席位暂不可混买。
+- 额度按席位单独限制。管理员可开超额按量（限时按 [API 刊例价](https://bigmodel.cn/pricing) 9 折，以团队页当时说明为准）。
+- 个人并发建议：Lite 单项目；Pro 1–2 个；Max 2+。团队：标准版 1–2；高级版 2+（[usage-notes](https://docs.bigmodel.cn/cn/coding-plan/usage-notes)、team）。
+
+取消自动续费：个人在 [套餐概览](https://www.bigmodel.cn/coding-plan/personal/overview) 操作，须在下一扣费日**至少 3 天前**。订阅一经购买不支持退款（[usage-notes](https://docs.bigmodel.cn/cn/coding-plan/usage-notes)）。
+
+## 6. Cursor 自定义模型被拒
+
+国内 Cursor 页原文：非**高级会员及以上**会报 `The model GLM does not work with your current plan or api key`。先核对 Cursor 自己的订阅，再核对 Base URL 是否为 `https://open.bigmodel.cn/api/coding/paas/v4`，模型名是否按该页要求使用大写。

--- a/docs/zh/products/glm-coding/glm-coding-glossary.md
+++ b/docs/zh/products/glm-coding/glm-coding-glossary.md
@@ -1,0 +1,97 @@
+---
+title: GLM Coding Plan 术语表
+description: 解释套餐、指定工具、Coding 端点、积分和次级调度。不教逐步配置。
+domain: product
+tags:
+  - coding-plan
+role: glossary
+---
+
+# GLM Coding Plan 术语表
+
+不教操作。把容易撞车的名字分开后，速查表里的端点和积分才有位置。选哪扇门看 [学习地图](./index.md)。
+
+## 概念关系
+
+```
+智谱清言 / Z.ai     聊天产品（#74）
+        │
+BigModel 标准 API    /api/paas/v4 按量，自建应用走这里
+        │
+GLM Coding Plan      订阅：只给指定编程工具供 GLM
+        ├── Coding Agent（Claude Code、Cursor …）优先调度
+        ├── 通用 Agent（OpenClaw …）次级调度
+        └── Coding Tool Helper     装载器，不是 Agent
+```
+
+## GLM Coding Plan
+
+**是什么：** 智谱面向 AI 编码场景的订阅套餐。官方原文：「专为 AI 编码打造的订阅套餐」（[overview](https://docs.bigmodel.cn/cn/coding-plan/overview)）。
+
+**为什么需要：** 在 Claude Code / Cursor 等现成助手里用 GLM，按套餐积分走，而不是按标准 API 逐 Token 付。
+
+**不是什么：** 不是清言，不是 Z.ai 聊天，不是智谱第一方终端 Agent，也不是开放平台资源包。
+
+## 指定工具
+
+**是什么：** 官方列出的 Coding Agent 与通用 Agent 名单（[tool/others](https://docs.bigmodel.cn/cn/coding-plan/tool/others)）。名单外调用 API，不可享用套餐额度。
+
+**为什么需要：** 编码 Agent 消耗高。平台用名单 + 专用端点，把套餐容量留在编程场景。
+
+**不是什么：** 不是「任何能填 Base URL 的客户端」。官网体验中心也不算。
+
+## Coding 端点
+
+**是什么：** 套餐专用的 Anthropic / OpenAI Compatible URL。国内分别是 `https://open.bigmodel.cn/api/anthropic` 与 `https://open.bigmodel.cn/api/coding/paas/v4`。
+
+**为什么需要：** 同一把 Key 打到 `/api/paas/v4` 会走标准计费或报余额不足，看起来像「套餐没生效」。
+
+**不是什么：** 不是海外 `api.z.ai` 的同一主机。国内 / 海外两套站点，不要混。
+
+## 积分
+
+**是什么：** 套餐同时设每 5 小时和每周上限。模型按 Token × 抵扣系数 / 10000 扣；MCP 按次数 × Output 系数扣。
+
+**为什么需要：** 用积分而不是裸 Token，才能在高峰 / 非高峰、不同模型和 MCP 之间做同一套账。
+
+**不是什么：** 不是账户现金余额，也不是开放平台资源包。额度耗尽后等刷新，官方写明不会改扣其它余额。
+
+## 次级调度
+
+**是什么：** OpenClaw 等通用 Agent 的资源策略。overview 原文：采用**次级调度**与尽力交付；Coding Agent 任务享有资源抢占优先权；高负载下触发动态排队、限流等公平使用策略。
+
+**为什么需要：** 大部分用户在 Coding Agent 场景；通用 Agent 分享同一池子时，编程请求优先。
+
+**不是什么：** 不是「官方不支持 OpenClaw」。支持，但保障级别低于 Claude Code。
+
+## 团队套餐 Key
+
+**是什么：** 团队版每位成员在「团队编程套餐」里拿到的专用调用凭证。与平台其他 API Key 相互独立（[team](https://docs.bigmodel.cn/cn/coding-plan/team)）。
+
+**为什么需要：** 席位、账单、超额按量按组织结算。混用个人 Key 会打到错误的额度池。
+
+**不是什么：** 不是主管理员账号自带的那把平台 Key。主管理员默认不占席位，要用额度得给自己分配席位。
+
+## Coding Tool Helper
+
+**是什么：** 命令行助手，npm 包 `@z_ai/coding-helper`，二进制 `coding-helper` / `chelper`。把套餐装进 Claude Code、OpenCode、Crush、Factory Droid。
+
+**为什么需要：** 免手改 `settings.json` 和 MCP。
+
+**不是什么：** 不是编码 Agent，也不覆盖 Cursor 等其余指定工具。
+
+## 服务端模型映射
+
+**是什么：** Claude Code 配好套餐后，界面仍可能显示 Claude 的 Opus / Sonnet / Haiku 名称，实际由服务端映射到 GLM（[tool/claude](https://docs.bigmodel.cn/cn/coding-plan/tool/claude)）。
+
+**为什么需要：** 让现有 Claude Code 工作流少改界面。硬编码映射会在套餐默认模型升级时掉队。
+
+**不是什么：** 不是你真的在调 Anthropic。`/status` 里应能看到 `glm-*`。
+
+## 国内站 vs 海外站
+
+**是什么：** 国内 `docs.bigmodel.cn` + `open.bigmodel.cn`；海外 `docs.z.ai/devpack` + `api.z.ai`。Helper 的套餐标识分别是 `glm_coding_plan_china` 与 `glm_coding_plan_global`。
+
+**为什么需要：** Key、端点、适用工具名单都不完全相同。
+
+**不是什么：** 不是同一控制台的两个皮肤。清言 / Z.ai 也不是这两个编码控制台。

--- a/docs/zh/products/glm-coding/glm-coding.md
+++ b/docs/zh/products/glm-coding/glm-coding.md
@@ -1,0 +1,181 @@
+---
+title: GLM Coding Plan 教程
+description: 订阅智谱编码套餐，用官方 npx @z_ai/coding-helper 或手配，把额度接到 Claude Code 与 Cursor。
+domain: product
+tags:
+  - coding-plan
+role: tutorial
+---
+
+# GLM Coding Plan 教程
+
+本页带你从订阅走到**第一次**在 Claude Code 或 Cursor 里用上套餐额度。参数与名单见 [速查表](./glm-coding-cheatsheet.md)，切模型 / MCP / 报错见 [Cookbook](./glm-coding-cookbook.md)。
+
+官方路径：[快速开始](https://docs.bigmodel.cn/cn/coding-plan/quick-start)。本页默认**国内**端点。海外用 `api.z.ai`，见 [docs.z.ai/devpack/quick-start](https://docs.z.ai/devpack/quick-start)。
+
+## 1. 先确认你买的是对的东西
+
+你买的是**指定工具里的订阅额度**，不是清言会员，也不是开放平台资源包。
+
+- 套餐只在官方 [指定工具与产品环境](https://docs.bigmodel.cn/cn/coding-plan/tool/others#%E4%B8%80%E3%80%81%E9%80%82%E7%94%A8%E5%B7%A5%E5%85%B7) 里生效。
+- 自建应用、网站、机器人、SaaS 走标准 API，**不可享用** Coding 套餐额度（[FAQ](https://docs.bigmodel.cn/cn/coding-plan/faq)）。
+- 官网体验中心也不吃这套餐。
+
+## 2. 订阅并拿到套餐 Key
+
+1. 打开 [智谱开放平台](https://open.bigmodel.cn) 注册 / 登录。
+2. 到 [套餐详情页](https://zhipuaishengchan.datasink.sensorsdata.cn/t/Gd) 选个人或团队套餐（[快速开始](https://docs.bigmodel.cn/cn/coding-plan/quick-start) 原文链接）。
+3. 取 Key：
+   - **个人**： [个人编程套餐 > 套餐概览](https://bigmodel.cn/coding-plan/personal/overview) 新建 API Key。
+   - **团队成员**： [团队编程套餐 > 我的套餐](https://bigmodel.cn/coding-plan?z_plan=team) 取 Key。
+
+> **团队套餐 Key 与平台其他 API Key 不通用。** 要用团队额度，必须用团队套餐 Key。
+
+不要把 Key 写进仓库。
+
+## 3. 推荐路径：Coding Tool Helper
+
+[一键安装助手](https://docs.bigmodel.cn/cn/coding-plan/extension/coding-tool-helper) 原文：Coding Tool Helper 把 **GLM 编码套餐** 装进你喜爱的编码工具。前提：**Node.js >= v18.0.0**。
+
+当前 Helper **自动支持**的编码工具只有：
+
+- Claude Code
+- OpenCode
+- Crush
+- Factory Droid
+
+Cursor / Cline / TRAE 等**不在**这张表里，跳到第 5 节手配。
+
+### 方式一（官方推荐：npx 即用）
+
+```bash
+npx @z_ai/coding-helper
+```
+
+### 方式二：全局安装
+
+```bash
+npm install -g @z_ai/coding-helper
+coding-helper
+```
+
+全局安装后也可以跑 `chelper`。权限不够时，官方示例是 `sudo npm install -g @z_ai/coding-helper`，或退回 npx。macOS 更建议用 nvm 装 Node，避免 `EACCES`。
+
+向导顺序（官方原文）：选择界面语言 → 选择编码套餐 → 输入 API 密钥 → 选择要管理的工具 → 自动安装工具（如需要） → 进入工具管理菜单 → 装载编码套餐到工具 → 管理 MCP 服务（可选） → 启动编码工具。
+
+非交互命令见 [速查表](./glm-coding-cheatsheet.md)。国内直接写 Key 的官方命令是：
+
+```bash
+coding-helper auth glm_coding_plan_china <token>
+```
+
+出问题先跑：
+
+```bash
+coding-helper doctor
+```
+
+## 4. 接到 Claude Code
+
+官方页：[tool/claude](https://docs.bigmodel.cn/cn/coding-plan/tool/claude)。先装 Claude Code，再配套餐。装完**不要**立刻裸跑 `claude`（官方：可能因网络或地区限制无法使用）。
+
+前提：Node.js 18+。Windows 还要 [Git for Windows](https://git-scm.com/download/win)。
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude --version
+```
+
+### 4.1 用 Helper（推荐）
+
+```bash
+npx @z_ai/coding-helper
+```
+
+在向导里选 Claude Code，装载套餐。
+
+### 4.2 脚本（仅 macOS / Linux，官方写明不支持 Windows）
+
+```bash
+curl -O "https://cdn.bigmodel.cn/install/claude_code_env.sh" && bash ./claude_code_env.sh
+```
+
+脚本会改 `~/.claude/settings.json`，写入：
+
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "your_zhipu_api_key",
+    "ANTHROPIC_BASE_URL": "https://open.bigmodel.cn/api/anthropic",
+    "API_TIMEOUT_MS": "3000000",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": 1
+  }
+}
+```
+
+并在 `~/.claude.json` 加上 `"hasCompletedOnboarding": true`。
+
+### 4.3 手改配置（macOS / Linux / Windows）
+
+路径：
+
+- macOS / Linux：`~/.claude/settings.json` 与 `~/.claude.json`
+- Windows：`用户目录/.claude/settings.json` 与 `用户目录/.claude.json`
+
+`settings.json` 的 `env` 与上一节脚本写入的字段相同。JSON 逗号多一个少一个都会让配置静默失败。
+
+配完**新开一个终端**，进入仓库：
+
+```bash
+cd your-project
+claude
+```
+
+若弹出「Do you want to use this API key」，选 Yes。官方建议用新版本；他们验证过 `2.0.14` 等版本，升级：
+
+```bash
+claude --version
+claude update
+```
+
+默认是**服务端模型映射**：界面仍可能显示 Claude 模型名，实际打到 GLM。不要为了「看起来像 GLM」去硬编码映射——`tool/claude` 明确不推荐，升级时不好跟。要主动切到 GLM-5.3，用 [Cookbook](./glm-coding-cookbook.md) 里 `latest-model` 的原文，不要抄 `tool/claude` FAQ 里仍写着的 GLM-4.7 表。
+
+## 5. 接到 Cursor
+
+官方页：[tool/cursor](https://docs.bigmodel.cn/cn/coding-plan/tool/cursor)。**Helper 不会替你配 Cursor。**
+
+> 由于 Cursor 的限制，只有订阅了 Cursor **高级会员及以上**的用户才支持自定义配置模型。若非 Cursor 高级会员，配置后会报错 `The model GLM does not work with your current plan or api key`。
+
+1. 从 Cursor 官网安装。
+2. 打开 **Models** → **Add Custom Model**。
+3. 选 **OpenAI 协议**。
+4. **OpenAI API Key** 填智谱套餐 Key（个人从 [API Keys](https://bigmodel.cn/usercenter/proj-mgmt/apikeys) / 套餐概览取；团队用团队套餐 Key）。
+5. **Override OpenAI Base URL** 换成：
+
+   `https://open.bigmodel.cn/api/coding/paas/v4`
+
+6. 模型编码按 Cursor 页填写。官方原文：「需要输入模型的**大写名称**，如 `GLM-5.2`，不能填小写名称。」
+
+套餐当前全量模型名单以 [overview](https://docs.bigmodel.cn/cn/coding-plan/overview) 为准（GLM-5.3 / GLM-5-Turbo / GLM-4.7）。Cursor 页示例仍是 `GLM-5.2`。本页不发明 `GLM-5.3` 的 Cursor 写法；以该工具页当时示例为准。
+
+保存后，在主页切到刚建的 Provider。
+
+## 6. 第一次对话
+
+官方 [quick-start](https://docs.bigmodel.cn/cn/coding-plan/quick-start) 给的例子：
+
+```text
+请帮我创建一个 React 组件，包含用户登录表单
+```
+
+```text
+我的 API 请求返回 404 错误，请帮我检查代码
+```
+
+```text
+这个函数性能不好，请帮我优化一下
+```
+
+用量在 [用量统计](https://www.bigmodel.cn/coding-plan/personal/usage) 看。个人积分与高峰规则见 [速查表](./glm-coding-cheatsheet.md)。
+
+下一步：切到 GLM-5.3、加视觉 / 搜索 MCP、处理 `1113`，去 [Cookbook](./glm-coding-cookbook.md)。

--- a/docs/zh/products/glm-coding/index.md
+++ b/docs/zh/products/glm-coding/index.md
@@ -1,0 +1,116 @@
+---
+title: GLM Coding Plan 学习地图
+description: GLM Coding Plan 是智谱给指定编程工具用的订阅套餐，不是清言，也不是再做一个聊天产品。本目录只写套餐边界和怎么接到 Claude Code / Cursor 等。
+domain: product
+tags:
+  - coding-plan
+role: map
+---
+
+# GLM Coding Plan 学习地图
+
+> **GLM Coding Plan** 是专为 AI 编码打造的**订阅套餐**。它把额度卖给你，让你在官方指定的 Claude Code、Cursor 等工具里调用 GLM。它**不是**聊天窗口，也**不是**智谱自己的终端 Agent。
+>
+> 官方定义（[套餐概览](https://docs.bigmodel.cn/cn/coding-plan/overview)）：
+> 「GLM Coding Plan 是专为 AI 编码打造的订阅套餐，仅需少量投入，即可覆盖需求理解、代码生成、调试修复、代码库问答与自动化任务处理等开发全流程。」
+
+## 产品全景
+
+智谱同时卖聊天、开放平台 API、以及这套「给现有编程助手加油」的订阅。本目录的**主学习路径**只有 **GLM Coding Plan**。清言 / Z.ai 正文见 [#74](https://github.com/zenHeart/learn-ai/issues/74)，这里只占一行。
+
+```
+智谱 / Zhipu
+├── 智谱清言 — chatglm.cn（聊天 / Agent，#74）
+├── Z.ai — z.ai（海外聊天 / Agent，#74）
+├── BigModel 开放平台 — bigmodel.cn（标准按量 API）
+├── GLM Coding Plan — 指定工具里的编码订阅（本目录）
+│   ├── 个人：Lite / Pro / Max
+│   ├── 团队：标准版 / 高级版
+│   └── 装载：npx @z_ai/coding-helper（只覆盖部分 CLI）
+└── 其它一级产品 — AutoGLM / AutoClaw / ZCode / Zread.ai …
+```
+
+| 官方一级入口 | 是什么 | 官方 URL | 本站去向 |
+|--------------|--------|----------|----------|
+| **GLM Coding Plan** | 指定编程工具里的订阅额度 | [bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding)、[套餐概览](https://docs.bigmodel.cn/cn/coding-plan/overview) | 本目录独立页 |
+| 智谱清言 | 面向消费者的聊天 / Agent | [chatglm.cn](https://chatglm.cn/) | 地图一行，正文 [#74](https://github.com/zenHeart/learn-ai/issues/74) |
+| Z.ai | 海外聊天 / Agent 与 API 入口 | [z.ai](https://z.ai/) | 地图一行，正文 [#74](https://github.com/zenHeart/learn-ai/issues/74) |
+| BigModel 开放平台 | 标准按量模型 API | [bigmodel.cn](https://bigmodel.cn/)、[平台介绍](https://docs.bigmodel.cn/cn/guide/start/introduction) | 地图一行；和本套餐不是同一口额度 |
+| ZCode | 可用本套餐的第一方编码工具 | [tool/zcode](https://docs.bigmodel.cn/cn/coding-plan/tool/zcode) | 地图一行；本目录不写 Agent 教程 |
+| AutoGLM | 同厂 Agent 产品 | [zhipuai.cn](https://www.zhipuai.cn/) | 地图一行 |
+| AutoClaw | 本地 OpenClaw 客户端 | [autoglm.zhipuai.cn/autoclaw](https://autoglm.zhipuai.cn/autoclaw) | 地图一行 |
+| Zread.ai | 开源仓库阅读产品 | [zread.ai](https://zread.ai) | 地图一行；套餐侧只写 [Zread MCP](https://docs.bigmodel.cn/cn/coding-plan/mcp/zread-mcp-server) |
+| AMiner | 学术检索 | [zhipuai.cn](https://www.zhipuai.cn/) | 非本站 |
+| 智谱学习中心 | 教育 | [zhipuai.cn](https://www.zhipuai.cn/) | 非本站 |
+| 智谱AI输入法 | 输入法 | [zhipuai.cn](https://www.zhipuai.cn/) | 非本站 |
+
+来源：[zhipuai.cn](https://www.zhipuai.cn/) 顶栏 / 页脚「产品」、[docs.bigmodel.cn 编码套餐](https://docs.bigmodel.cn/cn/coding-plan/overview)。
+
+**容易撞名：**
+
+- **套餐 ≠ 清言 / Z.ai**。清言是聊天。套餐是给你已经在用的 Claude Code / Cursor 供 GLM。
+- **套餐 Key ≠ 平台其它 API Key**。团队套餐 Key 不通用（[快速开始](https://docs.bigmodel.cn/cn/coding-plan/quick-start)、[团队版](https://docs.bigmodel.cn/cn/coding-plan/team)）。
+- **`/api/coding/paas/v4` ≠ `/api/paas/v4`**。配错端点会报 `1113 余额不足` 或扣账户余额（[FAQ](https://docs.bigmodel.cn/cn/coding-plan/faq)）。
+- **Coding Tool Helper ≠ 编码 Agent**。`npx @z_ai/coding-helper` 只负责装工具、灌套餐。
+- **Helper 支持的 4 个工具 ≠ 适用工具全集**。Helper 当前只有 Claude Code / OpenCode / Crush / Factory Droid（[一键安装助手](https://docs.bigmodel.cn/cn/coding-plan/extension/coding-tool-helper)）。Cursor 要按 [Cursor 页](https://docs.bigmodel.cn/cn/coding-plan/tool/cursor) 手配。
+
+### 快速决策：我该走哪扇门？
+
+```
+我要做什么？
+├── 在已经在用的 Claude Code / Cursor / Cline 里换 GLM、吃订阅额度
+│   └── → 本目录（先 Tutorial，再按工具页配置）
+├── 聊天、写作、通用助手
+│   └── → 智谱清言 / Z.ai（#74），不是本套餐
+├── 自建应用 / 网站 / 机器人 / SaaS 里调 GLM
+│   └── → BigModel 标准 API（FAQ 原文：不可享用 Coding 套餐额度）
+├── 团队统一席位、账单、IP 白名单
+│   └── → 团队版（标准版 / 高级版）
+└── 只要一个「智谱自己的 IDE」
+    └── → ZCode 是指定工具之一，教程看官方 tool/zcode，本目录不展开
+```
+
+国内与海外是两套域名。本中文手册默认 **国内**（`open.bigmodel.cn`）。海外端点见 [docs.z.ai/devpack](https://docs.z.ai/devpack/overview) 与英文目录。
+
+## 套餐边界（先看这个再订阅）
+
+| 项 | 官方口径 |
+|----|----------|
+| 可用模型 | 所有套餐：**GLM-5.3**、GLM-5-Turbo、GLM-4.7。调用 GLM-5.2 / GLM-5.1 自动切到 GLM-5.3 |
+| 能用在哪 | 仅限 [指定工具](https://docs.bigmodel.cn/cn/coding-plan/tool/others#%E4%B8%80%E3%80%81%E9%80%82%E7%94%A8%E5%B7%A5%E5%85%B7) |
+| 额度耗尽 | 等下一个 5 小时周期；**不**继续扣资源包 / 账户余额 |
+| 国内 Anthropic 端点 | `https://open.bigmodel.cn/api/anthropic` |
+| 国内 OpenAI Compatible 端点 | `https://open.bigmodel.cn/api/coding/paas/v4` |
+| 个人积分 | Lite 2,000 / 10,000；Pro 12,000 / 60,000；Max 28,000 / 140,000（5 小时 / 每周） |
+| 高峰 | 周一至周五 14:00–18:00（UTC+8）；非高峰模型调用按基础积分 **50%** 抵扣 |
+| OpenClaw 等通用 Agent | **次级调度** + 尽力交付；Coding Agent 任务优先 |
+
+刊例价以 [订阅页](https://bigmodel.cn/glm-coding) 当时展示为准。文档站 overview 不写人民币价，本页不回填。
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 分清门 | 本页家族表 | 不要进清言，也不要把套餐当标准 API |
+| 2. 订上并接到工具 | [Tutorial](./glm-coding.md) | 15 分钟内用 Helper 或手配跑通 Claude Code / Cursor |
+| 3. 切模型、MCP、排错 | [Cookbook](./glm-coding-cookbook.md) | GLM-5.3、视觉 / 搜索 MCP、`1113` |
+| 4. 回查数字 | [速查表](./glm-coding-cheatsheet.md) | 端点、积分、命令、指定工具名单 |
+| 5. 理清概念 | [术语表](./glm-coding-glossary.md) | 套餐 vs API vs 聊天、积分、次级调度 |
+
+## 功能速查
+
+只列官方编码套餐文档里有独立页的能力。
+
+| 能力 | 一句话 | 官方文档 |
+|------|--------|----------|
+| 套餐概览 | 模型、积分、指定工具 | [overview](https://docs.bigmodel.cn/cn/coding-plan/overview) |
+| 快速开始 | 注册、订阅、取 Key、选工具 | [quick-start](https://docs.bigmodel.cn/cn/coding-plan/quick-start) |
+| 一键安装助手 | `npx @z_ai/coding-helper` | [coding-tool-helper](https://docs.bigmodel.cn/cn/coding-plan/extension/coding-tool-helper) |
+| 指定工具 | 适用 Coding Agent / 通用 Agent 名单 | [tool/others](https://docs.bigmodel.cn/cn/coding-plan/tool/others) |
+| 切换模型 | Claude Code `settings.json` / 其它自定义模型 | [latest-model](https://docs.bigmodel.cn/cn/coding-plan/latest-model) |
+| 团队版 | 席位、团队 Key、超额按量 | [team](https://docs.bigmodel.cn/cn/coding-plan/team) |
+| 视觉 MCP | 本地 `@z_ai/mcp-server`，模型 GLM-4.6V | [vision](https://docs.bigmodel.cn/cn/coding-plan/mcp/vision-mcp-server) |
+| 联网搜索 MCP | Remote `web_search_prime` | [search](https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server) |
+| 网页读取 MCP | Remote Reader | [reader](https://docs.bigmodel.cn/cn/coding-plan/mcp/reader-mcp-server) |
+| 开源仓库 MCP | Remote Zread | [zread](https://docs.bigmodel.cn/cn/coding-plan/mcp/zread-mcp-server) |
+| GLM in Excel (Beta) | 套餐权益，不是编程 Agent | [glm-in-excel](https://docs.bigmodel.cn/cn/coding-plan/extension/glm-in-excel) |


### PR DESCRIPTION
Closes #75

## Summary

GLM Coding Plan 是订阅套餐，不是聊天产品。本 PR 按 doc-research + Diataxis 补了 ZH + EN 手册，只写套餐边界和怎么接到 Claude Code / Cursor 等指定工具。

清言 / Z.ai 只在家族图一行，正文归 #74。未改 `products-gallery.js` 与 sidebar（执行约束）。

## Files

- `.claude/skills/doc-research/references/glm-coding.md` — 形态调研 + 维护约定
- `docs/zh/products/glm-coding/` — 中文：map / tutorial / cookbook / cheatsheet / glossary
- `docs/products/glm-coding/` — 英文同构（端点与名单抄 `docs.z.ai/devpack`）

## Official install / load commands (verbatim)

```bash
npx @z_ai/coding-helper
npm install -g @z_ai/coding-helper
coding-helper
coding-helper auth glm_coding_plan_china <token>   # CN
coding-helper auth glm_coding_plan_global <token>  # global
npm install -g @anthropic-ai/claude-code
curl -O "https://cdn.bigmodel.cn/install/claude_code_env.sh" && bash ./claude_code_env.sh
curl -O "https://cdn.bigmodel.cn/install/claude_code_zai_env.sh" && bash ./claude_code_zai_env.sh
```

CN endpoints: `https://open.bigmodel.cn/api/anthropic` and `https://open.bigmodel.cn/api/coding/paas/v4`.

Global: `https://api.z.ai/api/anthropic` and `https://api.z.ai/api/coding/paas/v4`.

Helper auto-loads only Claude Code / OpenCode / Crush / Factory Droid. Cursor is manual.

## Family map

Official first-party AI entries from zhipuai.cn + coding-plan docs are on `index.md` (independent page / one row / out of scope). No Qingyan or Z.ai tutorial in this directory.

## Official conflicts called out, not smoothed

- overview / latest-model: current models are GLM-5.3 + GLM-5-Turbo + GLM-4.7
- `tool/claude` FAQ still shows GLM-4.7 mappings
- CN Cursor page example is uppercase `GLM-5.2`; global Cursor page examples are `GLM-4.7` / `GLM-4.5-air`
- team.md coefficient table still labels GLM-5.2

RMB list prices are **not** copied; they are not on the docs overview. Link the live subscribe page. Global overview quote kept: “Starting at just 18 USD per month”.

## Checks

- [x] No gallery / sidebar edits
- [x] No sibling-vendor tutorials in this directory
- [x] Commands and package names copied from official pages / `npm view @z_ai/coding-helper`
- [ ] `pnpm docs:build` not run in this isolated worktree (refactor working tree is dirty; pages are Markdown-only)