### PR TITLE
docs(codebuddy): add CodeBuddy handbook (ZH+EN) for #78

### DIFF
--- a/.claude/skills/doc-research/references/codebuddy.md
+++ b/.claude/skills/doc-research/references/codebuddy.md
@@ -1,0 +1,105 @@
+# CodeBuddy 维护参考
+
+> 这是 [`_template.md`](./_template.md) 针对腾讯云 CodeBuddy 的具体化。读者可见的数据源写在 `docs/zh/products/codebuddy/codebuddy-cheatsheet.md` 的「高质量信息源」。
+
+## 基本信息
+
+- 工具名：腾讯云代码助手 CodeBuddy（Tencent Cloud Code Assistant CodeBuddy）
+- 官方文档根地址：<https://www.codebuddy.cn/docs/>
+- 国际站文档根地址：<https://www.codebuddy.ai/docs/>（中文镜像 <https://www.codebuddy.ai/docs/zh/>）
+- 腾讯云产品页：<https://cloud.tencent.com/product/acc>
+- 腾讯云文档（WorkBuddy Enterprise / 形态总览）：<https://cloud.tencent.com/document/product/1831/134343>
+- 发版节奏：CLI 文档站「版本发布」按小版本连发（调研时侧栏头部约 v2.81.0）
+- 当前覆盖版本：2026-08-18 官方文档快照（不以某一个 CLI 小版本号写进读者正文标题）
+
+## 官方一级导航（产品家族）
+
+> 排轴 A/B 之前先填完。规则见 [`family-completeness.md`](./family-completeness.md)。抓页见 [`official-fetch.md`](./official-fetch.md)。
+>
+> 文档站顶栏一级（2026-08-18 打开 <https://www.codebuddy.cn/docs/>、<https://www.codebuddy.cn/docs/cli/troubleshooting>）：**IDE / 插件 / CLI / WorkBuddy / WorkBuddy 小程序 / WorkBuddy 移动端 / 企业版**。
+>
+> 官网顶栏另有：WorkBuddy、定价、文档、博客、API 文档、活动。这些是资源栏，不是独立编码产品。
+
+| 官方一级入口 | 官方 URL | 本站去向 | 不拆页理由（若一行） |
+|--------------|----------|----------|----------------------|
+| CodeBuddy IDE | <https://www.codebuddy.cn/docs/> · 安装 <https://www.codebuddy.cn/docs/ide/Getting-Started/Installation> · 下载 <https://www.codebuddy.cn/ide/> | 独立页（Tutorial 内） | |
+| CodeBuddy 插件 | <https://www.codebuddy.cn/docs/plugin/> | 独立页（Tutorial 内） | |
+| CodeBuddy Code（CLI） | <https://www.codebuddy.cn/docs/cli/> · 安装 <https://www.codebuddy.cn/docs/cli/installation> | 独立页（Tutorial 内） | |
+| WorkBuddy | <https://www.codebuddy.cn/docs/workbuddy/> · 官网 <https://www.codebuddy.cn/work/> | 地图一行 | 办公工作台，不是编码主线；#78 明确不写正文 |
+| WorkBuddy 小程序 | <https://www.codebuddy.cn/docs/workbuddymini/> | 地图一行 | WorkBuddy 移动入口；不写微信教程 |
+| WorkBuddy 移动端 | <https://www.codebuddy.cn/docs/workbuddyapp/> | 地图一行 | WorkBuddy App，不是编码主线 |
+| 企业版 | <https://www.codebuddy.cn/docs/ide/Codebuddy-enterprise-edition/Codebuddy-enterprise-purchase> · 云文档 <https://cloud.tencent.com/document/product/1831/134343> | 地图一行 | 购买 / 专享版流程，密度给企业管理员，不拆前端教程 |
+| 元宝（同厂，非本站一级） | <https://yuanbao.tencent.com/> | 地图一行 | 另 issue #76；本目录不写教程 |
+| 混元（同厂，非本站一级） | <https://hunyuan.tencent.com/> · 云产品 <https://cloud.tencent.com/product/tclm> | 地图一行 | 另 issue #77；本目录不写教程 |
+
+**本站只收**：CodeBuddy 的三种编程形态（IDE / 插件 / CLI）。
+
+**明确不收**：
+
+- 元宝、混元的完整教程（家族图一行 + 官方链接）
+- WorkBuddy / 小程序 / 移动端 / 企业版的完整教程
+- 微信、QQ、企业微信、微信支付、云主机等非 AI 产品
+- 官网营销数字（「提升编码效率 90%」一类）不当本站论断
+- 模型内部机制（链 Learn LLM）
+
+易撞名：
+
+- **CodeBuddy ≠ WorkBuddy**。前者是编码产品族；后者官方定义是「全场景 AI 办公工作台」。
+- **CodeBuddy 插件 ≠ CLI 的 plugin 系统**。插件是 VS Code / JetBrains 等编辑器扩展；CLI `codebuddy plugin` 是 CodeBuddy Code 自己的扩展包。
+- **CodeBuddy Code ≠ 只在 IDE 里写代码**。官方产品名是 **CodeBuddy Code**，可执行文件是 `codebuddy`，npm 包是 `@tencent-ai/codebuddy-code`。
+- **国内站 ≠ 国际站**。国内文档 / 登录走 `codebuddy.cn` 与 `copilot.tencent.com`；国际站走 `codebuddy.ai`。CLI 启动后四选一登录。
+- **混元是模型，不是 CodeBuddy 产品**。CodeBuddy 官方写「支持混元、DeepSeek 等多种对话大模型」。
+- **微信开发者工具**是插件官方支持的宿主 IDE 之一，不是本站要写的微信产品。
+
+## 文档文件结构（Diataxis）
+
+```
+docs/zh/products/codebuddy/
+├── index.md                    # 学习地图 + 家族图
+├── codebuddy.md                # Tutorial：三种形态装上并跑通
+├── codebuddy-cookbook.md       # How-to：官方工作流配方
+├── codebuddy-cheatsheet.md     # Reference：安装 / 命令 / 斜杠命令 / 数据源
+└── codebuddy-glossary.md       # Explanation：形态、权限、CODEBUDDY.md
+
+docs/products/codebuddy/        # 英文，与中文同构
+```
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 + 速查 | 家族图、决策树、学习路径 | 逐步安装 |
+| `codebuddy.md` | Tutorial | 装 IDE / 插件 / CLI、登录、第一次对话 | 完整 flag 表、概念长文 |
+| `codebuddy-cookbook.md` | How-to | `/init`、print 模式、自定义斜杠命令、MCP、从 Claude Code 迁移 | 安装、术语定义 |
+| `codebuddy-cheatsheet.md` | Reference | 安装原文、CLI 命令、斜杠命令、键位、数据源 | 学习路径、概念散文 |
+| `codebuddy-glossary.md` | Explanation | 是什么 / 不是什么 / 易撞名 | 命令清单 |
+
+三种编程形态密度都够写，但 #78 指定一个 Tutorial 覆盖 IDE / 插件 / CLI，不拆成三份主教程。
+
+## 监控页面
+
+- CLI 安装：<https://www.codebuddy.cn/docs/cli/installation>
+- CLI 快速开始：<https://www.codebuddy.cn/docs/cli/quickstart>
+- CLI 参考：<https://www.codebuddy.cn/docs/cli/cli-reference>
+- 斜杠命令：<https://www.codebuddy.cn/docs/cli/slash-commands>
+- 故障排查：<https://www.codebuddy.cn/docs/cli/troubleshooting>
+- IDE 安装：<https://www.codebuddy.cn/docs/ide/Getting-Started/Installation>
+- 插件安装：<https://www.codebuddy.cn/docs/plugin/>
+- 定价：<https://www.codebuddy.cn/pricing/>
+- 腾讯云产品页：<https://cloud.tencent.com/product/acc>
+- CLI 版本发布侧栏：<https://www.codebuddy.cn/docs/cli/troubleshooting>（侧栏「版本发布」）
+
+## Git 提交 scope
+
+```
+docs(codebuddy): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+- **安装命令以安装页为准，快速开始页另一套 URL 并存**：安装页原生安装是 `curl -fsSL https://www.codebuddy.cn/cli/install.sh | bash` 与 `irm https://www.codebuddy.cn/cli/install.ps1 | iex`。快速开始页写的是 `https://copilot.tencent.com/cli/install.sh` / `install.ps1`。两边都是官方页，不要合成一条，并排引用。
+- **Node.js 口径不完全一致**：CLI 安装页与故障排查写 **Node.js 18.20+**；文档总览 CLI 节写 **Node.js 18.0+**；腾讯云国际站产品 FAQ 写过 **Node.js 22+**。本站以 [安装指南](https://www.codebuddy.cn/docs/cli/installation) 的 18.20 为 CLI 包管理器通道的事实源，其它口径在正文标差异。
+- **国内站 / 国际站文档树不完全同步**：`www.codebuddy.ai/docs/` 英文总览曾写「两种形态（IDE 和 CLI）」；中文总览与腾讯云文档明确写 **IDE、插件、CLI 三种**。本站以中文文档站 + `cloud.tencent.com/document/product/1831/134343` 为准。
+- **`www.codebuddy.cn` / `www.codebuddy.ai` 在部分代理（fake-ip 198.18.x）下 curl 会 404**。核对安装原文用页面阅读器，不要用失败的 curl 当「页面不存在」。
+- **不要把 WorkBuddy 写进 Tutorial**。安装页提到 `CODEBUDDY_CONFIG_DIR` 可避免与 WorkBuddy 配置冲突，那是配置提示，不是 WorkBuddy 教程。
+- **不要写微信 / QQ 产品教程**。插件支持「微信开发者工具」只作为官方宿主表一行。
+- **额度**：官方只写「CLI、CodeBuddy IDE 和 CodeBuddy Plugin 共享同一账号的资源配额」。定价页是前端渲染，不要臆造套餐数字。链 <https://www.codebuddy.cn/pricing/>。
+- **不写精确 CLI 小版本到正文标题**。版本发布侧栏更新很快。

--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -12,5 +12,6 @@
 | Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
 | Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
 | Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| CodeBuddy | [`codebuddy.md`](./codebuddy.md) | `docs/zh/products/codebuddy/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/docs/products/codebuddy/codebuddy-cheatsheet.md
+++ b/docs/products/codebuddy/codebuddy-cheatsheet.md
@@ -1,0 +1,246 @@
+---
+title: CodeBuddy Cheatsheet
+description: "Lookup only. Install commands, CLI subcommands, slash commands, and keys are copied from the codebuddy.cn docs. Treat codebuddy --help and the official pages as the full set."
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# CodeBuddy Cheatsheet
+
+Lookup only. Install commands, CLI subcommands, slash commands, and keys are copied from official pages. The full set is `codebuddy --help` plus the links below.
+
+Verified **2026-08-18**.
+
+## Install and update
+
+Sources: [Install guide](https://www.codebuddy.cn/docs/cli/installation), [Quick start](https://www.codebuddy.cn/docs/cli/quickstart), [Troubleshooting](https://www.codebuddy.cn/docs/cli/troubleshooting)
+
+| Case | Command / action | Source |
+|------|------------------|--------|
+| npm | `npm install -g @tencent-ai/codebuddy-code` | Install |
+| pnpm | `pnpm add -g @tencent-ai/codebuddy-code` | Install |
+| yarn | `yarn global add @tencent-ai/codebuddy-code` | Install |
+| bun | `bun install -g @tencent-ai/codebuddy-code` | Install |
+| Homebrew | `brew tap Tencent-CodeBuddy/tap` then `brew install codebuddy-code` | Install |
+| Native fresh (install page) | `curl -fsSL https://www.codebuddy.cn/cli/install.sh \| bash` | Install |
+| Native Windows (install page) | `irm https://www.codebuddy.cn/cli/install.ps1 \| iex` | Install |
+| Native fresh (quick start) | `curl -fsSL https://copilot.tencent.com/cli/install.sh \| bash` | Quick start |
+| Native Windows (quick start) | `irm https://copilot.tencent.com/cli/install.ps1 \| iex` | Quick start |
+| npm → native | `codebuddy install` | Install |
+| Verify | `codebuddy --version` | Install |
+| Update | `codebuddy update` | Install / troubleshooting |
+| npm update fallback | `npm install -g @tencent-ai/codebuddy-code@latest` | Troubleshooting |
+| npm latest | `npm view @tencent-ai/codebuddy-code version` | Troubleshooting |
+| Disable auto-update | `export DISABLE_AUTOUPDATER=1` | Install |
+| Uninstall Homebrew | `brew uninstall codebuddy-code` | Install |
+| Uninstall npm | `npm uninstall -g @tencent-ai/codebuddy-code` | Install |
+| Remove native binary | `rm -f ~/.local/bin/codebuddy` | Install |
+
+Node.js: **18.20+** (install + troubleshooting). The overview has said 18.0+. Do not mix the two.
+
+Native PATH: `~/.local/bin`; Windows `%USERPROFILE%\AppData\Local\codebuddy\bin`.
+
+Config dir: `~/.codebuddy` / `%USERPROFILE%\.codebuddy`. Override: `CODEBUDDY_CONFIG_DIR`.
+
+IDE download: [codebuddy.cn/ide](https://www.codebuddy.cn/ide/) · CN [copilot.tencent.com/ide](https://copilot.tencent.com/ide) · intl [codebuddy.ai](https://www.codebuddy.ai/). Requirements: [IDE install](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation).
+
+Plugin: marketplace search **腾讯云代码助手**. [Plugin page](https://www.codebuddy.cn/docs/plugin/).
+
+## CLI commands
+
+Source: [CLI reference](https://www.codebuddy.cn/docs/cli/cli-reference)
+
+| Command | What it does | Example |
+|---------|--------------|---------|
+| `codebuddy` | Interactive REPL | `codebuddy` |
+| `codebuddy "query"` | REPL with an opening prompt | `codebuddy "Explain this project"` |
+| `codebuddy -p "query"` | Print and exit | `codebuddy -p "Explain this function"` |
+| `cat file \| codebuddy -p "query"` | Pipe | `cat logs.txt \| codebuddy -p "Analyze the log"` |
+| `codebuddy -c` | Continue the latest chat | `codebuddy -c` |
+| `codebuddy -c -p "query"` | Continue in print mode | `codebuddy -c -p "Check type errors"` |
+| `codebuddy -r "<id>" "query"` | Resume by id | `codebuddy -r "abc123" "Finish this MR"` |
+| `codebuddy update` | Update | `codebuddy update` |
+| `codebuddy mcp` | Configure MCP | See [MCP](https://www.codebuddy.cn/docs/cli/mcp) |
+| `codebuddy daemon start` | Start daemon | `codebuddy daemon start --port 8080` |
+| `codebuddy daemon stop` / `status` / `restart` | Stop / inspect / restart | |
+| `codebuddy daemon install` / `uninstall` | Register or remove a system service | `codebuddy daemon install --port 8080` |
+| `codebuddy auto-mode defaults` / `config` / `critique` | Inspect auto-mode rules | |
+| `codebuddy ps` | List workers | `codebuddy ps` |
+| `codebuddy logs <name>` | Worker logs | `codebuddy logs feature-x` |
+| `codebuddy attach <name>` | Attach to a worker | `codebuddy attach feature-x` |
+| `codebuddy kill <name>` | Kill a worker | `codebuddy kill feature-x` |
+| `codebuddy plugin install <plugin>` | Install a CLI plugin | See [plugin reference](https://www.codebuddy.ai/docs/cli/plugins-reference) |
+
+## Common flags
+
+Source: [CLI reference](https://www.codebuddy.cn/docs/cli/cli-reference). Daily subset, not the full page.
+
+| Flag | Meaning |
+|------|---------|
+| `--print`, `-p` | Print and exit |
+| `-y` / `--dangerously-skip-permissions` | Skip permission prompts |
+| `--permission-mode` | `default` / `acceptEdits` / `auto` / `dontAsk` / `plan` / `bypassPermissions` |
+| `--continue` / `-c` | Latest chat in this directory |
+| `--resume` | Resume by id |
+| `--model` | Model for this session |
+| `--ide` | Connect to an IDE on start |
+| `--add-dir` | Extra work directory |
+| `--sandbox` | Sandbox (Beta) |
+| `--worktree [name]` | Isolated git worktree |
+| `--tmux` | With `--worktree` |
+| `--bg` / `--name` | Background session |
+| `--serve` | HTTP server |
+| `--plugin-dir` | Load plugins from local dirs |
+| `--output-format` | `text` / `json` / `stream-json` (print mode) |
+| `--max-turns` | Max non-interactive turns |
+| `--verbose` / `--debug` | Verbose / debug |
+| `--system-prompt` / `--append-system-prompt` | Replace or append the system prompt |
+| `--mcp-config` | Load MCP JSON |
+
+Official note: `-p` plus file / shell / network work needs an explicit permission policy (`-y`, `--permission-mode auto` / `dontAsk`, pre-set `permissions.allow`, or a permission-prompt MCP tool).
+
+## Slash commands
+
+Source: [Slash commands](https://www.codebuddy.cn/docs/cli/slash-commands). High-frequency subset; full table is on the official page.
+
+| Command | Role |
+|---------|------|
+| `/help` | Help |
+| `/clear` | New conversation |
+| `/login` / `/logout` | Sign in / out |
+| `/init` | Initialize repo context |
+| `/config` | Local settings |
+| `/model` | Switch or list models |
+| `/status` / `/doctor` | Session / environment |
+| `/mcp` | MCP |
+| `/skills` | Loaded Skills |
+| `/plugin` | CLI plugins and marketplaces |
+| `/compact` | Compact context |
+| `/cost` / `/stats` | Token / usage |
+| `/resume` / `/rewind` | Resume / rewind checkpoint |
+| `/permissions` | Tool and directory permissions |
+| `/plan` | Preview the plan file |
+| `/ide` | IDE connection |
+| `/sandbox` | Bash sandbox |
+| `/memory` | Long-term memory |
+| `/upgrade` | Open the upgrade page |
+
+Custom commands: project `.codebuddy/commands/*.md`, user `~/.codebuddy/commands/*.md`. `test.md` → `/test`. Nested dirs use colons: `frontend/build.md` → `/frontend:build`.
+
+## Keys
+
+Source: [Quick start · shortcuts](https://www.codebuddy.cn/docs/cli/quickstart)
+
+| Key | Action |
+|-----|--------|
+| `↑/↓` | History; `↓` lists background tasks when any are running |
+| `Tab` | Complete |
+| `Esc` | Clear input (twice) / go up |
+| `Ctrl+C` / `Ctrl+D` | Quit (`Ctrl+D` needs an empty input, twice) |
+| `Shift+Tab` (Windows also `Alt+M`) | Permission cycle `default → bypass → accept → plan` |
+| `Enter` | Send |
+| `Shift+Enter` / `\Enter` / `Ctrl+J` | Newline |
+| `Ctrl+G` | Edit the prompt in an external editor |
+| `Ctrl+R` | Expand / collapse detail |
+| `Ctrl+O` | Thinking panel |
+
+JetBrains terminal: ESC may not work — use `Ctrl+ESC` or `Shift+ESC` ([troubleshooting](https://www.codebuddy.cn/docs/cli/troubleshooting)).
+
+## MCP add (excerpt)
+
+Source: [MCP](https://www.codebuddy.cn/docs/cli/mcp)
+
+```bash
+codebuddy mcp add --scope user my-tool -- /path/to/tool arg1 arg2
+codebuddy mcp add --scope project python-tool -- python /path/to/script.py
+codebuddy mcp add --scope user --transport sse sse-server https://example.com/mcp/sse
+codebuddy mcp add --scope project --transport http http-server https://example.com/mcp/http
+```
+
+## Decision table
+
+| Situation | Pick |
+|-----------|------|
+| Already in VS Code / JetBrains | Plugin |
+| One sentence → prototype / design / deploy | IDE |
+| Terminal / CI / headless | CLI |
+| Office docs / PPT, not a repo | WorkBuddy (not taught here) |
+| General chat | Yuanbao (not taught here) |
+| China account | CLI Chinese Site |
+| Overseas account | CLI International Site |
+
+## Glossary index
+
+One-line hooks. Definitions live in the [Glossary](./codebuddy-glossary).
+
+| Term | Hook | More |
+|------|------|------|
+| CodeBuddy IDE | Standalone editor | [Glossary](./codebuddy-glossary#codebuddy-ide) |
+| CodeBuddy Plugin | Extension in an existing IDE | [Glossary](./codebuddy-glossary#codebuddy-plugin) |
+| CodeBuddy Code | Terminal agent, `codebuddy` | [Glossary](./codebuddy-glossary#codebuddy-code) |
+| WorkBuddy | Office workbench, not the coding path | [Glossary](./codebuddy-glossary#workbuddy) |
+| CN / intl sites | Two docs and login domains | [Glossary](./codebuddy-glossary#cn-vs-intl-sites) |
+| `CODEBUDDY.md` | Migratable instruction file | [Glossary](./codebuddy-glossary#codebuddymd) |
+
+## Common errors
+
+| Symptom | Official handling |
+|---------|-------------------|
+| `codebuddy: command not found` | PATH missing the install dir; `source ~/.zshrc` |
+| Windows "not recognized" | `npm config get prefix`, add the global npm dir to PATH |
+| npm succeeded, binary still old | Multiple binaries (npm + Homebrew / nvm) |
+| Native binary missing | `export PATH="$HOME/.local/bin:$PATH"` |
+| `-p` cannot touch files | Add `-y` or another permission policy |
+| LAN `--serve` empty response | Listens on `127.0.0.1`; use `--host 0.0.0.0` |
+
+## Agent SDK (optional)
+
+Source: [Agent SDK](https://www.codebuddy.cn/docs/cli/sdk). Docs target SDK v0.1.0+.
+
+```bash
+npm install @tencent-ai/agent-sdk
+```
+
+```bash
+pip install codebuddy-agent-sdk
+```
+
+TypeScript/JavaScript needs Node.js >= 18.20. This site does not treat the SDK as the main path.
+
+## High-quality sources
+
+Last verified: 2026-08-18. Only pages opened during research.
+
+### First-party
+
+| Source | Use |
+|--------|-----|
+| [codebuddy.cn](https://www.codebuddy.cn/) | CN marketing site |
+| [codebuddy.cn/docs](https://www.codebuddy.cn/docs/) | ZH overview (three forms) |
+| [IDE install](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation) | IDE requirements and login |
+| [Plugin docs](https://www.codebuddy.cn/docs/plugin/) | Host versions and install |
+| [CLI overview](https://www.codebuddy.cn/docs/cli/) | CLI entry |
+| [CLI install](https://www.codebuddy.cn/docs/cli/installation) | Package managers / native / uninstall |
+| [CLI quick start](https://www.codebuddy.cn/docs/cli/quickstart) | Login, `/init`, keys, `-p` |
+| [CLI reference](https://www.codebuddy.cn/docs/cli/cli-reference) | Subcommands and flags |
+| [Slash commands](https://www.codebuddy.cn/docs/cli/slash-commands) | Full `/` table |
+| [Troubleshooting](https://www.codebuddy.cn/docs/cli/troubleshooting) | Node, Windows, migration, quota |
+| [MCP](https://www.codebuddy.cn/docs/cli/mcp) | `codebuddy mcp add` |
+| [SDK](https://www.codebuddy.cn/docs/cli/sdk) | Agent SDK |
+| [Pricing](https://www.codebuddy.cn/pricing/) | Plan entry (client-rendered) |
+| [Tencent Cloud acc](https://cloud.tencent.com/product/acc) | Cloud product page |
+| [Overview 1831](https://cloud.tencent.com/document/product/1831/134343) | Three-form comparison |
+| [codebuddy.ai/docs](https://www.codebuddy.ai/docs/) | Intl docs |
+| [codebuddy.ai/docs/zh](https://www.codebuddy.ai/docs/zh/) | Intl ZH mirror |
+| [WorkBuddy intro](https://www.codebuddy.cn/docs/workbuddy/) | Map-row source |
+| [WorkBuddy mini program](https://www.codebuddy.cn/docs/workbuddymini/) | Map row |
+| [WorkBuddy mobile](https://www.codebuddy.cn/docs/workbuddyapp/) | Map row |
+| [Yuanbao](https://yuanbao.tencent.com/) | Same-vendor assistant |
+| [Hunyuan](https://hunyuan.tencent.com/) | Same-vendor model |
+
+### Unverified
+
+- Concrete pricing numbers (page is client-rendered; 2026-08-18 reader did not extract a tariff table)
+- Whether a repo-root `CODEBUDDY.md` is auto-injected the same way as `~/.codebuddy/CODEBUDDY.md` (troubleshooting only names the migration file)

--- a/docs/products/codebuddy/codebuddy-cookbook.md
+++ b/docs/products/codebuddy/codebuddy-cookbook.md
@@ -1,0 +1,195 @@
+---
+title: CodeBuddy Cookbook
+description: "For readers who can already sign in. Each recipe copies official steps: goal, commands, then the pitfall. No install walkthrough."
+domain: product
+tags:
+  - coding-agent
+role: cookbook
+---
+
+# CodeBuddy Cookbook
+
+For people who can already sign in. Each recipe is one job: goal, official commands, then the pitfall.
+
+If you cannot install yet, read the [tutorial](./codebuddy). Command lookup is the [cheatsheet](./codebuddy-cheatsheet).
+
+## Run `/init` before you edit a repo
+
+**Goal**: build project context in the CLI before a large change.
+
+Source: [Quick start](https://www.codebuddy.cn/docs/cli/quickstart)
+
+```bash
+cd /path/to/your-project
+codebuddy
+```
+
+```
+> /init
+```
+
+The official page marks `/init` as "strongly recommended": it builds a knowledge graph so later turns scan less. After a large structural change:
+
+```
+> /clear
+> /init
+```
+
+**Pitfall**: skipping `/init` and throwing a cross-file task at a cold session. Official copy says that is slower and more error-prone. "The repo is huge so it must know" is not a substitute.
+
+## One-shot review in print mode
+
+**Goal**: run once from a script or pipe, no REPL.
+
+Sources: [Quick start](https://www.codebuddy.cn/docs/cli/quickstart), [CLI reference](https://www.codebuddy.cn/docs/cli/cli-reference)
+
+```bash
+codebuddy -p "Optimize this SQL query"
+cat error.log | codebuddy -p "Analyze these error logs"
+codebuddy -p "Review code quality of src/utils.js" -y
+```
+
+Official wording: with `-p/--print`, operations that need file access or command execution must add `-y` (or `--dangerously-skip-permissions`). You may also use `--permission-mode auto` / `dontAsk`, or pre-set `permissions.allow`.
+
+**Pitfall**: `-p` alone blocks turns that need confirmation. `-y` skips prompts; official text says use it carefully.
+
+## Add a custom slash command
+
+**Goal**: turn a repeated task into `/name`.
+
+Source: [Slash commands · custom](https://www.codebuddy.cn/docs/cli/slash-commands)
+
+- Project: `.codebuddy/commands/`
+- User: `~/.codebuddy/commands/`
+
+`test.md` registers `/test`. Nested dirs use colons: `commands/frontend/build.md` → `/frontend:build`.
+
+Official review example:
+
+```markdown
+---
+description: "Review the given files"
+argument-hint: "[file-paths...]"
+allowed-tools: Read
+---
+
+Please review the following files for quality, maintainability, and security:
+
+@$ARGUMENTS
+```
+
+Commands that run shell lines need `Bash` in frontmatter or the official page says they will not run.
+
+**Pitfall**: custom slash commands are user-triggered. Official Skills are "templates the AI recognizes and invokes". Do not write them as one system.
+
+## Add an MCP server
+
+**Goal**: let the CLI call an external tool.
+
+Source: [MCP](https://www.codebuddy.cn/docs/cli/mcp)
+
+```bash
+codebuddy mcp add --scope user my-tool -- /path/to/tool arg1 arg2
+codebuddy mcp add --scope project python-tool -- python /path/to/script.py
+codebuddy mcp add --scope user --transport sse sse-server https://example.com/mcp/sse
+codebuddy mcp add --scope project --transport http http-server https://example.com/mcp/http
+```
+
+CloudBase's own docs say IDE users authorize **Tencent CloudBase** in Settings / Integrations instead of writing MCP by hand. That is CloudBase's wording; trust the settings page on your machine.
+
+## Migrate from Claude Code
+
+**Goal**: reuse Claude Code agents / commands / skills / instruction files.
+
+Source: [Troubleshooting · migrate from Claude Code](https://www.codebuddy.cn/docs/cli/troubleshooting)
+
+Official mapping:
+
+| Path | Role |
+|------|------|
+| `agents/` | Custom agents |
+| `commands/` | Slash commands |
+| `skills/` | Skills |
+| `CLAUDE.md` → `CODEBUDDY.md` | AI instructions and memory |
+
+Option 1 (official recommended, symlinks):
+
+```bash
+cd ~/.codebuddy
+ln -s ~/.claude/agents agents
+ln -s ~/.claude/commands commands
+ln -s ~/.claude/skills skills
+ln -s ~/.claude/CLAUDE.md CODEBUDDY.md
+```
+
+Option 2 (copy, independent configs):
+
+```bash
+cp -r ~/.claude/agents ~/.codebuddy/agents
+cp -r ~/.claude/commands ~/.codebuddy/commands
+cp -r ~/.claude/skills ~/.codebuddy/skills
+cp ~/.claude/CLAUDE.md ~/.codebuddy/CODEBUDDY.md
+```
+
+Verify:
+
+```bash
+codebuddy
+```
+
+```
+> /skills
+> /config
+```
+
+Official note: Skills from Claude Code plugins can be installed in one click and load automatically.
+
+**Pitfall**: this copies config. It does not make Claude Code and CodeBuddy the same product. Permission modes, login domains, and quota stay on the CodeBuddy account.
+
+## Control tokens: new task, new session
+
+**Goal**: do not stuff ten unrelated jobs into one chat.
+
+Source: [Troubleshooting · cost](https://www.codebuddy.cn/docs/cli/troubleshooting)
+
+Official rules:
+
+- `/clear` for a new task
+- `/compact` on a long chat
+- `@filename` instead of pasting code
+
+Official comparison (their numbers, not this site's measurements):
+
+| Approach | Input tokens | Relative cost |
+|----------|--------------|---------------|
+| 10 tasks in one session | ~50,000 | High |
+| New session per task | ~15,000 | Low |
+| Periodic `/compact` | ~25,000 | Medium |
+
+Official advice: `/compact` every 20–30 turns.
+
+## Ask the plugin about the whole repo
+
+**Goal**: question the project, not just the current file.
+
+Source: [Product overview](https://cloud.tencent.com/document/product/1831/134343)
+
+Official mentions: `@workspace` and `#Codebase` for structure, class relationships, dependencies, and business flow.
+
+**Pitfall**: this is plugin / IDE repo Q&A. It is not the same switch as CLI `/init`.
+
+## IDE: one sentence to a previewable artifact
+
+**Goal**: use the standalone IDE for 0-to-1, not a one-line patch in an old repo.
+
+Sources: [Product overview](https://cloud.tencent.com/document/product/1831/134343), [IDE landing](https://www.codebuddy.cn/ide/)
+
+Official chain: natural-language idea → structured PRD → prototype / mock (or sketch / component library) → design-to-code (built-in Figma) → CloudBase / Supabase → CloudStudio / EdgeOne Pages.
+
+**Pitfall**: this is the IDE's home field. The plugin does not become the same product-design-dev pipeline. Do not invent console paths for deploy or BaaS; use the IDE settings page.
+
+## Guardrails
+
+- Every command in a recipe must exist on a linked official page. No "usually you can".
+- Do not teach WorkBuddy, Yuanbao, WeChat, or QQ here.
+- Do not install a CLI `plugin` and an editor extension as if they were one step.

--- a/docs/products/codebuddy/codebuddy-glossary.md
+++ b/docs/products/codebuddy/codebuddy-glossary.md
@@ -1,0 +1,146 @@
+---
+title: CodeBuddy Glossary
+description: "No how-to. Name collisions in the CodeBuddy family: three coding surfaces, WorkBuddy, Hunyuan, CN vs intl sites, CODEBUDDY.md."
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# CodeBuddy Glossary
+
+No how-to. This page answers "what is it / what is it not". Pick a surface on the [map](./).
+
+## Concept map
+
+```
+Tencent AI (the slice this directory cares about)
+├── CodeBuddy — coding family
+│   ├── IDE
+│   ├── Plugin (VS Code / JetBrains / …)
+│   └── CodeBuddy Code (CLI, command codebuddy)
+│       ├── Interactive REPL
+│       ├── Print (-p)
+│       └── CLI-native plugin / Skills / MCP
+├── WorkBuddy — office workbench (not the coding path)
+├── Yuanbao — general assistant
+└── Hunyuan — model (one engine CodeBuddy can switch to)
+```
+
+## CodeBuddy
+
+**What it is**: Tencent Cloud's AI coding assistant. Official definition ([docs overview](https://www.codebuddy.cn/docs/), [product overview](https://cloud.tencent.com/document/product/1831/134343)): **IDE, plugin, and CLI**.
+
+**What it is not**: not Hunyuan itself, not Yuanbao, not WorkBuddy. Marketing copy says it is based on Hunyuan code models; the same official docs also mention DeepSeek and other chat models.
+
+The three coding forms share one account quota ([troubleshooting](https://www.codebuddy.cn/docs/cli/troubleshooting)).
+
+## CodeBuddy IDE
+
+**What it is**: a standalone editor. Official pitch: a product-design-dev workbench; "conversation is programming". Audience: PMs / designers / full-stack / beginners.
+
+**Why it exists**: the plugin assists inside an IDE you already have; the IDE keeps requirements, design, code, and deploy in one product.
+
+**What it is not**: not a reskin of the VS Code extension. Requirements: macOS 11+ / Windows 10+ ([install](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation)).
+
+## CodeBuddy Plugin
+
+**What it is**: an extension for an existing editor. Official marketplace name: **腾讯云代码助手**. Hosts include VS Code, Visual Studio, JetBrains family, Android Studio, and WeChat DevTools ([plugin page](https://www.codebuddy.cn/docs/plugin/)).
+
+**Why it exists**: you already have an editor and a workflow; you want completion, chat, and repo Q&A.
+
+**What it is not**:
+
+- not `codebuddy plugin` on the CLI
+- listing WeChat DevTools as a host is not a WeChat or QQ product tutorial
+
+## CodeBuddy Code
+
+**What it is**: an AI CLI for professional engineers. Binary `codebuddy`, npm package `@tencent-ai/codebuddy-code`. Official audience: DevOps / SRE / senior engineers.
+
+**Three faces** (one product):
+
+| Face | Entry |
+|------|-------|
+| Interactive REPL | `codebuddy` |
+| Print / headless | `codebuddy -p "..."` |
+| Hosted extras | `codebuddy --serve`, `daemon`, `--bg` |
+
+**What it is not**: not a retired "Tencent Copilot" product name. The CN login host is `copilot.tencent.com`; that is an auth site, not a second product.
+
+## WorkBuddy
+
+**What it is**: official wording ([WorkBuddy intro](https://www.codebuddy.cn/docs/workbuddy/)) — "WorkBuddy is Tencent's all-scenario AI office workbench." The docs nav lists it next to CodeBuddy IDE / plugin / CLI.
+
+**Why it is on this table**: family completeness forbids dropping a first-level entry. Issue #78 only ships the three coding forms, so WorkBuddy stays one row.
+
+**What it is not**: not "CodeBuddy IDE on a phone". The mini program and the App belong to WorkBuddy.
+
+## Yuanbao
+
+**What it is**: Tencent's general AI assistant. [yuanbao.tencent.com](https://yuanbao.tencent.com/).
+
+**What it is not**: not CodeBuddy. No tutorial here (issue #76).
+
+## Hunyuan
+
+**What it is**: Tencent's model family. [hunyuan.tencent.com](https://hunyuan.tencent.com/), [cloud tclm](https://cloud.tencent.com/product/tclm). CodeBuddy official copy: Hunyuan, DeepSeek, and other chat models.
+
+**What it is not**: not a coding IDE, and not something you `npm install`. No Hunyuan API tutorial here (issue #77).
+
+## CN vs intl sites
+
+**What they are**: two sites and two login domains.
+
+| | China | International |
+|--|-------|----------------|
+| Docs / marketing | codebuddy.cn | codebuddy.ai |
+| CLI login option | Chinese Site → copilot.tencent.com | International Site → codebuddy.ai |
+| IDE download (official table) | [copilot.tencent.com/ide](https://copilot.tencent.com/ide) | [codebuddy.ai](https://www.codebuddy.ai/) |
+
+**Why it matters**: model lists and auth domains differ. The official quick start says the China site supports mainstream CN models and the intl site supports mainstream overseas models.
+
+**What they are not**: not "one site is stale". Both update. If an English overview omits the plugin form, follow the ZH overview and Tencent Cloud 1831 docs.
+
+## Enterprise
+
+**What it is**: SaaS flagship and dedicated private-cloud editions. Sign-in goes through Tencent Unified Identity or an address from your admin.
+
+**What it is not**: not a reskin of the personal plan. Purchase is out of this tutorial.
+
+## `CODEBUDDY.md`
+
+**What it is**: the official counterpart of `CLAUDE.md` when migrating from Claude Code — "AI instructions and memory". The user-level path in the sample is `~/.codebuddy/CODEBUDDY.md`.
+
+**Why it exists**: standing rules should not be retyped every session.
+
+**What it is not**: not the CLI plugin list, and not the Skills directory. Skills live in `~/.codebuddy/skills/`; custom slash commands live in `.codebuddy/commands/`.
+
+Whether a repo-root `CODEBUDDY.md` is auto-read is not a hard sentence on the troubleshooting page. Check `/config` and the official memory doc.
+
+<!-- TODO: 待核实 — auto-injection scope of a repo-root CODEBUDDY.md -->
+
+## Permission modes
+
+**What they are**: CLI knobs for "ask me before this tool call". Official `--permission-mode` values: `default`, `acceptEdits`, `auto`, `dontAsk`, `plan`, `bypassPermissions`. The `Shift+Tab` cycle is written `default → bypass → accept → plan`.
+
+**Why two namings**: the key hint uses short names; scripts should use the flag names.
+
+**What they are not**: not the sandbox. `--sandbox` (official Beta) limits filesystem / network after a call is approved.
+
+## CLI plugin vs editor plugin
+
+| | Editor plugin | CLI plugin |
+|--|---------------|------------|
+| Lives in | VS Code / JetBrains… | `codebuddy plugin install` |
+| Docs tree | `/docs/plugin/` | `/docs/cli/` plugin system / marketplace |
+| Job | Completion and chat in an existing IDE | Package Skills / hooks / tools for the terminal agent |
+
+Same English word, two installs.
+
+## Do not write these as facts
+
+- "CodeBuddy is only a plugin" — official first-level nav has three coding forms
+- "CodeBuddy is the Hunyuan IDE" — Hunyuan is a model
+- A `gh`-style Tencent Copilot extension as the current CLI — the shipping package is `@tencent-ai/codebuddy-code`
+- WorkBuddy as a CodeBuddy mode

--- a/docs/products/codebuddy/codebuddy.md
+++ b/docs/products/codebuddy/codebuddy.md
@@ -1,0 +1,275 @@
+---
+title: CodeBuddy Tutorial
+description: "Install CodeBuddy IDE, the editor plugin, or the CLI from official steps and finish the first sign-in. Commands are copied from the codebuddy.cn docs, not rewritten from memory."
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# CodeBuddy Tutorial
+
+> This is a **tutorial** — follow it once and you will download or install one surface, sign in, and send a first prompt.
+>
+> Look up commands in the [Cheatsheet](./codebuddy-cheatsheet); copy recipes from the [Cookbook](./codebuddy-cookbook); untangle names in the [Glossary](./codebuddy-glossary).
+
+Goal: stop treating CodeBuddy as "Tencent also has a coding assistant" and start knowing whether to open the IDE, install the plugin, or run `codebuddy`.
+
+## Step 0: pick a surface
+
+The three official coding forms are not one product with three skins. The table is from the [product overview](https://cloud.tencent.com/document/product/1831/134343):
+
+| Your situation | Use |
+|----------------|-----|
+| You already live in VS Code / JetBrains / Visual Studio | **Plugin** |
+| You want one sentence → prototype, mock, deployable app | **IDE** |
+| You work in a terminal, or need headless / CI / bulk repo edits | **CLI (CodeBuddy Code)** |
+
+The three forms share one account quota ([troubleshooting](https://www.codebuddy.cn/docs/cli/troubleshooting)). Install one to start.
+
+The pricing page is client-rendered. This site does not invent plan numbers. See [codebuddy.cn/pricing](https://www.codebuddy.cn/pricing/). The page description mentions a limited-time free personal plan, a limited-time free enterprise flagship plan, and a dedicated enterprise edition.
+
+## Install the IDE
+
+Source: [Install and sign-in](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation).
+
+**Requirements** (official table):
+
+| OS | Supported versions |
+|----|--------------------|
+| macOS | macOS 11 (Big Sur) and later |
+| Windows | Windows 10 and later (Windows 7/8/8.1 not supported) |
+
+Official note: systems that miss those versions cannot start CodeBuddy IDE.
+
+**Download**: [CodeBuddy CN](https://www.codebuddy.cn/) or the [IDE landing page](https://www.codebuddy.cn/ide/), matching your CPU. Official CN download is also listed as [copilot.tencent.com/ide](https://copilot.tencent.com/ide); intl is [codebuddy.ai](https://www.codebuddy.ai/).
+
+**macOS**: drag the package into Applications.
+
+**Windows** (official steps):
+
+1. Double-click the installer. If it asks to install for the current user only, choose **OK**.
+2. Accept the agreement.
+3. Pick the install location and keep choosing **Next**.
+
+**Personal sign-in** (official): open the IDE → **Sign in** → WeChat or phone number → return to the IDE.
+
+Enterprise / dedicated editions use Tencent Unified Identity or an address from your admin. This tutorial does not cover purchase.
+
+Update: top-right **Account** → **Check for updates** → **Install now** if a build is waiting.
+
+## Install the plugin
+
+Source: [Plugin docs home](https://www.codebuddy.cn/docs/plugin/).
+
+**Official minimum versions** (plugin page; the overview lists Visual Studio as 17.0, the plugin page lists 17.6 — this table follows the plugin page):
+
+| IDE | Minimum |
+|-----|---------|
+| Visual Studio Code | 1.82 |
+| Visual Studio | 17.6 (VS 2022) |
+| IntelliJ IDEA / PyCharm / GoLand / CLion / PhpStorm | 2022.2 |
+| Android Studio | Flamingo \| 2022.2.1 |
+| WeChat DevTools IDE | 1.06.2409140 |
+
+Official notes: other JetBrains IDEs follow the JetBrains marketplace; a compatibility pack goes down to 2020.3 but "cannot use the latest product features".
+
+**VS Code** (three official paths):
+
+1. Install VS Code 1.82+.
+2. Install the extension by any of:
+   - Official one-click install (VS Code must already be installed)
+   - Marketplace search **腾讯云代码助手**
+   - Download the package and install it by hand
+
+**JetBrains**: Settings → **Plugins** → search **腾讯云代码助手** → **Install**; or install from disk.
+
+**Sign-in**: official [login page](https://www.codebuddy.cn/docs/plugin/%E5%BF%AB%E9%80%9F%E5%85%A5%E9%97%A8/%E7%99%BB%E5%BD%95%E5%8F%8A%E9%80%80%E5%87%BA) — click the status-bar icon or the plugin login page.
+
+Plugin capabilities ([product overview](https://cloud.tencent.com/document/product/1831/134343)): inline completion, fix, explain, unit tests, local review, `@workspace` / `#Codebase`, chat, custom instructions, RAG knowledge bases, Hunyuan / DeepSeek model switching.
+
+First session: open a file you know, accept one completion, then ask what the file does. For repo-level questions use the official `@workspace` or `#Codebase` mentions. Do not assume the plugin has ingested every repo at the company.
+
+## Install the CLI
+
+The product name is **CodeBuddy Code**. The binary is `codebuddy`. The npm package is `@tencent-ai/codebuddy-code`.
+
+Sources: [Installation guide](https://www.codebuddy.cn/docs/cli/installation), [Quick start](https://www.codebuddy.cn/docs/cli/quickstart).
+
+### Package managers (start here)
+
+**Prerequisite (install page):** Node.js **18.20** or later.
+
+The troubleshooting page says the same. The docs overview CLI section says `Node.js 18.0+`. Tencent Cloud intl FAQ has said Node.js 22+. This page follows the install guide.
+
+Official package-manager commands:
+
+```bash
+npm install -g @tencent-ai/codebuddy-code
+```
+
+```bash
+pnpm add -g @tencent-ai/codebuddy-code
+```
+
+```bash
+yarn global add @tencent-ai/codebuddy-code
+```
+
+```bash
+bun install -g @tencent-ai/codebuddy-code
+```
+
+**Homebrew (macOS/Linux, no Node.js)** from the install page:
+
+```bash
+brew tap Tencent-CodeBuddy/tap
+brew install codebuddy-code
+```
+
+or:
+
+```bash
+brew install Tencent-CodeBuddy/tap/codebuddy-code
+```
+
+Verify (install page):
+
+```bash
+codebuddy --version
+```
+
+### Native binary (Beta)
+
+The install page marks native install as **Beta**. Platforms: macOS (Apple Silicon or Intel x86_64), Linux (arm64 or x86_64), Windows (x86_64).
+
+Migrate from npm:
+
+```bash
+codebuddy install
+```
+
+Fresh install (**install page**):
+
+```bash
+curl -fsSL https://www.codebuddy.cn/cli/install.sh | bash
+```
+
+```powershell
+irm https://www.codebuddy.cn/cli/install.ps1 | iex
+```
+
+The [quick start](https://www.codebuddy.cn/docs/cli/quickstart) publishes a second official pair:
+
+```bash
+curl -fsSL https://copilot.tencent.com/cli/install.sh | bash
+```
+
+```powershell
+irm https://copilot.tencent.com/cli/install.ps1 | iex
+```
+
+Both pages are official. Do not merge them. Follow the page you are reading.
+
+If the command is missing, the install page says add:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Windows: `%USERPROFILE%\AppData\Local\codebuddy\bin`.
+
+Windows troubleshooting also requires **Git Bash** ([troubleshooting](https://www.codebuddy.cn/docs/cli/troubleshooting)).
+
+Update:
+
+```bash
+codebuddy update
+```
+
+or re-run the package-manager install. Disable auto-update with `export DISABLE_AUTOUPDATER=1`.
+
+Default config dir: `~/.codebuddy` (Windows `%USERPROFILE%\.codebuddy`). Override with `CODEBUDDY_CONFIG_DIR`. The install page says this avoids clashes with other apps that use the CodeBuddy engine (for example WorkBuddy).
+
+## Sign in to the CLI
+
+Source: [Quick start · login](https://www.codebuddy.cn/docs/cli/quickstart).
+
+On first launch:
+
+```
+Select login method:
+› Log in via Chinese Site
+  Log in via International Site
+  Log in via Enterprise Domain
+  Log in via iOA (Tencent only)
+```
+
+| Method | When | Notes |
+|--------|------|-------|
+| **Chinese Site** | Users in China | Auth via copilot.tencent.com |
+| **International Site** | Users outside China | Auth via codebuddy.ai |
+| **Enterprise Domain** | Dedicated / private deploy | Needs the address from your company |
+| **iOA** | Tencent employees | Internal only |
+
+Use `↑↓` and `Enter`; the browser finishes auth.
+
+## First CLI session
+
+```bash
+cd /path/to/your/project
+codebuddy
+```
+
+Official strong recommendation:
+
+```
+> /init
+```
+
+The [quick start](https://www.codebuddy.cn/docs/cli/quickstart) calls `/init` "strongly recommended": it builds a project knowledge graph so later turns scan less. After a large structural change: `/clear` then `/init`.
+
+Then:
+
+```
+> Help me analyze this project's structure
+```
+
+Language: `/config` → Language after launch.
+
+One-shot (official examples):
+
+```bash
+codebuddy -p "Optimize this SQL query"
+```
+
+When the turn needs files or shell, official docs require `-y` or `--dangerously-skip-permissions`:
+
+```bash
+codebuddy -p "Review code quality of src/utils.js" -y
+```
+
+Permission modes: `Shift+Tab` (Windows also `Alt+M`). The quick start cycle is `default → bypass → accept → plan`. `--permission-mode` values on the [CLI reference](https://www.codebuddy.cn/docs/cli/cli-reference) are `default`, `acceptEdits`, `auto`, `dontAsk`, `plan`, `bypassPermissions`. Do not mix the short key-cycle names with the flag names in scripts.
+
+Full command table: [Cheatsheet](./codebuddy-cheatsheet).
+
+## Step 4: write down standing rules
+
+CLI troubleshooting maps `CLAUDE.md` → `CODEBUDDY.md` as the "AI instructions and memory" file. The user-level path in the migration sample is `~/.codebuddy/CODEBUDDY.md`. Whether a repo-root `CODEBUDDY.md` is auto-injected is not a hard sentence on that page — check `/config` and the official memory doc instead of guessing.
+
+The official "symlink (recommended)" migration is in the [Cookbook](./codebuddy-cookbook#migrate-from-claude-code).
+
+## Guardrails
+
+- **Copy install commands from official pages.** The npm package is `@tencent-ai/codebuddy-code`, not a guessed `@tencent/codebuddy`.
+- **Native install has two official URL pairs** (`codebuddy.cn/cli` and `copilot.tencent.com/cli`). Do not invent a third.
+- **`-p` is not "allow everything".** File / shell / network turns need an explicit permission policy.
+- **Do not treat WorkBuddy, Yuanbao, or Hunyuan as the next lesson.** They are one row each on the [map](./).
+- **Do not amplify marketing percentages** such as "90% efficiency".
+
+## Next
+
+- Recipes: [Cookbook](./codebuddy-cookbook)
+- Commands and keys: [Cheatsheet](./codebuddy-cheatsheet)
+- Concepts: [Glossary](./codebuddy-glossary)
+- Official CLI next: the "Getting started" group on [CLI docs](https://www.codebuddy.cn/docs/cli/)

--- a/docs/products/codebuddy/index.md
+++ b/docs/products/codebuddy/index.md
@@ -1,0 +1,133 @@
+---
+title: CodeBuddy Learning Map
+description: "Tencent Cloud CodeBuddy is a family of AI coding surfaces that share one account quota: a standalone IDE, editor plugins, and a terminal CLI. This page is the family map and decision tree."
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# CodeBuddy Learning Map
+
+> Tencent Cloud Code Assistant **CodeBuddy** ships **IDE, plugin, and CLI** forms. Official wording ([docs overview](https://www.codebuddy.cn/docs/), [Tencent Cloud product overview](https://cloud.tencent.com/document/product/1831/134343)):
+>
+> The product supports IDE, plugin, and CLI forms, covering full-scenario needs from professional developers to zero-foundation users.
+
+This page is the landscape and decision tree — **name the surface first, then decide what to learn**. Install steps live in the [tutorial](./codebuddy).
+
+## Product family
+
+Top-level entries on the docs site (opened 2026-08-18 at [codebuddy.cn/docs](https://www.codebuddy.cn/docs/)):
+
+```
+Tencent Cloud / CodeBuddy family
+├── CodeBuddy IDE — standalone editor, "conversation is programming"
+├── CodeBuddy Plugin — extension inside VS Code / JetBrains / …
+├── CodeBuddy Code (CLI) — terminal agent, command `codebuddy`
+├── WorkBuddy — office workbench (no tutorial in this directory)
+│   ├── WorkBuddy mini program
+│   └── WorkBuddy mobile
+└── Enterprise — SaaS flagship / dedicated edition (no tutorial here)
+Same-vendor AI (no tutorial in this directory)
+├── Yuanbao — general assistant
+└── Hunyuan — model, not a coding product
+```
+
+| Official first-level entry | What it is | Official URL | This site |
+|----------------------------|------------|--------------|-----------|
+| **CodeBuddy IDE** | Product-design-dev workbench; "conversation is programming" | [Docs overview](https://www.codebuddy.cn/docs/) · [Install](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation) · [Download](https://www.codebuddy.cn/ide/) | [Tutorial](./codebuddy#install-the-ide) |
+| **CodeBuddy Plugin** | AI assist inside an existing editor | [Plugin docs](https://www.codebuddy.cn/docs/plugin/) | [Tutorial](./codebuddy#install-the-plugin) |
+| **CodeBuddy Code (CLI)** | Natural-language driven development in the terminal | [CLI docs](https://www.codebuddy.cn/docs/cli/) · [Install](https://www.codebuddy.cn/docs/cli/installation) | [Tutorial](./codebuddy#install-the-cli) |
+| **WorkBuddy** | "Tencent's all-scenario AI office workbench." | [WorkBuddy intro](https://www.codebuddy.cn/docs/workbuddy/) · [Site /work](https://www.codebuddy.cn/work/) | **One map row**, no tutorial |
+| **WorkBuddy mini program** | One mobile entry for WorkBuddy | [Mini program intro](https://www.codebuddy.cn/docs/workbuddymini/) | **One map row**, no tutorial |
+| **WorkBuddy mobile** | Companion app for desktop WorkBuddy | [Mobile intro](https://www.codebuddy.cn/docs/workbuddyapp/) | **One map row**, no tutorial |
+| **Enterprise** | SaaS flagship / dedicated private-cloud edition | [Purchase flow](https://www.codebuddy.cn/docs/ide/Codebuddy-enterprise-edition/Codebuddy-enterprise-purchase) · [Cloud overview](https://cloud.tencent.com/document/product/1831/134343) | **One map row**, no tutorial |
+| **Yuanbao** | Tencent general AI assistant | [yuanbao.tencent.com](https://yuanbao.tencent.com/) | **One map row** (issue #76) |
+| **Hunyuan** | Tencent model; one of the engines CodeBuddy can switch to | [hunyuan.tencent.com](https://hunyuan.tencent.com/) · [Cloud tclm](https://cloud.tencent.com/product/tclm) | **One map row** (issue #77) |
+
+**Out of scope**: WeChat, QQ, CVM, payments. If those appear in a vendor nav, mark them "not this site".
+
+Official form comparison ([product overview](https://cloud.tencent.com/document/product/1831/134343)):
+
+| | **CodeBuddy Plugin** | **CodeBuddy IDE** | **CodeBuddy Code** |
+|---|---------------------|-------------------|---------------------|
+| Audience | Everyday coders / people locked to one IDE | PMs / designers / full-stack / beginners | DevOps / SRE / senior engineers |
+| Strength | Plug in, stay in the current workflow | Product-design-dev; CloudBase / EdgeOne Pages / CloudStudio | Shell / files / network; headless; task orchestration / Sub Agent |
+| How to start | Search **腾讯云代码助手** in the marketplace | Intl [codebuddy.ai](https://www.codebuddy.ai/) · CN [copilot.tencent.com/ide](https://copilot.tencent.com/ide) | `npm install -g @tencent-ai/codebuddy-code` |
+
+The three coding forms **share one account quota** ([troubleshooting](https://www.codebuddy.cn/docs/cli/troubleshooting)).
+
+### Quick decision: which surface?
+
+```
+What am I doing?
+├── I already live in VS Code / JetBrains / Visual Studio
+│   └── → Plugin (marketplace search 腾讯云代码助手)
+├── I want one sentence → prototype / mock / deployable app
+│   └── → IDE
+├── The work is in a terminal: scripts, CI, bulk refactors, headless
+│   └── → CodeBuddy Code (`codebuddy` / `codebuddy -p`)
+├── Office docs / PPT / local file batching, not a git repo
+│   └── → WorkBuddy (not taught here)
+└── General chat / search, not a coding product
+    └── → Yuanbao (not taught here)
+```
+
+Three name collisions to lock in:
+
+| Easy to confuse | Difference |
+|-----------------|------------|
+| **CodeBuddy** vs **WorkBuddy** | Coding family vs office workbench |
+| **Editor plugin** vs **CLI `plugin`** | VS Code extension vs `codebuddy plugin install` |
+| **Hunyuan** vs **CodeBuddy** | Model vs product; official docs also mention DeepSeek |
+
+More look-alikes live in the [Glossary](./codebuddy-glossary).
+
+## Which page to read
+
+This set follows [Diataxis](https://diataxis.fr/):
+
+| Page | Type | When |
+|------|------|------|
+| [Tutorial](./codebuddy) | Tutorial | First time: install IDE / plugin / CLI → sign in → first chat |
+| [Cookbook](./codebuddy-cookbook) | How-to | Already running; copy `/init`, print mode, custom commands, MCP, migration |
+| [Cheatsheet](./codebuddy-cheatsheet) | Reference | Install text, CLI commands, slash commands, keys |
+| [Glossary](./codebuddy-glossary) | Explanation | Forms, permission modes, `CODEBUDDY.md`, CN vs intl sites |
+
+## Learning path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Pick a form and install it | [Tutorial](./codebuddy) | Sign in on one surface in 15 minutes |
+| 2. First real task | Tutorial first chat; CLI starts with `/init` | Let it read the repo or make a small edit |
+| 3. Daily workflow | [Cookbook](./codebuddy-cookbook) | Print mode, slash commands, MCP |
+| 4. Look up flags | [Cheatsheet](./codebuddy-cheatsheet) | Commands and official install text |
+| 5. Untangle names | [Glossary](./codebuddy-glossary) | WorkBuddy / Hunyuan / CLI plugin stay distinct |
+
+## Feature snapshot
+
+| Capability | Where | Official source |
+|------------|-------|-----------------|
+| Inline completion, chat, `@workspace` / `#Codebase` | Plugin | [Product overview](https://cloud.tencent.com/document/product/1831/134343) |
+| Natural language → PRD / design / code / one-click deploy | IDE | Same |
+| Interactive REPL, `codebuddy -p`, slash commands, MCP | CLI | [Quick start](https://www.codebuddy.cn/docs/cli/quickstart) · [CLI reference](https://www.codebuddy.cn/docs/cli/cli-reference) |
+| Skills / Hooks / subagents / Daemon | CLI (advanced) | [CLI tree](https://www.codebuddy.cn/docs/cli/) |
+
+## Goals and non-goals
+
+**Goal**: Help a front-end engineer tell the three CodeBuddy coding surfaces apart, then install, sign in, and finish a first task from official steps.
+
+**Non-goals**:
+
+- No full tutorials for Yuanbao, Hunyuan, or WorkBuddy
+- No WeChat / QQ product pages
+- No model internals
+- No recycling of marketing percentages as measured results
+
+## Resources
+
+- [CN docs](https://www.codebuddy.cn/docs/)
+- [Intl docs](https://www.codebuddy.ai/docs/) · [ZH mirror](https://www.codebuddy.ai/docs/zh/)
+- [Tencent Cloud product acc](https://cloud.tencent.com/product/acc)
+- [Pricing](https://www.codebuddy.cn/pricing/) — client-rendered; do not invent plan numbers here
+- [Cheatsheet · sources](./codebuddy-cheatsheet#high-quality-sources)

--- a/docs/zh/products/codebuddy/codebuddy-cheatsheet.md
+++ b/docs/zh/products/codebuddy/codebuddy-cheatsheet.md
@@ -1,0 +1,246 @@
+---
+title: CodeBuddy 速查表
+description: "只查不学。安装命令、CLI 子命令、斜杠命令和键位均抄自 codebuddy.cn 官方文档。完整集合以你本机 codebuddy --help 与官方页为准。"
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# CodeBuddy 速查表
+
+只查不学。安装命令、CLI 子命令、斜杠命令和键位均抄自官方页。完整集合以你本机 `codebuddy --help` 与下列链接为准。
+
+覆盖核对日期：**2026-08-18**。
+
+## 安装与更新
+
+来源：[安装指南](https://www.codebuddy.cn/docs/cli/installation)、[快速入门](https://www.codebuddy.cn/docs/cli/quickstart)、[故障排查](https://www.codebuddy.cn/docs/cli/troubleshooting)
+
+| 场景 | 命令 / 动作 | 出处 |
+|------|-------------|------|
+| npm | `npm install -g @tencent-ai/codebuddy-code` | 安装页 |
+| pnpm | `pnpm add -g @tencent-ai/codebuddy-code` | 安装页 |
+| yarn | `yarn global add @tencent-ai/codebuddy-code` | 安装页 |
+| bun | `bun install -g @tencent-ai/codebuddy-code` | 安装页 |
+| Homebrew | `brew tap Tencent-CodeBuddy/tap` 然后 `brew install codebuddy-code` | 安装页 |
+| 原生全新安装（安装页） | `curl -fsSL https://www.codebuddy.cn/cli/install.sh \| bash` | 安装页 |
+| 原生 Windows（安装页） | `irm https://www.codebuddy.cn/cli/install.ps1 \| iex` | 安装页 |
+| 原生全新安装（快速开始页） | `curl -fsSL https://copilot.tencent.com/cli/install.sh \| bash` | 快速开始 |
+| 原生 Windows（快速开始页） | `irm https://copilot.tencent.com/cli/install.ps1 \| iex` | 快速开始 |
+| npm → 原生 | `codebuddy install` | 安装页 |
+| 验证 | `codebuddy --version` | 安装页 |
+| 更新 | `codebuddy update` | 安装页 / 故障排查 |
+| npm 更新备选 | `npm install -g @tencent-ai/codebuddy-code@latest` | 故障排查 |
+| 查 npm 最新 | `npm view @tencent-ai/codebuddy-code version` | 故障排查 |
+| 关自动更新 | `export DISABLE_AUTOUPDATER=1` | 安装页 |
+| 卸载 Homebrew | `brew uninstall codebuddy-code` | 安装页 |
+| 卸载 npm | `npm uninstall -g @tencent-ai/codebuddy-code` | 安装页 |
+| 删原生二进制 | `rm -f ~/.local/bin/codebuddy` | 安装页 |
+
+Node.js：**18.20+**（安装页、故障排查）。总览页写过 18.0+；不要混用。
+
+原生 PATH：`~/.local/bin`；Windows `%USERPROFILE%\AppData\Local\codebuddy\bin`。
+
+配置目录：`~/.codebuddy` / `%USERPROFILE%\.codebuddy`。改位置：`CODEBUDDY_CONFIG_DIR`。
+
+IDE 下载：[codebuddy.cn/ide](https://www.codebuddy.cn/ide/) · 国内 [copilot.tencent.com/ide](https://copilot.tencent.com/ide) · 国际 [codebuddy.ai](https://www.codebuddy.ai/)。系统要求见 [IDE 安装](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation)。
+
+插件：市场搜索 **腾讯云代码助手**。[插件页](https://www.codebuddy.cn/docs/plugin/)。
+
+## CLI 命令
+
+来源：[CLI 参考](https://www.codebuddy.cn/docs/cli/cli-reference)
+
+| 命令 | 说明 | 示例 |
+|------|------|------|
+| `codebuddy` | 启动交互式 REPL | `codebuddy` |
+| `codebuddy "查询"` | 带初始提示词启动 REPL | `codebuddy "解释这个项目"` |
+| `codebuddy -p "查询"` | 打印后退出 | `codebuddy -p "解释这个函数"` |
+| `cat 文件 \| codebuddy -p "查询"` | 处理管道 | `cat logs.txt \| codebuddy -p "分析日志"` |
+| `codebuddy -c` | 继续最近的对话 | `codebuddy -c` |
+| `codebuddy -c -p "查询"` | 继续并以打印模式提问 | `codebuddy -c -p "检查类型错误"` |
+| `codebuddy -r "<id>" "查询"` | 按 ID 恢复会话 | `codebuddy -r "abc123" "完成这个 MR"` |
+| `codebuddy update` | 更新到最新版本 | `codebuddy update` |
+| `codebuddy mcp` | 配置 MCP 服务器 | 见 [MCP 文档](https://www.codebuddy.cn/docs/cli/mcp) |
+| `codebuddy daemon start` | 启动 Daemon | `codebuddy daemon start --port 8080` |
+| `codebuddy daemon stop` / `status` / `restart` | 停 / 查 / 重启 | |
+| `codebuddy daemon install` / `uninstall` | 注册或移除系统服务 | `codebuddy daemon install --port 8080` |
+| `codebuddy auto-mode defaults` / `config` / `critique` | 查看或审视 auto 模式规则 | |
+| `codebuddy ps` | 列出活跃 Worker | `codebuddy ps` |
+| `codebuddy logs <name>` | 查看 Worker 日志 | `codebuddy logs feature-x` |
+| `codebuddy attach <name>` | 附加到后台 Worker | `codebuddy attach feature-x` |
+| `codebuddy kill <name>` | 终止 Worker | `codebuddy kill feature-x` |
+| `codebuddy plugin install <plugin>` | 从市场安装 CLI 插件 | 见 [插件参考](https://www.codebuddy.ai/docs/cli/plugins-reference) |
+
+## 常用 flag
+
+来源：[CLI 参考](https://www.codebuddy.cn/docs/cli/cli-reference)。下表只收教程和日常脚本会碰到的项，不是全量。
+
+| 参数 | 说明 |
+|------|------|
+| `--print`, `-p` | 打印响应后退出 |
+| `-y` / `--dangerously-skip-permissions` | 跳过权限提示 |
+| `--permission-mode` | `default` / `acceptEdits` / `auto` / `dontAsk` / `plan` / `bypassPermissions` |
+| `--continue` / `-c` | 加载当前目录最近对话 |
+| `--resume` | 按 ID 恢复 |
+| `--model` | 设置本次会话模型 |
+| `--ide` | 启动时连 IDE |
+| `--add-dir` | 额外工作目录 |
+| `--sandbox` | 沙箱（Beta） |
+| `--worktree [name]` | 独立 git worktree |
+| `--tmux` | 与 `--worktree` 配合 |
+| `--bg` / `--name` | 后台会话 |
+| `--serve` | HTTP 服务 |
+| `--plugin-dir` | 从本地目录加载插件 |
+| `--output-format` | `text` / `json` / `stream-json`（打印模式） |
+| `--max-turns` | 非交互最大轮次 |
+| `--verbose` / `--debug` | 详细日志 / 调试 |
+| `--system-prompt` / `--append-system-prompt` | 替换或追加系统提示 |
+| `--mcp-config` | 加载 MCP JSON |
+
+官方提示：`-p` 且需要文件 / 命令 / 网络时，必须有明确权限策略（`-y`、`--permission-mode auto` / `dontAsk`、预先 `permissions.allow`，或权限提示 MCP 工具）。
+
+## 斜杠命令
+
+来源：[斜杠命令](https://www.codebuddy.cn/docs/cli/slash-commands)。官方表很长，这里只列上手高频。全表看官方页。
+
+| 命令 | 作用 |
+|------|------|
+| `/help` | 帮助 |
+| `/clear` | 全新对话 |
+| `/login` / `/logout` | 登录 / 退出 |
+| `/init` | 初始化仓库上下文 |
+| `/config` | 本地配置 |
+| `/model` | 切换或查看模型 |
+| `/status` / `/doctor` | 会话状态 / 环境检查 |
+| `/mcp` | 管理 MCP |
+| `/skills` | 查看已加载 Skills |
+| `/plugin` | 管理 CLI 插件和市场 |
+| `/compact` | 压缩上下文 |
+| `/cost` / `/stats` | Token / 使用统计 |
+| `/resume` / `/rewind` | 恢复会话 / 回退检查点 |
+| `/permissions` | 工具与目录权限 |
+| `/plan` | 预览计划模式文件 |
+| `/ide` | IDE 连接 |
+| `/sandbox` | Bash 沙箱 |
+| `/memory` | 长期记忆 |
+| `/upgrade` | 打开升级页 |
+
+自定义命令：项目 `.codebuddy/commands/*.md`，用户 `~/.codebuddy/commands/*.md`。`test.md` → `/test`；子目录用冒号，如 `frontend/build.md` → `/frontend:build`。
+
+## 交互键位
+
+来源：[快速入门 · 快捷键](https://www.codebuddy.cn/docs/cli/quickstart)
+
+| 键 | 功能 |
+|----|------|
+| `↑/↓` | 命令历史；有后台任务时 `↓` 看任务 |
+| `Tab` | 补全 |
+| `Esc` | 清空输入（按两次） / 返回上级 |
+| `Ctrl+C` / `Ctrl+D` | 退出（`Ctrl+D` 需输入框空且连按两次） |
+| `Shift+Tab`（Windows 也可用 `Alt+M`） | 权限模式 `default → bypass → accept → plan` |
+| `Enter` | 发送 |
+| `Shift+Enter` / `\Enter` / `Ctrl+J` | 换行 |
+| `Ctrl+G` | 外部编辑器改提示词 |
+| `Ctrl+R` | 展开 / 收起详细输出 |
+| `Ctrl+O` | 思考详情面板 |
+
+JetBrains 终端里 ESC 不生效：改用 `Ctrl+ESC` 或 `Shift+ESC`（[故障排查](https://www.codebuddy.cn/docs/cli/troubleshooting)）。
+
+## MCP 添加（摘录）
+
+来源：[MCP 文档](https://www.codebuddy.cn/docs/cli/mcp)
+
+```bash
+codebuddy mcp add --scope user my-tool -- /path/to/tool arg1 arg2
+codebuddy mcp add --scope project python-tool -- python /path/to/script.py
+codebuddy mcp add --scope user --transport sse sse-server https://example.com/mcp/sse
+codebuddy mcp add --scope project --transport http http-server https://example.com/mcp/http
+```
+
+## 决策表
+
+| 场景 | 选 |
+|------|----|
+| 已有 VS Code / JetBrains | 插件 |
+| 一句话到原型 / 设计 / 部署 | IDE |
+| 终端 / CI / 无头 | CLI |
+| 办公文档 / PPT，不是仓库 | WorkBuddy（本站不教） |
+| 通用聊天 | 元宝（本站不教） |
+| 国内账号 | CLI 选 Chinese Site |
+| 海外账号 | CLI 选 International Site |
+
+## 术语索引
+
+一行钩子，解释在 [术语表](./codebuddy-glossary)。
+
+| 术语 | 一句话 | 详解 |
+|------|--------|------|
+| CodeBuddy IDE | 独立编辑器 | [术语表](./codebuddy-glossary#codebuddy-ide) |
+| CodeBuddy 插件 | 装进已有 IDE 的扩展 | [术语表](./codebuddy-glossary#codebuddy-插件) |
+| CodeBuddy Code | 终端 agent，命令 `codebuddy` | [术语表](./codebuddy-glossary#codebuddy-code) |
+| WorkBuddy | 办公工作台，不是编码主线 | [术语表](./codebuddy-glossary#workbuddy) |
+| 国内站 / 国际站 | 两套文档和登录域 | [术语表](./codebuddy-glossary#国内站--国际站) |
+| `CODEBUDDY.md` | 可迁移的指令文件 | [术语表](./codebuddy-glossary#codebuddymd) |
+
+## 常见错误
+
+| 症状 | 官方原因 / 处理 |
+|------|-----------------|
+| `codebuddy: command not found` | PATH 未包含安装目录；`source ~/.zshrc` |
+| Windows「不是内部或外部命令」 | `npm config get prefix`，把全局 npm 目录加入 PATH |
+| npm 装成功但仍是旧版本 | 多个可执行文件并存（npm + Homebrew / nvm） |
+| 原生命令找不到 | `export PATH="$HOME/.local/bin:$PATH"` |
+| `-p` 动不了文件 | 补 `-y` 或其它权限策略 |
+| 局域网访问 `--serve` 空响应 | 默认听 `127.0.0.1`；用 `--host 0.0.0.0` |
+
+## Agent SDK（可选）
+
+来源：[Agent SDK](https://www.codebuddy.cn/docs/cli/sdk)。文档针对 SDK v0.1.0+。
+
+```bash
+npm install @tencent-ai/agent-sdk
+```
+
+```bash
+pip install codebuddy-agent-sdk
+```
+
+TypeScript/JavaScript 要求 Node.js >= 18.20。本站不把 SDK 当主学习路径。
+
+## 高质量信息源
+
+最后核实：2026-08-18。只收录亲自打开过的官方页。
+
+### 一手官方
+
+| 来源 | 用途 |
+|------|------|
+| [codebuddy.cn](https://www.codebuddy.cn/) | 国内官网 |
+| [codebuddy.cn/docs](https://www.codebuddy.cn/docs/) | 中文文档总览（三种形态） |
+| [IDE 安装](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation) | IDE 系统要求与安装登录 |
+| [插件文档](https://www.codebuddy.cn/docs/plugin/) | 宿主版本与安装 |
+| [CLI 概述](https://www.codebuddy.cn/docs/cli/) | CLI 入口 |
+| [CLI 安装](https://www.codebuddy.cn/docs/cli/installation) | 包管理器 / 原生 / 卸载 |
+| [CLI 快速开始](https://www.codebuddy.cn/docs/cli/quickstart) | 登录、`/init`、键位、`-p` |
+| [CLI 参考](https://www.codebuddy.cn/docs/cli/cli-reference) | 子命令与 flag |
+| [斜杠命令](https://www.codebuddy.cn/docs/cli/slash-commands) | `/` 命令全表 |
+| [故障排查](https://www.codebuddy.cn/docs/cli/troubleshooting) | Node 版本、Windows、迁移、额度 |
+| [MCP](https://www.codebuddy.cn/docs/cli/mcp) | `codebuddy mcp add` |
+| [SDK](https://www.codebuddy.cn/docs/cli/sdk) | Agent SDK |
+| [定价](https://www.codebuddy.cn/pricing/) | 套餐入口（前端渲染，勿臆造数字） |
+| [腾讯云 acc](https://cloud.tencent.com/product/acc) | 云产品页 |
+| [产品概述 1831](https://cloud.tencent.com/document/product/1831/134343) | 三形态对照表 |
+| [codebuddy.ai/docs](https://www.codebuddy.ai/docs/) | 国际站文档 |
+| [codebuddy.ai/docs/zh](https://www.codebuddy.ai/docs/zh/) | 国际站中文镜像 |
+| [WorkBuddy 简介](https://www.codebuddy.cn/docs/workbuddy/) | 家族图一行的出处 |
+| [WorkBuddy 小程序](https://www.codebuddy.cn/docs/workbuddymini/) | 家族图一行 |
+| [WorkBuddy 移动端](https://www.codebuddy.cn/docs/workbuddyapp/) | 家族图一行 |
+| [元宝](https://yuanbao.tencent.com/) | 同厂助手 |
+| [混元](https://hunyuan.tencent.com/) | 同厂模型 |
+
+### 待核实
+
+- 定价页具体套餐数字（页面前端渲染，2026-08-18 阅读器未抽出价目表）
+- 仓库根 `CODEBUDDY.md` 是否与用户级 `~/.codebuddy/CODEBUDDY.md` 同样自动注入（官方故障排查只明确了迁移文件名）

--- a/docs/zh/products/codebuddy/codebuddy-cookbook.md
+++ b/docs/zh/products/codebuddy/codebuddy-cookbook.md
@@ -1,0 +1,195 @@
+---
+title: CodeBuddy 实战手册
+description: "面向已经装好、能登录的读者。每个配方抄官方步骤：先说目标，再给命令，最后标坑。不重复安装。"
+domain: product
+tags:
+  - coding-agent
+role: cookbook
+---
+
+# CodeBuddy 实战手册
+
+面向「已经装好、能登录」的读者。每个配方是一个具体任务：先说目标，再给官方命令，最后说坑。
+
+不会装的先看 [上手教程](./codebuddy)；只查命令去 [速查表](./codebuddy-cheatsheet)。
+
+## 第一次进仓库先 `/init`
+
+**目标**：让 CLI 先建项目上下文，再开始改代码。
+
+来源：[快速入门](https://www.codebuddy.cn/docs/cli/quickstart)
+
+```bash
+cd /path/to/your/project
+codebuddy
+```
+
+```
+> /init
+```
+
+官方把 `/init` 标成「强烈推荐」：预先构建项目知识图谱，后续少重复扫描。结构大变时：
+
+```
+> /clear
+> /init
+```
+
+**坑**：跳过 `/init` 直接甩跨文件大任务，官方说会更慢、更容易误判。不要用「仓库很大所以它肯定懂」代替这一步。
+
+## 用 print 模式做一次性审查
+
+**目标**：脚本或管道里跑一次，不要进 REPL。
+
+来源：[快速入门](https://www.codebuddy.cn/docs/cli/quickstart)、[CLI 参考](https://www.codebuddy.cn/docs/cli/cli-reference)
+
+```bash
+codebuddy -p "优化这个 SQL 查询的性能"
+cat error.log | codebuddy -p "分析这些错误日志"
+codebuddy -p "审查 src/utils.js 的代码质量" -y
+```
+
+官方原文：使用 `-p/--print` 时，如果操作需要访问文件、执行命令等授权操作，必须添加 `-y`（或 `--dangerously-skip-permissions`）。也可以改用 `--permission-mode auto` / `dontAsk`，或预先配置 `permissions.allow`。
+
+**坑**：只写 `-p` 不写权限策略，需要确认的操作会被挡住。`-y` 会跳过权限提示，官方写「谨慎使用」。
+
+## 自定义一条斜杠命令
+
+**目标**：把重复任务收成 `/名字`。
+
+来源：[斜杠命令 · 自定义](https://www.codebuddy.cn/docs/cli/slash-commands)
+
+- 项目级：`.codebuddy/commands/`
+- 用户级：`~/.codebuddy/commands/`
+
+`test.md` 会注册成 `/test`。子目录用冒号：`commands/frontend/build.md` → `/frontend:build`。
+
+官方示例（审查文件）：
+
+```markdown
+---
+description: "对指定文件进行代码审查"
+argument-hint: "[file-paths...]"
+allowed-tools: Read
+---
+
+请对以下文件进行代码审查，关注代码质量、可维护性和安全性：
+
+@$ARGUMENTS
+```
+
+带 Shell 的命令必须在 frontmatter 写上 `Bash`，否则官方说「命令无法执行」。
+
+**坑**：自定义斜杠命令是人手动触发的。官方另有 Skills——「AI 自动识别并调用的专业能力模板」。不要把两套写成一套。
+
+## 加一个 MCP 服务器
+
+**目标**：让 CLI 调到外部工具。
+
+来源：[MCP 文档](https://www.codebuddy.cn/docs/cli/mcp)
+
+```bash
+codebuddy mcp add --scope user my-tool -- /path/to/tool arg1 arg2
+codebuddy mcp add --scope project python-tool -- python /path/to/script.py
+codebuddy mcp add --scope user --transport sse sse-server https://example.com/mcp/sse
+codebuddy mcp add --scope project --transport http http-server https://example.com/mcp/http
+```
+
+IDE 里的 CloudBase 一类集成，CloudBase 文档写：IDE 用户在设置页 / 集成点「Tencent CloudBase」授权，不必手写 MCP。那是 CloudBase 文档的口径，配 CodeBuddy 时以你本机设置为准。
+
+## 从 Claude Code 迁移
+
+**目标**：把已有 Claude Code 的 agents / commands / skills / 指令文件接到 CodeBuddy。
+
+来源：[故障排查 · 从 Claude Code 迁移](https://www.codebuddy.cn/docs/cli/troubleshooting)
+
+官方迁移表：
+
+| 目录 / 文件 | 说明 |
+|-------------|------|
+| `agents/` | 自定义 agents |
+| `commands/` | 斜杠命令 |
+| `skills/` | Skills |
+| `CLAUDE.md` → `CODEBUDDY.md` | AI 指令和记忆文档 |
+
+方案一（官方推荐，符号链接）：
+
+```bash
+cd ~/.codebuddy
+ln -s ~/.claude/agents agents
+ln -s ~/.claude/commands commands
+ln -s ~/.claude/skills skills
+ln -s ~/.claude/CLAUDE.md CODEBUDDY.md
+```
+
+方案二（复制，两边独立）：
+
+```bash
+cp -r ~/.claude/agents ~/.codebuddy/agents
+cp -r ~/.claude/commands ~/.codebuddy/commands
+cp -r ~/.claude/skills ~/.codebuddy/skills
+cp ~/.claude/CLAUDE.md ~/.codebuddy/CODEBUDDY.md
+```
+
+验证：
+
+```bash
+codebuddy
+```
+
+```
+> /skills
+> /config
+```
+
+官方还写：Claude Code 插件中的 Skills 支持一键安装，安装后自动加载。
+
+**坑**：这是「拷配置」，不是「Claude Code 和 CodeBuddy 是同一个产品」。权限模式、登录域、额度都走 CodeBuddy 自己的账号。
+
+## 控制 Token：新任务新会话
+
+**目标**：别在一个会话里塞十件无关的事。
+
+来源：[故障排查 · 成本优化](https://www.codebuddy.cn/docs/cli/troubleshooting)
+
+官方原则：
+
+- 新任务用 `/clear`
+- 长对话用 `/compact`
+- 用 `@filename` 引用文件，避免粘贴代码
+
+官方对照（原文数字，不是本站测算）：
+
+| 方式 | 输入 Token | 相对成本 |
+|------|------------|----------|
+| 单会话连续 10 个任务 | ~50,000 | 高 |
+| 每个任务新会话 | ~15,000 | 低 |
+| 定期 `/compact` | ~25,000 | 中 |
+
+官方建议每 20–30 轮 `/compact`。
+
+## 在插件里问整个工程
+
+**目标**：不问「当前文件」，问仓库结构。
+
+来源：[产品概述](https://cloud.tencent.com/document/product/1831/134343)
+
+官方提供 `@workspace` 和 `#Codebase`：对工程提问，覆盖结构、函数和类关系、依赖、业务流程。
+
+**坑**：这是插件 / IDE 侧的工程问答能力。不要把它和 CLI 的 `/init` 当成同一个开关。
+
+## 让 IDE 从一句话走到可预览产物
+
+**目标**：用独立 IDE 做 0-1，而不是在旧仓库里补一行。
+
+来源：[产品概述](https://cloud.tencent.com/document/product/1831/134343)、[IDE 落地页](https://www.codebuddy.cn/ide/)
+
+官方链路：自然语言描述 → 结构化 PRD → 原型 / 设计稿（也可手绘或组件库）→ 设计稿转代码（内置 Figma）→ CloudBase / Supabase → 部署到 CloudStudio / EdgeOne Pages。
+
+**坑**：这是 IDE 的主场。插件不会 magically 变成同一条「产设研」流水线。部署和 BaaS 以 IDE 设置页为准，不要在本站编一套控制台路径。
+
+## 护栏
+
+- 配方里的命令必须能在上面列出的官方页找到。找不到就不要补「通常可以」。
+- 不要在这里教 WorkBuddy、元宝、微信或 QQ。
+- 不要把 CLI `plugin` 和编辑器插件写成同一次安装。

--- a/docs/zh/products/codebuddy/codebuddy-glossary.md
+++ b/docs/zh/products/codebuddy/codebuddy-glossary.md
@@ -1,0 +1,148 @@
+---
+title: CodeBuddy 术语表
+description: "不教操作，只解释 CodeBuddy 家族里容易撞名的词：三种编程形态、WorkBuddy、混元、国内站 / 国际站、CODEBUDDY.md。"
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# CodeBuddy 术语表
+
+不教操作，只解释「是什么 / 不是什么」。选哪个入口看 [学习地图](./)。
+
+## 概念关系
+
+```
+腾讯 AI（与本目录相关的部分）
+├── CodeBuddy — 编码产品族
+│   ├── IDE
+│   ├── 插件（装进 VS Code / JetBrains 等）
+│   └── CodeBuddy Code（CLI，命令 codebuddy）
+│       ├── 交互 REPL
+│       ├── print（-p）
+│       └── CLI 自己的 plugin / Skills / MCP
+├── WorkBuddy — 办公工作台（不是编码主线）
+├── 元宝 — 通用助手
+└── 混元 — 模型（CodeBuddy 可切换的引擎之一）
+```
+
+## CodeBuddy
+
+**是什么**：腾讯云的 AI 辅助编程产品。官方定义（[文档总览](https://www.codebuddy.cn/docs/)、[产品概述](https://cloud.tencent.com/document/product/1831/134343)）是同时支持 **IDE、插件、CLI** 三种形态。
+
+**不是什么**：不是混元本身，也不是元宝，更不是 WorkBuddy。官网营销句「基于混元代码大模型」说的是模型来源之一；同一套官方文档还写支持 DeepSeek 等。
+
+三种形态共享同一账号资源配额（[故障排查](https://www.codebuddy.cn/docs/cli/troubleshooting)）。
+
+## CodeBuddy IDE
+
+**是什么**：独立安装的编辑器。官方定位：产设研一体工作台，主打「对话即编程」。面向产品 / 设计师 / 全栈 / 编程初学者。
+
+**为什么需要**：插件留在你现有 IDE 里打辅助；IDE 把需求、设计、代码、部署放进同一个产品。
+
+**不是什么**：不是 VS Code 插件的皮肤。系统要求是 macOS 11+ / Windows 10+（[安装和登录](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation)）。
+
+## CodeBuddy 插件
+
+**是什么**：装进已有编辑器的扩展。市场搜索名官方写 **腾讯云代码助手**。宿主包括 VS Code、Visual Studio、JetBrains 系列、Android Studio，以及微信开发者工具（[插件页](https://www.codebuddy.cn/docs/plugin/)）。
+
+**为什么需要**：你已经有编辑器和工作流，只想要补全、对话、工程问答。
+
+**不是什么**：
+
+- 不是 CLI 的 `codebuddy plugin`
+- 本站不因此写微信或 QQ 产品教程；微信开发者工具只是官方列出的宿主之一
+
+## CodeBuddy Code
+
+**是什么**：面向专业工程师的 AI CLI。可执行文件 `codebuddy`，npm 包 `@tencent-ai/codebuddy-code`。官方适用：DevOps / 运维 / SRE / 资深开发者。
+
+**三张脸**（同一产品，不是三个产品）：
+
+| 面 | 入口 |
+|----|------|
+| 交互 REPL | `codebuddy` |
+| 打印 / 无头 | `codebuddy -p "..."` |
+| 进阶托管 | `codebuddy --serve`、`daemon`、`--bg` |
+
+**不是什么**：不是已停更的某个「腾讯 Copilot」口头禅。国内登录域确实是 `copilot.tencent.com`，那是认证站，不是另一个产品名。
+
+## WorkBuddy
+
+**是什么**：官方原文（[WorkBuddy 简介](https://www.codebuddy.cn/docs/workbuddy/)）——「WorkBuddy 是腾讯出品的全场景 AI 办公工作台。」文档站把它和 CodeBuddy IDE / 插件 / CLI 并列成一级入口。
+
+**为什么出现在这张表**：家族完备要求一级入口不能从地图消失。#78 只收 CodeBuddy 编码三形态，所以 WorkBuddy 只占一行。
+
+**不是什么**：不是 CodeBuddy IDE 的移动版。小程序和 App 是 WorkBuddy 自己的入口。
+
+## 元宝
+
+**是什么**：腾讯的通用 AI 助手。[yuanbao.tencent.com](https://yuanbao.tencent.com/)。
+
+**不是什么**：不是 CodeBuddy。本目录不写教程（#76）。
+
+## 混元
+
+**是什么**：腾讯自研大模型。[hunyuan.tencent.com](https://hunyuan.tencent.com/)、[云产品 tclm](https://cloud.tencent.com/product/tclm)。CodeBuddy 官方写「支持混元、DeepSeek 等多种对话大模型」。
+
+**不是什么**：不是一个编码 IDE，也不是你要 `npm install` 的东西。本目录不写混元 API 教程（#77）。
+
+## 国内站 / 国际站
+
+**是什么**：两套站点与登录。
+
+| | 国内 | 国际 |
+|--|------|------|
+| 文档 / 官网 | codebuddy.cn | codebuddy.ai |
+| CLI 登录选项 | Chinese Site → copilot.tencent.com | International Site → codebuddy.ai |
+| IDE 下载（官方表） | [copilot.tencent.com/ide](https://copilot.tencent.com/ide) | [codebuddy.ai](https://www.codebuddy.ai/) |
+
+**为什么要分**：模型清单和认证域不同。官方快速开始写：国内站「支持国内主流模型」，国际站「支持海外主流模型」。
+
+**不是什么**：不是「一个站过时了」。两边都会更新；若英文总览少写了「插件」这一形态，以中文总览和腾讯云 1831 文档为准。
+
+## 企业版
+
+**是什么**：SaaS 企业版（旗舰版）和专有云专享版。登录走腾讯统一身份或企业管理员下发的地址。
+
+**不是什么**：不是个人版换皮。购买和专享版流程不在本教程展开。
+
+## `CODEBUDDY.md`
+
+**是什么**：官方从 Claude Code 迁移时对应 `CLAUDE.md` 的「AI 指令和记忆文档」。用户级路径在迁移示例里是 `~/.codebuddy/CODEBUDDY.md`。
+
+**为什么需要**：把稳定约定从对话里抽出来，避免每次重讲。
+
+**不是什么**：不是 CLI plugin 清单，也不是 Skills 目录。Skills 在 `~/.codebuddy/skills/`；自定义斜杠命令在 `.codebuddy/commands/`。
+
+仓库根是否自动读 `CODEBUDDY.md`，官方故障排查没有写成一句硬规则。以本机 `/config` 和官方「记忆」页为准。
+
+<!-- TODO: 待核实 —— 项目根 CODEBUDDY.md 的自动注入范围 -->
+
+## 权限模式
+
+**是什么**：CLI 决定「这次工具调用要不要问你」的档位。`--permission-mode` 官方值：`default`、`acceptEdits`、`auto`、`dontAsk`、`plan`、`bypassPermissions`。交互里 `Shift+Tab` 的文案是 `default → bypass → accept → plan`。
+
+**为什么分两套名字**：键位提示用短名，flag 用全名。写脚本用 flag 全名。
+
+**不是什么**：不是沙箱。沙箱（`--sandbox`，官方标 Beta）限制批准之后能碰到的文件系统 / 网络。权限过了，沙箱仍可能拦住。
+
+## CLI plugin vs 编辑器插件
+
+| | 编辑器插件 | CLI plugin |
+|--|-----------|------------|
+| 装在哪 | VS Code / JetBrains… | `codebuddy plugin install` |
+| 官方文档树 | `/docs/plugin/` | `/docs/cli/` 的插件系统 / 插件市场 |
+| 解决什么 | 在已有 IDE 里补全和对话 | 给终端 agent 打包 Skills / hooks / 工具 |
+
+两者都叫「插件」，不是同一次安装。
+
+## 已退役或易过时的说法
+
+本站**不要**再写成事实的句子：
+
+- 「CodeBuddy 只有插件」——官方一级是三种形态
+- 「CodeBuddy 就是混元 IDE」——混元是模型
+- 「`gh` 式腾讯 Copilot 扩展」——现行 CLI 是独立包 `@tencent-ai/codebuddy-code`
+- 把 WorkBuddy 写成 CodeBuddy 的一种 Mode

--- a/docs/zh/products/codebuddy/codebuddy.md
+++ b/docs/zh/products/codebuddy/codebuddy.md
@@ -1,0 +1,275 @@
+---
+title: CodeBuddy 上手
+description: "按官方步骤把 CodeBuddy IDE、插件或 CLI 装上并完成第一次登录。命令和安装原文抄自 codebuddy.cn 文档站，不自行改写。"
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# CodeBuddy 上手
+
+> 这是一份**教程**——按顺序读完，你会在一种形态里完成：下载或安装 → 登录 → 第一次对话。
+>
+> 查命令去 [Cheatsheet](./codebuddy-cheatsheet)；抄场景去 [Cookbook](./codebuddy-cookbook)；撞名去 [术语表](./codebuddy-glossary)。
+
+本指南目标：把 CodeBuddy 从「听说腾讯也有个编码助手」变成「你知道该开 IDE、装插件，还是跑 `codebuddy`」。
+
+## 第 0 步：先选形态
+
+官方三种编程形态不是同一张皮。对照来自 [产品概述](https://cloud.tencent.com/document/product/1831/134343)：
+
+| 你现在的环境 | 选 |
+|-------------|----|
+| 已经在用 VS Code / JetBrains / Visual Studio | **插件** |
+| 要从一句话需求做到原型、设计稿、可部署应用 | **IDE** |
+| 人在终端，或要无头 / CI / 批量改仓库 | **CLI（CodeBuddy Code）** |
+
+三种形态共享同一账号额度（[故障排查](https://www.codebuddy.cn/docs/cli/troubleshooting)）。先装一种就能用。
+
+定价页是前端渲染，本站不抄未核过的套餐数字。看 [codebuddy.cn/pricing](https://www.codebuddy.cn/pricing/)。页面描述有「限时免费个人版、限时免费企业旗舰版以及企业专享版」。
+
+## 安装 IDE
+
+来源：[安装和登录](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation)。
+
+**环境要求**（官方表）：
+
+| 操作系统 | 支持版本 |
+|----------|----------|
+| macOS | macOS 11 (Big Sur) 及以上 |
+| Windows | Windows 10 及以上（不支持 Windows 7/8/8.1） |
+
+官方提示：不满足上述要求的系统将无法启动 CodeBuddy IDE。
+
+**下载**：访问 [CodeBuddy CN 官网](https://www.codebuddy.cn/) 或 [IDE 落地页](https://www.codebuddy.cn/ide/)，按处理器选择对应版本。国内版下载入口官方还写了 [copilot.tencent.com/ide](https://copilot.tencent.com/ide)；国际版 [codebuddy.ai](https://www.codebuddy.ai/)。
+
+**macOS 安装**：把安装包拖到 Applications。
+
+**Windows 安装**（官方步骤）：
+
+1. 双击安装包。若提示只为当前用户安装，选**确定**。
+2. 选择**我同意此协议**。
+3. 选择安装位置，一直**下一步**。
+
+**个人版登录**（官方）：打开 IDE → **登录** → 选择个人微信或手机号登录 → 回到 IDE。
+
+企业版 / 专享版登录走「腾讯统一身份」或企业管理员下发的入口，见官方同一页。本教程不展开企业购买。
+
+更新：点右上角**账户** → **检查更新** → 有新版本时点**立即安装**。
+
+## 安装 插件
+
+来源：[插件文档首页](https://www.codebuddy.cn/docs/plugin/)。
+
+**官方最低版本**（文档总览与插件页；Visual Studio 一行插件页写 17.6，总览写 17.0，以插件页为准）：
+
+| IDE | 最低版本要求 |
+|-----|----------------|
+| Visual Studio Code | 1.82 |
+| Visual Studio | 17.6（VS 2022） |
+| IntelliJ IDEA / PyCharm / GoLand / CLion / PhpStorm | 2022.2 |
+| Android Studio | Flamingo \| 2022.2.1 |
+| 微信开发者工具 IDE | 1.06.2409140 |
+
+官方注意：其它 JetBrains IDE 看 JetBrains 插件市场；另有可低至 2020.3 的兼容包，但「无法体验最新的产品功能」。
+
+**VS Code**（官方三种装法）：
+
+1. 安装 VS Code 1.82+。
+2. 装插件，任选其一：
+   - 官方「一键安装」跳转（需本机已正确安装 VS Code）
+   - 在插件市场搜索 **腾讯云代码助手**
+   - 下载安装包，在 VS Code 里手动安装
+
+**JetBrains**：设置 → **插件** → 搜索 **腾讯云代码助手** → **安装**；或「从磁盘安装插件」。
+
+**登录**：官方 [登陆及退出](https://www.codebuddy.cn/docs/plugin/%E5%BF%AB%E9%80%9F%E5%85%A5%E9%97%A8/%E7%99%BB%E5%BD%95%E5%8F%8A%E9%80%80%E5%87%BA) 写：单击底部 icon 或登录页触发登录。
+
+插件能力（[产品概述](https://cloud.tencent.com/document/product/1831/134343)）：行内补全、错误修复、解释、单测、本地评审、`@workspace` / `#Codebase`、技术对话、自定义指令、RAG 知识库、混元 / DeepSeek 等模型切换。
+
+第一次建议：打开一个你熟悉的文件，用补全写下一行；再用对话问「这个文件做什么」。工程级问题用官方提供的 `@workspace` 或 `#Codebase`，不要假设它已经记住整个公司的所有仓库。
+
+## 安装 CLI
+
+产品名是 **CodeBuddy Code**，命令是 `codebuddy`，npm 包是 `@tencent-ai/codebuddy-code`。
+
+来源：[CodeBuddy Code 安装指南](https://www.codebuddy.cn/docs/cli/installation)、[快速入门](https://www.codebuddy.cn/docs/cli/quickstart)。
+
+### 包管理器（推荐先走这条）
+
+**前置要求（安装页原文）：** Node.js **18.20** 或更高版本。
+
+故障排查页同样写「需要 Node.js v18.20 或更高版本」。文档总览 CLI 节写过 `Node.js 18.0+`；腾讯云国际站产品 FAQ 写过 Node.js 22+。本页以安装指南为准。
+
+官方给出的包管理器命令：
+
+```bash
+npm install -g @tencent-ai/codebuddy-code
+```
+
+```bash
+pnpm add -g @tencent-ai/codebuddy-code
+```
+
+```bash
+yarn global add @tencent-ai/codebuddy-code
+```
+
+```bash
+bun install -g @tencent-ai/codebuddy-code
+```
+
+**Homebrew（macOS/Linux，无需 Node.js）**，安装页原文：
+
+```bash
+brew tap Tencent-CodeBuddy/tap
+brew install codebuddy-code
+```
+
+或：
+
+```bash
+brew install Tencent-CodeBuddy/tap/codebuddy-code
+```
+
+验证（安装页原文）：
+
+```bash
+codebuddy --version
+```
+
+### 原生二进制（Beta）
+
+安装页原文：原生二进制「目前处于 Beta 测试阶段」。支持 macOS（Apple Silicon 或 Intel x86_64）、Linux（arm64 或 x86_64）、Windows（x86_64）。
+
+从 npm 迁移：
+
+```bash
+codebuddy install
+```
+
+全新安装（**安装页**）：
+
+```bash
+curl -fsSL https://www.codebuddy.cn/cli/install.sh | bash
+```
+
+```powershell
+irm https://www.codebuddy.cn/cli/install.ps1 | iex
+```
+
+[快速入门](https://www.codebuddy.cn/docs/cli/quickstart) 写的是另一对官方 URL：
+
+```bash
+curl -fsSL https://copilot.tencent.com/cli/install.sh | bash
+```
+
+```powershell
+irm https://copilot.tencent.com/cli/install.ps1 | iex
+```
+
+两页都是官方。不要合成一条。优先跟你正在读的那一页走。
+
+命令找不到时，安装页要求把路径加入 `PATH`：
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Windows：`%USERPROFILE%\AppData\Local\codebuddy\bin`。
+
+Windows 平台故障排查还要求安装 **Git Bash**（[troubleshooting](https://www.codebuddy.cn/docs/cli/troubleshooting)）。
+
+更新：
+
+```bash
+codebuddy update
+```
+
+或再跑一遍对应的包管理器安装命令。关闭自动更新：`export DISABLE_AUTOUPDATER=1`。
+
+配置目录默认 `~/.codebuddy`（Windows `%USERPROFILE%\.codebuddy`），可用 `CODEBUDDY_CONFIG_DIR` 改位置。安装页写：与其它使用 CodeBuddy 引擎的应用（如 WorkBuddy）共存时，用这个变量避免配置冲突。
+
+## 登录 CLI
+
+来源：[快速入门 · 登录认证](https://www.codebuddy.cn/docs/cli/quickstart)。
+
+启动后选择：
+
+```
+Select login method:
+› Log in via Chinese Site
+  Log in via International Site
+  Log in via Enterprise Domain
+  Log in via iOA (Tencent only)
+```
+
+| 登录方式 | 适用场景 | 说明 |
+|----------|----------|------|
+| **Chinese Site** | 国内用户 | 通过腾讯云国内站 (copilot.tencent.com) 认证 |
+| **International Site** | 海外用户 | 通过腾讯云国际站 (codebuddy.ai) 认证 |
+| **Enterprise Domain** | 专享版 / 私有化 | 需要企业提供的服务地址 |
+| **iOA** | 腾讯内部员工 | 仅限腾讯内部 |
+
+`↑↓` 选择，`Enter` 后打开浏览器完成认证。
+
+## 第一次跑 CLI
+
+```bash
+cd /path/to/your/project
+codebuddy
+```
+
+官方强烈建议先：
+
+```
+> /init
+```
+
+[快速入门](https://www.codebuddy.cn/docs/cli/quickstart) 把 `/init` 写成「强烈推荐」：预先构建项目知识图谱，后续少重复扫描。项目结构大变时：`/clear` 再 `/init`。
+
+然后可以问：
+
+```
+> 帮我分析这个项目的结构
+```
+
+语言：启动后 `/config` 可设 Language。
+
+单次命令（官方示例）：
+
+```bash
+codebuddy -p "优化这个 SQL 查询的性能"
+```
+
+需要碰文件或跑命令时，官方要求带 `-y` 或 `--dangerously-skip-permissions`：
+
+```bash
+codebuddy -p "审查 src/utils.js 的代码质量" -y
+```
+
+权限模式用 `Shift+Tab` 切换（Windows 也支持 `Alt+M`）：官方快速开始写的顺序是 `default → bypass → accept → plan`。`--permission-mode` 的合法值见 [CLI 参考](https://www.codebuddy.cn/docs/cli/cli-reference)：`default`、`acceptEdits`、`auto`、`dontAsk`、`plan`、`bypassPermissions`。键位缩写和 flag 全名不要混着用错。
+
+完整命令表见 [Cheatsheet](./codebuddy-cheatsheet)。
+
+## 第 4 步：把重复约定写下来
+
+CLI 故障排查把 `CLAUDE.md` → `CODEBUDDY.md` 列为可迁移的「AI 指令和记忆文档」。用户级文件在 `~/.codebuddy/CODEBUDDY.md`。项目级约定放哪、官方是否保证自动读取仓库根的 `CODEBUDDY.md`，以你本机 `/config` 和官方「记忆」页为准，不要猜路径。
+
+从 Claude Code 迁过来的推荐做法（官方「方案一：符号链接」）见 [Cookbook](./codebuddy-cookbook#从-claude-code-迁移)。
+
+## 护栏
+
+- **安装命令只抄官方页**。npm 包名是 `@tencent-ai/codebuddy-code`，不是猜出来的 `@tencent/codebuddy`。
+- **原生安装有两套官方 URL**（`codebuddy.cn/cli` 与 `copilot.tencent.com/cli`）。不要自行发明第三套。
+- **`-p` 不是「自动允许一切」的同义词**。碰文件 / 跑命令必须另有权限策略（`-y`、`--permission-mode` 等）。
+- **不要把 WorkBuddy、元宝、混元当成本教程的下一步**。它们在 [地图](./) 各占一行。
+- **不要对官网「提升编码效率 90%」这类句子做二次发挥**。
+
+## 下一步
+
+- 场景配方：[Cookbook](./codebuddy-cookbook)
+- 命令与键位：[Cheatsheet](./codebuddy-cheatsheet)
+- 概念：[术语表](./codebuddy-glossary)
+- 官方 CLI 进阶：[常见工作流](https://www.codebuddy.cn/docs/cli/)（文档树「入门指南」）

--- a/docs/zh/products/codebuddy/index.md
+++ b/docs/zh/products/codebuddy/index.md
@@ -1,0 +1,133 @@
+---
+title: CodeBuddy 学习地图
+description: "腾讯云 CodeBuddy 是一套共享账号额度、但入口完全不同的 AI 编程产品族：独立 IDE、编辑器插件、终端 CLI。本页是家族图和决策树——先分清形态，再决定学什么。"
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# CodeBuddy 学习地图
+
+> 腾讯云代码助手 **CodeBuddy** 同时提供 **IDE、插件、CLI** 三种编程形态。官方原文（[文档总览](https://www.codebuddy.cn/docs/)、[腾讯云产品概述](https://cloud.tencent.com/document/product/1831/134343)）：
+>
+> 「产品支持 IDE、插件和 CLI 三种形态，覆盖从专业开发者到零基础用户的全场景需求。」
+
+本页是全景图和决策树——**先分清形态，再决定学什么**。安装步骤见 [上手教程](./codebuddy)。
+
+## 产品家族
+
+文档站顶栏一级入口（2026-08-18 打开 [codebuddy.cn/docs](https://www.codebuddy.cn/docs/)）：
+
+```
+腾讯云 / CodeBuddy 家族
+├── CodeBuddy IDE — 独立编辑器，「对话即编程」
+├── CodeBuddy 插件 — VS Code / JetBrains 等宿主里的扩展
+├── CodeBuddy Code（CLI）— 终端 agent，命令 `codebuddy`
+├── WorkBuddy — 办公工作台（本目录不写教程）
+│   ├── WorkBuddy 小程序
+│   └── WorkBuddy 移动端
+└── 企业版 — SaaS 旗舰 / 专享版（本目录不写教程）
+同厂其它 AI（本目录不写教程）
+├── 元宝 — 通用助手
+└── 混元 — 模型，不是编码产品
+```
+
+| 官方一级入口 | 是什么 | 官方 URL | 本站去向 |
+|--------------|--------|----------|----------|
+| **CodeBuddy IDE** | 产设研一体工作台，主打「对话即编程」 | [文档总览](https://www.codebuddy.cn/docs/) · [安装](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation) · [下载](https://www.codebuddy.cn/ide/) | [教程](./codebuddy#安装-ide) |
+| **CodeBuddy 插件** | 装进已有编辑器的 AI 辅助 | [插件文档](https://www.codebuddy.cn/docs/plugin/) | [教程](./codebuddy#安装-插件) |
+| **CodeBuddy Code（CLI）** | 终端里用自然语言驱动开发 | [CLI 文档](https://www.codebuddy.cn/docs/cli/) · [安装](https://www.codebuddy.cn/docs/cli/installation) | [教程](./codebuddy#安装-cli) |
+| **WorkBuddy** | 「全场景 AI 办公工作台。说出要求、开始执行任务、交付完整成果。」 | [WorkBuddy 简介](https://www.codebuddy.cn/docs/workbuddy/) · [官网 /work](https://www.codebuddy.cn/work/) | **地图一行**，不拆教程 |
+| **WorkBuddy 小程序** | WorkBuddy 的移动端入口之一 | [小程序简介](https://www.codebuddy.cn/docs/workbuddymini/) | **地图一行**，不拆教程 |
+| **WorkBuddy 移动端** | 桌面 WorkBuddy 的配套 App | [移动端简介](https://www.codebuddy.cn/docs/workbuddyapp/) | **地图一行**，不拆教程 |
+| **企业版** | SaaS 企业版（旗舰版）/ 专有云专享版 | [购买流程](https://www.codebuddy.cn/docs/ide/Codebuddy-enterprise-edition/Codebuddy-enterprise-purchase) · [云文档概述](https://cloud.tencent.com/document/product/1831/134343) | **地图一行**，不拆教程 |
+| **元宝** | 腾讯通用 AI 助手 | [yuanbao.tencent.com](https://yuanbao.tencent.com/) | **地图一行**（另 #76） |
+| **混元** | 腾讯自研大模型；CodeBuddy 可切换的模型之一 | [hunyuan.tencent.com](https://hunyuan.tencent.com/) · [云产品 tclm](https://cloud.tencent.com/product/tclm) | **地图一行**（另 #77） |
+
+**不是本站范围**：微信、QQ、云主机、支付。Retrieve 时若官方 nav 冒出这些，标「非本站」即可。
+
+官方形态对照（[产品概述](https://cloud.tencent.com/document/product/1831/134343)）：
+
+| | **CodeBuddy 插件** | **CodeBuddy IDE** | **CodeBuddy Code** |
+|---|-------------------|-------------------|---------------------|
+| 需求用户 | 日常编码开发者 / 特定 IDE 使用者 | 产品 / 设计师 / 全栈开发 / 编程初学者 | DevOps / 运维 / SRE / 资深开发者 |
+| 核心优势 | 即插即用，零成本学习；融入现有工作流 | 产设研一体；CloudBase / EdgeOne Pages / CloudStudio | Shell / 文件 / 网络；无头环境；任务编排 / Sub Agent |
+| 使用指引 | 插件市场搜索 **腾讯云代码助手** | 国际版 [codebuddy.ai](https://www.codebuddy.ai/) · 国内版 [copilot.tencent.com/ide](https://copilot.tencent.com/ide) | `npm install -g @tencent-ai/codebuddy-code` |
+
+三种形态 **共享同一账号的资源配额**（[故障排查 · 额度共享](https://www.codebuddy.cn/docs/cli/troubleshooting)）。
+
+### 快速决策：我该用哪个？
+
+```
+我现在要干什么？
+├── 已经有 VS Code / JetBrains / Visual Studio，只想要补全和对话
+│   └── → 插件（市场搜「腾讯云代码助手」）
+├── 要从一句话需求走到原型 / 设计稿 / 可部署应用
+│   └── → IDE（对话即编程）
+├── 工作在终端：脚本、CI、批量重构、无头自动化
+│   └── → CodeBuddy Code（`codebuddy` / `codebuddy -p`）
+├── 办公文档 / PPT / 本地文件批处理，不是对着仓库写代码
+│   └── → WorkBuddy（本目录不教；去官方）
+└── 通用聊天 / 搜索，不是编码产品
+    └── → 元宝（本目录不教）
+```
+
+三个最容易混的名字，先记住：
+
+| 容易混的 | 区别 |
+|---------|------|
+| **CodeBuddy** vs **WorkBuddy** | 前者写代码；后者是办公工作台 |
+| **编辑器插件** vs **CLI `plugin`** | 前者装进 VS Code；后者是 `codebuddy plugin install` |
+| **混元** vs **CodeBuddy** | 混元是模型；CodeBuddy 是产品，官方还写支持 DeepSeek 等 |
+
+更多辨析见 [术语表](./codebuddy-glossary)。
+
+## 该读哪一篇
+
+本组文档按 [Diataxis](https://diataxis.fr/) 拆分：
+
+| 文档 | 类型 | 什么时候看 |
+|------|------|-----------|
+| [上手教程](./codebuddy) | Tutorial | 第一次用：装 IDE / 插件 / CLI → 登录 → 第一次对话 |
+| [实战 Cookbook](./codebuddy-cookbook) | How-to | 已经能跑，要抄 `/init`、print 模式、自定义命令、MCP、迁移 |
+| [Cheatsheet](./codebuddy-cheatsheet) | Reference | 查安装原文、CLI 命令、斜杠命令、键位 |
+| [术语表](./codebuddy-glossary) | Explanation | 形态、权限模式、`CODEBUDDY.md`、国内站 / 国际站 |
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 选对形态并装上 | [教程](./codebuddy) | 15 分钟内在一种形态里完成登录 |
+| 2. 跑通第一次任务 | [教程](./codebuddy) 的第一次对话；CLI 先 `/init` | 敢让它读仓库或改一小处 |
+| 3. 接到日常工作流 | [Cookbook](./codebuddy-cookbook) | print 模式、斜杠命令、MCP |
+| 4. 回查参数 | [速查表](./codebuddy-cheatsheet) | 命令、flag、安装原文 |
+| 5. 理清概念 | [术语表](./codebuddy-glossary) | 不再把 WorkBuddy / 混元 / CLI plugin 当同一个东西 |
+
+## 功能速查
+
+| 功能 | 在哪 | 官方出处 |
+|------|------|----------|
+| 行内补全、技术对话、`@workspace` / `#Codebase` | 插件 | [产品概述](https://cloud.tencent.com/document/product/1831/134343) |
+| 自然语言 → PRD / 设计稿 / 代码 / 一键部署 | IDE | 同上 |
+| 交互式 REPL、`codebuddy -p`、斜杠命令、MCP | CLI | [快速开始](https://www.codebuddy.cn/docs/cli/quickstart) · [CLI 参考](https://www.codebuddy.cn/docs/cli/cli-reference) |
+| Skills / Hooks / 子代理 / Daemon | CLI（高级） | [CLI 文档树](https://www.codebuddy.cn/docs/cli/) |
+
+## 目标与非目标
+
+**目标**：让前端工程师分清 CodeBuddy 的三种编程形态，并按官方步骤装上、登录、跑通第一次任务。
+
+**非目标**：
+
+- 不写元宝、混元、WorkBuddy 的完整教程
+- 不写微信 / QQ 产品
+- 不写模型内部机制
+- 不把官网营销百分比当成实测结论
+
+## 资源
+
+- [国内文档站](https://www.codebuddy.cn/docs/)
+- [国际文档站](https://www.codebuddy.ai/docs/) · [中文镜像](https://www.codebuddy.ai/docs/zh/)
+- [腾讯云产品页 acc](https://cloud.tencent.com/product/acc)
+- [定价](https://www.codebuddy.cn/pricing/) — 页面是前端渲染；不要在本站抄未核过的套餐数字
+- [Cheatsheet · 高质量信息源](./codebuddy-cheatsheet#高质量信息源)


### PR DESCRIPTION
Closes #78

从零建立腾讯云 CodeBuddy（IDE / 插件 / CLI）中英文手册。方法论按 `doc-research`：先 Retrieve 官方一级 nav，再写地图与 Diataxis 四象限。

## 做了什么

- 维护参考：`.claude/skills/doc-research/references/codebuddy.md`
- 中文：`docs/zh/products/codebuddy/`（`index` / `codebuddy` / `cookbook` / `cheatsheet` / `glossary`）
- 英文同构：`docs/products/codebuddy/`
- 绑定表加了 CodeBuddy 一行

官方一级（`codebuddy.cn/docs` 顶栏，2026-08-18）：**IDE / 插件 / CLI / WorkBuddy / WorkBuddy 小程序 / WorkBuddy 移动端 / 企业版**。
本 issue 只收编码三形态独立页；WorkBuddy 一家、企业版、元宝、混元只在 ZH 地图家族表一行。不写微信 / QQ 产品教程。

## 官方安装原文（CLI）

包管理器（[installation](https://www.codebuddy.cn/docs/cli/installation)，Node.js **18.20+**）：

```bash
npm install -g @tencent-ai/codebuddy-code
```

原生安装有两套官方 URL，正文并排、不合成：

- 安装页：`curl -fsSL https://www.codebuddy.cn/cli/install.sh | bash`
- 快速开始页：`curl -fsSL https://copilot.tencent.com/cli/install.sh | bash`

验证：`codebuddy --version`。

IDE：[Getting-Started/Installation](https://www.codebuddy.cn/docs/ide/Getting-Started/Installation)（macOS 11+ / Windows 10+）。
插件：市场搜索 **腾讯云代码助手**（[plugin docs](https://www.codebuddy.cn/docs/plugin/)）。

## 故意没做

- **没改** `products-gallery.js` 与 `sidebars/ai-coding.mjs`（执行指令禁止改 gallery/sidebar；覆盖 issue 步骤 7）。
- 不写定价数字（定价页前端渲染，未抽出价目表）。
- Node 口径左证不一致：安装页 18.20+，总览 18.0+，云国际站 FAQ 曾写 22+。正文以安装页为准并标差异。

## 验收

- [x] `references/codebuddy.md` 先于正文
- [x] 本目录无元宝 / 混元 / WorkBuddy 完整教程
- [x] ZH 地图家族表覆盖官方一级 AI 入口
- [x] 安装 / 命令抄官方，禁止自撰包名
- [ ] gallery / sidebar 按执行指令未挂