### PR TITLE
docs(minimax-agent): add MiniMax Agent handbook for #73

### DIFF
--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -12,5 +12,6 @@
 | Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
 | Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
 | Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| MiniMax Agent | [`minimax-agent.md`](./minimax-agent.md) | `docs/zh/products/minimax-agent/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/.claude/skills/doc-research/references/minimax-agent.md
+++ b/.claude/skills/doc-research/references/minimax-agent.md
@@ -1,0 +1,149 @@
+# MiniMax Agent 维护参考
+
+> 通用维护流程见 [`maintenance-workflow.md`](./maintenance-workflow.md)；高质量数据源清单发布在 `docs/zh/products/minimax-agent/minimax-agent-cheatsheet.md` 的「高质量信息源」。文档架构见 [`documentation-architecture.md`](./documentation-architecture.md)。
+
+## 产品形态调研结论（写教程前必须先有这一节）
+
+调研时间：2026-08-19。以下每条都来自一手官方来源，来源标在括号里。
+
+**结论一：本 issue 的主产品是通用 Agent 工作台 MiniMax Agent，不是 MiniMax Code。**
+
+- 国内入口 [agent.minimaxi.com](https://agent.minimaxi.com/) 标题原文：「MiniMax Agent: 简单指令, 无限可能」。
+- 海外入口 [agent.minimax.io](https://agent.minimax.io/) 标题原文：「MiniMax Agent: Minimize Effort, Maximize Intelligence」。
+- 官方新闻 [MiniMax Agent，最大的智慧是“靠谱”](https://www.minimaxi.com/news/minimax-agent)（2025-06-19）原文：「一个能完成长程（Long Horizon）复杂任务的通用智能体」。
+- 官方新闻 [MiniMax M2 & Agent，大巧若拙](https://www.minimaxi.com/news/minimax-m2) 原文：「基于 MiniMax-M2 的通用 Agent 产品 MiniMax Agent」。
+- **不要写 MiniMax Code 主教程。** Code 是桌面端编程 Agent，文档树在 `agent.minimaxi.com/docs/code/*`，另 issue #72。
+
+**结论二：同一文档域名现在同时扛「Agent 产品」和「Code 文档」。**
+
+- `https://agent.minimaxi.com/docs/llms.txt` 的 Docs 列表几乎全是 MiniMax Code 页（欢迎、下载、Coding/Work、工作区、权限、IM、Remote Control）。
+- [更新日志](https://agent.minimaxi.com/docs/changelog) 头部仍写「追踪 MiniMax Agent 每次更新」，正文从 v3.0.33（2026-05-29）起写「桌面端正式更名为 MiniMax Code」。
+- [下载页](https://agent.minimaxi.com/download) 当前标题是「MiniMax Code - 下载」。
+- 写教程时：Web 工作台叫 MiniMax Agent；桌面端文档与下载页当前品牌是 MiniMax Code。禁止把 `/docs/code/*` 抄进本目录当主教程。
+
+**结论三：官方一级产品不止 Agent。Code / Hailuo / 星野只在地图一行。**
+
+2026-08-19 打开的官方一级入口：
+
+| 来源 | 一级项 |
+|------|--------|
+| [www.minimaxi.com](https://www.minimaxi.com/) 关于我们 | MiniMax Code、MiniMax Design、MiniMax Audio、星野、开放平台 |
+| [www.minimaxi.com/en](https://www.minimaxi.com/en) Product nav | MiniMax Code、Video Hailuo、Audio、Talkie、API、Token Plan |
+| [www.minimaxi.com/en](https://www.minimaxi.com/en) About | MiniMax Code、**MiniMax Hub**、MiniMax Audio、Talkie、open platform |
+| [agent.minimaxi.com](https://agent.minimaxi.com/) | MiniMax Agent；站内还有 MaxHermes、MaxClaw、技能市场、下载桌面端 |
+
+Hub 与 Design 两份官方页对同一入口打架：英文 About 仍写 MiniMax Hub；[hub.minimaxi.com](https://hub.minimaxi.com/) 打开后加载的是 MiniMax Design（「正在加载 MiniMax Design…」）。本站以当前落地页为准写 Design，并把 Hub 标成旧名/英文 About 用词，禁止各写各的。
+
+**结论四：Agent 工作台的可写密度够立 Tutorial + 参考，不够写 Code 级 CLI 手册。**
+
+官方能直接引用的 Agent 面：
+
+- 使用面：网页 [agent.minimaxi.com](https://agent.minimaxi.com/) / [agent.minimax.io](https://agent.minimax.io/)；技能市场 [agent.minimaxi.com/skills](https://agent.minimaxi.com/skills)。
+- 两种模式（[M2 新闻](https://www.minimaxi.com/news/minimax-m2)）：**Lightning 高效模式**（对话问答 / 轻量级搜索 / 轻量级代码）、**Pro 专业模式**（深度研究 / 全栈开发 / PPT / 报告 / 网页制作）。
+- Agent Team（[techblog](https://agent.minimaxi.com/docs/techblog/agent-team.md)）：Leader / Worker / Verifier；用户只发一条消息。
+- 能力面：编程、多模态、MCP（[靠谱](https://www.minimaxi.com/news/minimax-agent)）；写作、语音、图像、文档、翻译（[features/zh.html](https://agent.minimax.io/features/zh.html)）。
+
+官方**没有**给 Agent 网页工作台单独的 Commands / Settings 参考。斜杠命令、权限模式、Worktree、Coding/Work 属于 Code 文档树，不要抄过来冒充 Agent 网页操作。
+
+**结论五：计费有两套官方说法，禁止猜哪套「当前仍免费」。**
+
+- [M2 新闻](https://www.minimaxi.com/news/minimax-m2) 原文：「我们目前在免费提供 MiniMax Agent, 直到我们的服务器撑不住为止。」
+- [技能市场](https://agent.minimaxi.com/skills) 弹层原文：「统一计费：全面打通 Token Plan」。
+- [下载页](https://agent.minimaxi.com/download) 列出 Plus ¥49/月、Max ¥119/月、Ultra ¥469，页面品牌是 MiniMax Code。
+
+教程只并列引用，链回官方套餐页。不要把限时免费写成长期政策，也不要把下载页档位写成 Agent 网页专用价。
+
+**结论六：易撞名必须写「不是什么」。**
+
+- MiniMax Agent ≠ MiniMax Code
+- MiniMax Hub ≠ MiniMax Agent（Hub 域名当前是 Design）
+- MiniMax Design ≠ MiniMax Agent
+- Mini-Agent（GitHub `MiniMax-AI/Mini-Agent`）≠ MiniMax Agent 产品
+- MaxHermes / MaxClaw ≠ 公司一级产品，是 Agent 站内入口
+- Hailuo / 海螺视频 ≠ Agent
+- 星野 / Talkie ≠ Agent
+- Token Plan ≠ 产品，是计费入口
+
+**结论七：适合本站「前端工程师」读者，但主路径不是终端编程。**
+
+依据：官方把 Agent 定位为通用长程智能体（研究、PPT、报告、网页、多模态交付），网页即可用。前端工程师会用它做调研、演示稿、落地页和轻量编码。仓库级桌面编程走 Code（#72），不要在本目录展开。
+
+## 基本信息
+
+- 工具名：MiniMax Agent（通用 Agent 工作台）
+- 官方产品入口：<https://agent.minimaxi.com/>（国内）、<https://agent.minimax.io/>（海外）
+- 厂商站：<https://www.minimaxi.com/>、<https://www.minimax.io/>
+- 文档根（当前以 Code 为主）：<https://agent.minimaxi.com/docs/llms.txt>
+- 发版节奏：桌面端 changelog 以 `v3.0.x` 记；网页工作台没有独立版本号。不要在读者标题里写精确版本。
+- 当前覆盖：2026-08-19 打开的官方页（见上）。模型内部机制不写，链 [Learn LLM](https://llm.zenheart.site/chapters/)。
+
+## 官方一级导航（产品家族）
+
+| 官方一级入口 | 官方 URL | 本站去向 | 不拆页理由（若一行） |
+|--------------|----------|----------|----------------------|
+| MiniMax Agent | https://agent.minimaxi.com/ | 独立页（本目录） | |
+| MiniMax Code | https://agent.minimaxi.com/docs/code/welcome | 地图一行 | 另 issue #72；本目录不写主教程 |
+| MiniMax Design / Hub | https://design.minimaxi.com/ 、https://hub.minimaxi.com/ | 地图一行 | 创作画布，不是通用 Agent 工作台 |
+| Hailuo / 海螺视频 | https://hailuoai.com/ | 地图一行 | 视频生成产品 |
+| MiniMax Audio | https://www.minimaxi.com/audio | 地图一行 | 语音 / 音乐产品 |
+| 星野 | https://www.xingyeai.com/ | 地图一行 | 沉浸式角色社区 |
+| Talkie | https://www.talkie-ai.com/ | 地图一行 | 星野海外对应 |
+| 开放平台 / API | https://platform.minimaxi.com/ | 地图一行 | 开发者 API，不是 Agent 工作台 |
+| Token Plan | 厂商站 Product nav「Token Plan」 | 地图一行 | 计费入口，不是产品 |
+| About / News / IR / Careers | https://www.minimaxi.com/ | 非本站 | 非 AI 产品 |
+
+易撞名：见结论六。
+
+## 文档文件结构（Diataxis）
+
+官方没有 Agent 专用 CLI 参考，所以不按 Claude Code 五文件硬凑命令表。采用 5 文件：地图 + Tutorial + 短 Cookbook + 入口速查 + 撞名术语。
+
+```
+docs/zh/products/minimax-agent/
+├── index.md
+├── minimax-agent.md
+├── minimax-agent-cookbook.md
+├── minimax-agent-cheatsheet.md
+└── minimax-agent-glossary.md
+
+docs/products/minimax-agent/        # 英文同构
+```
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 + 速查 | 家族图、决策树、Agent 功能速查 | Code 安装步骤 |
+| `minimax-agent.md` | Tutorial | 打开网页、选模式、发第一个长程任务、技能市场、Team | Code 工作区 / 终端 / 权限 flag |
+| `minimax-agent-cookbook.md` | How-to | 官方场景配方（研究、PPT/报告、技能、Team） | 臆造斜杠命令 |
+| `minimax-agent-cheatsheet.md` | Reference | 入口、模式、域名、数据源 | 概念散文 |
+| `minimax-agent-glossary.md` | Explanation | 撞名、Lightning/Pro、Team、Skill、Hub/Design | 操作步骤 |
+
+跨页顺序：`index` → `minimax-agent` → `cookbook` → `cheatsheet` → `glossary`。
+
+## 监控页面
+
+- Agent 产品入口：<https://agent.minimaxi.com/>
+- 海外入口：<https://agent.minimax.io/>
+- 技能市场：<https://agent.minimaxi.com/skills>
+- Changelog（桌面端已改名 Code）：<https://agent.minimaxi.com/docs/changelog>
+- 文档索引：<https://agent.minimaxi.com/docs/llms.txt>
+- Agent Team 技术文：<https://agent.minimaxi.com/docs/techblog/agent-team.md>
+- 功能页：<https://agent.minimax.io/features/zh.html>
+- FAQ（偏消费向）：<https://agent.minimax.io/faq/en.html>
+- 厂商新闻：<https://www.minimaxi.com/news/minimax-agent>、<https://www.minimaxi.com/news/minimax-m2>
+- Code 欢迎页（只作边界）：<https://agent.minimaxi.com/docs/code/welcome>
+- Design / Hub：<https://design.minimaxi.com/>、<https://hub.minimaxi.com/>
+
+## Git 提交 scope
+
+```
+docs(minimax-agent): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+1. **`www.minimaxi.com` / `agent.minimaxi.com` 对部分抓取器走 198.18 代理或 SSRF 拦截。** 用页面阅读器，不要把 `curl` 403 当成页面不存在。
+2. **`/docs/llms.txt` 是 Code 文档树，不是 Agent 网页工作台手册。** 写 Agent 操作前先问：这条原文是不是 `docs/code/*`。
+3. **中英 About 产品名不一致**（Hub vs Design）。家族图必须同时写两份原文。
+4. **禁止改 `products-gallery.js`。** 导航只挂 `sidebars/ai-coding.mjs`。
+5. **不要把 Token Plan 档位、积分日签、插件名单写成长期规格。** 这些出现在 Code changelog / 下载页，会变。
+6. **机制（MSA、注意力、训练）不写**，链 Learn LLM。

--- a/docs/.vitepress/sidebars/ai-coding.mjs
+++ b/docs/.vitepress/sidebars/ai-coding.mjs
@@ -192,6 +192,27 @@ export const enAiCodingItems = [
                                     },
                                  ]
                               },
+                              {
+                                 text: 'MiniMax Agent', link: '/products/minimax-agent/', items: [
+                                    { text: '🗺️ Learning Map', link: '/products/minimax-agent/' },
+                                    {
+                                       text: 'Core',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'MiniMax Agent Tutorial', link: '/products/minimax-agent/minimax-agent' },
+                                          { text: 'Cookbook', link: '/products/minimax-agent/minimax-agent-cookbook' },
+                                       ]
+                                    },
+                                    {
+                                       text: 'Appendix',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Cheatsheet', link: '/products/minimax-agent/minimax-agent-cheatsheet' },
+                                          { text: 'Glossary', link: '/products/minimax-agent/minimax-agent-glossary' },
+                                       ]
+                                    },
+                                 ]
+                              },
                               { text: 'Pi Agent', link: '/products/ai-coding/pi-agent' },
                               { text: 'Other Tools', link: '/products/ai-coding/othertools' },
 ]
@@ -378,6 +399,27 @@ export const zhAiCodingItems = [
                                        items: [
                                           { text: '速查表', link: '/zh/products/ai-coding/grok/grok-cheatsheet' },
                                           { text: '术语表', link: '/zh/products/ai-coding/grok/grok-glossary' },
+                                       ]
+                                    },
+                                 ]
+                              },
+                              {
+                                 text: 'MiniMax Agent', link: '/zh/products/minimax-agent/', items: [
+                                    { text: '🗺️ 学习地图', link: '/zh/products/minimax-agent/' },
+                                    {
+                                       text: '核心',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'MiniMax Agent 教程', link: '/zh/products/minimax-agent/minimax-agent' },
+                                          { text: 'Cookbook', link: '/zh/products/minimax-agent/minimax-agent-cookbook' },
+                                       ]
+                                    },
+                                    {
+                                       text: '附录',
+                                       collapsed: false,
+                                       items: [
+                                          { text: '速查表', link: '/zh/products/minimax-agent/minimax-agent-cheatsheet' },
+                                          { text: '术语表', link: '/zh/products/minimax-agent/minimax-agent-glossary' },
                                        ]
                                     },
                                  ]

--- a/docs/products/minimax-agent/index.md
+++ b/docs/products/minimax-agent/index.md
@@ -1,0 +1,140 @@
+---
+title: MiniMax Agent learning map
+description: "MiniMax Agent is the general-purpose agent workbench, not MiniMax Code. This directory covers the web workbench only. Code / Hailuo / Talkie stay one row on the family map."
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# MiniMax Agent learning map
+
+> **MiniMax Agent** is MiniMax's general-purpose agent workbench. The official launch post ([Agent](https://www.minimaxi.com/news/minimax-agent)) calls it a general agent that can finish **long-horizon** tasks: plan an expert solution, break the work down, run sub-tasks, and deliver a result.
+>
+> China entry: [agent.minimaxi.com](https://agent.minimaxi.com/). International entry: [agent.minimax.io](https://agent.minimax.io/).
+>
+> **This directory is not a MiniMax Code tutorial.** The desktop coding agent lives at the official [Code welcome page](https://agent.minimaxi.com/docs/code/welcome). This site tracks Code in issue #72.
+
+## Product landscape
+
+The company site, the Agent site, and the docs site reuse several names. They are **not** one product with four skins. The **core path** here is **MiniMax Agent** (the web workbench).
+
+```
+MiniMax family
+├── MiniMax Agent — general-purpose workbench (this directory)
+│   ├── Web: agent.minimaxi.com / agent.minimax.io
+│   ├── Lightning / Pro modes
+│   ├── Skill marketplace /skills
+│   └── On-site entries: MaxHermes, MaxClaw
+├── MiniMax Code — desktop coding agent (#72, not expanded here)
+├── MiniMax Design / Hub — multimodal creation canvas
+├── Hailuo — video generation
+├── MiniMax Audio — speech and music
+├── Xingye / Talkie — character / community apps
+└── Open Platform / Token Plan — API and billing
+```
+
+| Official first-level entry | What it is | Official URL | This site |
+|----------------------------|------------|--------------|-----------|
+| **MiniMax Agent** | Long-horizon general agent workbench | [agent.minimaxi.com](https://agent.minimaxi.com/) | Standalone pages in this directory |
+| MiniMax Code | Desktop AI agent for a local project / terminal / browser | [Code welcome](https://agent.minimaxi.com/docs/code/welcome) | One row. Main tutorial is #72 |
+| MiniMax Design / Hub | Multimodal creation studio. EN About still says Hub; `hub.minimaxi.com` now loads Design | [design.minimaxi.com](https://design.minimaxi.com/), [hub.minimaxi.com](https://hub.minimaxi.com/) | One row |
+| Hailuo | Text / image to video | [hailuoai.com](https://hailuoai.com/) | One row |
+| MiniMax Audio | Speech and music | [minimaxi.com/audio](https://www.minimaxi.com/audio) | One row |
+| Xingye (星野) | Immersive agent community (China) | [xingyeai.com](https://www.xingyeai.com/) | One row |
+| Talkie | Xingye's overseas counterpart | [talkie-ai.com](https://www.talkie-ai.com/) | One row |
+| Open Platform / API | Model HTTP API | [platform.minimaxi.com](https://platform.minimaxi.com/) | One row |
+| Token Plan | Subscription and quota | Product nav on the company site | One row |
+| About / News / IR | Company pages | [minimaxi.com](https://www.minimaxi.com/) | Out of scope |
+
+Sources: [www.minimaxi.com](https://www.minimaxi.com/) About, [www.minimaxi.com/en](https://www.minimaxi.com/en) Product / About, [agent.minimaxi.com](https://agent.minimaxi.com/), [docs/llms.txt](https://agent.minimaxi.com/docs/llms.txt). Opened 2026-08-19.
+
+**Names that collide:**
+
+- **MiniMax Agent ≠ MiniMax Code.** Agent is the general workbench. Code is the desktop app. Changelog [v3.0.33](https://agent.minimaxi.com/docs/changelog): "Desktop app officially renamed to MiniMax Code."
+- **MiniMax Hub ≠ MiniMax Agent.** EN About lists Hub next to Code / Audio / Talkie. Opening `hub.minimaxi.com` currently loads MiniMax Design.
+- **Mini-Agent ≠ MiniMax Agent.** `MiniMax-AI/Mini-Agent` is an open-platform sample, not this product.
+- **MaxHermes / MaxClaw** appear on the Agent home page. They are not company first-level products. See the [glossary](./minimax-agent-glossary.md).
+
+Model internals (MSA, attention, training) belong in [Learn LLM](https://llm.zenheart.site/chapters/). This directory does not explain them.
+
+### Quick decision: which surface?
+
+```
+What do I want to do?
+├── Finish a long task in the browser (research, PPT, report, site, multimodal deliverable)
+│   └── → MiniMax Agent (this directory)
+│       ├── Q&A / light search / light code → Lightning
+│       └── Long research / full-stack / PPT / report / site → Pro; turn on Agent Team when the work must split
+├── Edit a local repo, inspect diffs, run a terminal
+│   └── → MiniMax Code (official desktop docs; this site #72)
+├── Only generate video
+│   └── → Hailuo
+├── Only speech / music
+│   └── → MiniMax Audio
+├── Character roleplay / community
+│   └── → Xingye (China) / Talkie (overseas)
+├── Storyboard-to-film canvas
+│   └── → MiniMax Design (the domain may still say Hub)
+└── Call models from my own software
+    └── → Open Platform API
+```
+
+## When MiniMax Agent is worth a try
+
+**Try it when:**
+
+- You want a **browser deliverable**: research, slides, a report, a site — not a terminal session over a repo.
+- You already use a Claude.ai / Cowork-style workbench and want the China / MiniMax entry.
+- The job needs multimodal output or MCP. The [launch post](https://www.minimaxi.com/news/minimax-agent) lists programming, multimodality, and MCP as design bars.
+
+**Wait when:**
+
+- You need a local project, a terminal, and a git workspace — that is **MiniMax Code**.
+- You only need one video — use Hailuo.
+- You want a companion character — use Xingye / Talkie.
+- You need a copy-paste command / flag manual — there is no official Commands page for the Agent web workbench. This site only records wording we can open.
+
+## Learning path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Open it | [MiniMax Agent tutorial](./minimax-agent.md) | Sign in and send the first task |
+| 2. Pick a mode | Lightning / Pro in the tutorial, then the [Cookbook](./minimax-agent-cookbook.md) | Short Q&A stays off Pro |
+| 3. Skills and Team | Cookbook + [skill marketplace](https://agent.minimaxi.com/skills) | When to install a skill; when to open Team |
+| 4. Look up entries | [Cheatsheet](./minimax-agent-cheatsheet.md) | Domains, modes, sources |
+| 5. Untangle names | [Glossary](./minimax-agent-glossary.md) | Agent / Code / Hub / Design / Mini-Agent |
+
+## Feature snapshot
+
+Only capabilities with official wording.
+
+| Capability | One line | Official source |
+|------------|----------|-----------------|
+| Long-horizon tasks | Plan, split, deliver a final result | [Launch post](https://www.minimaxi.com/news/minimax-agent) |
+| Lightning | Fast Q&A / light search / light code | [M2 post](https://www.minimaxi.com/news/minimax-m2) |
+| Pro | Deep research / full-stack / PPT / reports / websites | [M2 post](https://www.minimaxi.com/news/minimax-m2) |
+| Agent Team | Lead agent splits work; Leader / Worker / Verifier | [Agent Team](https://agent.minimaxi.com/docs/techblog/agent-team.md) |
+| Skill marketplace | Browse, install, create, or import from GitHub | [skills](https://agent.minimaxi.com/skills) |
+| Programming | Complex flows, simulated user tests, UI quality | [Launch post](https://www.minimaxi.com/news/minimax-agent) |
+| Multimodal | Long text / video / audio / image; built-in generation | [Launch post](https://www.minimaxi.com/news/minimax-agent) |
+| MCP | Built-in MiniMax MCP; also lists GitHub / GitLab / Slack / Figma | [Launch post](https://www.minimaxi.com/news/minimax-agent) |
+| Writing / voice / image / docs / translate | Consumer feature page | [features](https://agent.minimax.io/features/en.html) |
+
+The driving model changes. The home page on 2026-08-19 showed MiniMax-M3. Internals: [Learn LLM](https://llm.zenheart.site/chapters/).
+
+## Resources
+
+- Product: <https://agent.minimaxi.com/>
+- International: <https://agent.minimax.io/>
+- Company: <https://www.minimaxi.com/>
+- Docs index: <https://agent.minimaxi.com/docs/llms.txt>
+- Full source list: [cheatsheet](./minimax-agent-cheatsheet.md#high-quality-sources)
+
+## Related pages
+
+- [MiniMax Agent tutorial](./minimax-agent.md)
+- [Cookbook](./minimax-agent-cookbook.md)
+- [Cheatsheet](./minimax-agent-cheatsheet.md)
+- [Glossary](./minimax-agent-glossary.md)
+- [All products](../index.md)

--- a/docs/products/minimax-agent/minimax-agent-cheatsheet.md
+++ b/docs/products/minimax-agent/minimax-agent-cheatsheet.md
@@ -1,0 +1,122 @@
+---
+title: MiniMax Agent cheatsheet
+description: "Look up, do not study. Entries, modes, name collisions, and sources. No official Commands page, so there is no invented command table."
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# MiniMax Agent cheatsheet
+
+Look up, do not study. Coverage: official pages opened 2026-08-19. Commands, flags, and check-in points that exist only in the Code changelog stay out of this table.
+
+## Entries
+
+| Use | URL |
+|-----|-----|
+| China workbench | https://agent.minimaxi.com/ |
+| International workbench | https://agent.minimax.io/ |
+| Skill marketplace | https://agent.minimaxi.com/skills |
+| Docs index | https://agent.minimaxi.com/docs/llms.txt |
+| Changelog | https://agent.minimaxi.com/docs/changelog |
+| Desktop download (currently branded Code) | https://agent.minimaxi.com/download |
+| Company site | https://www.minimaxi.com/ |
+| International company site | https://www.minimax.io/ |
+
+## Modes
+
+Source: [M2 post](https://www.minimaxi.com/en/news/minimax-m2)
+
+| Mode | Official wording | Use it for |
+|------|------------------|------------|
+| Lightning | Q&A, lightweight search, simple coding; instant output | Short tasks |
+| Pro | Complex long-running work; research, full-stack, PPT, reports, websites | Long tasks with a file |
+
+## Decision: Agent or another door
+
+| Job | Pick |
+|-----|------|
+| Finish research / PPT / report / site in the browser | Agent |
+| Local repo + terminal | Code |
+| Video only | Hailuo |
+| Speech / music only | Audio |
+| Character community | Xingye / Talkie |
+| Creation canvas | Design (Hub is the EN About / old host) |
+| Call models from my app | Open Platform |
+
+Term index (one line; detail in the [glossary](./minimax-agent-glossary.md)):
+
+| Term | Hook |
+|------|------|
+| MiniMax Agent | General web workbench |
+| MiniMax Code | Desktop app; not this tutorial |
+| Hub / Design | Creation product; two official names, trust the landing page |
+| Mini-Agent | GitHub sample, not the product |
+| Lightning / Pro | Two official modes |
+| Agent Team | Leader / Worker / Verifier |
+| MaxHermes / MaxClaw | On-site Agent entries, not first-level products |
+| Token Plan | Billing, not a product |
+
+## Billing (quote, do not merge)
+
+| Claim | Source |
+|-------|--------|
+| Free until the servers cannot keep up | [M2 post](https://www.minimaxi.com/en/news/minimax-m2) |
+| Unified billing via Token Plan | [Skill marketplace](https://agent.minimaxi.com/skills) |
+| Plus ¥49 / Max ¥119 / Ultra ¥469 | [Download page](https://agent.minimaxi.com/download) (title: MiniMax Code) |
+
+Trust the signed-in plan page.
+
+## Common errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Looking for a `minimax` CLI / workspace here | That is Code | [Code welcome](https://agent.minimaxi.com/docs/code/welcome) |
+| Short Q&A is slow | Pro / Team is on | Switch to Lightning |
+| Long report stops at 50% | Single agent reports early | Write acceptance checks, or Team |
+| Writing Hub and Agent as one tutorial | EN About still says Hub | Hub currently is Design |
+| Citing a mirror site's numbers | No official wording | Delete or mark unverified |
+
+## High-quality sources
+
+Last verified: 2026-08-19. Only pages we opened.
+
+### First-party official
+
+| Source | Use |
+|--------|-----|
+| [agent.minimaxi.com](https://agent.minimaxi.com/) | China product entry |
+| [agent.minimax.io](https://agent.minimax.io/) | International product entry |
+| [skills](https://agent.minimaxi.com/skills) | Skill marketplace |
+| [features/en.html](https://agent.minimax.io/features/en.html) | Consumer feature copy |
+| [faq/en.html](https://agent.minimax.io/faq/en.html) | Consumer FAQ, not an engineering reference |
+| [changelog](https://agent.minimax.io/docs/changelog) | Release notes; later entries are Code |
+| [llms.txt](https://agent.minimaxi.com/docs/llms.txt) | Docs tree index |
+| [Agent Team](https://agent.minimaxi.com/docs/techblog/agent-team.md) | Team design and when to use it |
+| [Launch post](https://www.minimaxi.com/news/minimax-agent) | Product positioning (2025-06-19) |
+| [M2 & Agent](https://www.minimaxi.com/en/news/minimax-m2) | Lightning / Pro and the free-trial wording |
+| [Code welcome](https://agent.minimaxi.com/docs/code/welcome) | Boundary only, not this tutorial |
+| [design.minimaxi.com](https://design.minimaxi.com/) | Current Design landing page |
+| [hub.minimaxi.com](https://hub.minimaxi.com/) | Loads Design |
+| [hailuoai.com](https://hailuoai.com/) | Hailuo |
+| [minimaxi.com/audio](https://www.minimaxi.com/audio) | Audio |
+| [xingyeai.com](https://www.xingyeai.com/) | Xingye |
+| [talkie-ai.com](https://www.talkie-ai.com/) | Talkie |
+| [platform.minimaxi.com](https://platform.minimaxi.com/) | Open Platform |
+
+### Unverified
+
+| Item | URL | Why it is unsure |
+|------|-----|------------------|
+| Whether the Agent web app is still free | In-app plan page (sign-in) | Launch "free until servers fail" and Token Plan now coexist |
+| Whether the plugin marketplace is on the web Agent | Changelog / home modal | Launch notes name MiniMax Code |
+
+**Fetch notes** (2026-08-19): some clients resolve `minimaxi.com` / `agent.minimaxi.com` through a 198.18 proxy or get blocked. Use a browser or a page reader. `docs/llms.txt` is readable.
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./minimax-agent.md)
+- [Cookbook](./minimax-agent-cookbook.md)
+- [Glossary](./minimax-agent-glossary.md)

--- a/docs/products/minimax-agent/minimax-agent-cookbook.md
+++ b/docs/products/minimax-agent/minimax-agent-cookbook.md
@@ -1,0 +1,106 @@
+---
+title: MiniMax Agent cookbook
+description: "Read this after you can sign in. Each recipe solves one job and only uses steps that exist on an official page."
+domain: product
+tags:
+  - coding-agent
+role: cookbook
+---
+
+# MiniMax Agent cookbook
+
+For readers who already have [agent.minimax.io](https://agent.minimax.io/) open. Each recipe: goal, steps, pitfall.
+
+Setup and mode choice live in the [tutorial](./minimax-agent.md). This page does not repeat them.
+
+## 1. A sourced research report
+
+**Goal:** Markdown / PDF a coworker can reuse, not a chat log.
+
+**When:** Pro. Turn on Agent Team if sources must be checked in parallel.
+
+**Steps:**
+
+1. Switch to Pro.
+2. Put scope, banned sources, and output format in the first sentence.
+3. Require an official URL after every claim.
+4. If you also need HTML / slides, ask for both in that same message.
+
+```
+Using 2026 official pages only, document what MiniMax Agent can and cannot do.
+Allowed hosts: minimaxi.com, minimax.io, agent.minimaxi.com, agent.minimax.io.
+Banned: review blogs, social screenshots, scrapers.
+Deliver a Markdown report. Every claim needs a source URL.
+```
+
+**Pitfall:** A single agent often stops halfway to "report progress." The [Agent Team](https://agent.minimaxi.com/docs/techblog/agent-team.md) article calls this context anxiety. Write "do not stop before the acceptance checks pass," or turn Team on.
+
+## 2. Slides, a report, or a site — not just prose
+
+**Goal:** A downloadable deck, document, or openable page.
+
+**Sources:** The [M2 post](https://www.minimaxi.com/en/news/minimax-m2) lists PPT, reports, and web development under Pro. The [launch post](https://www.minimaxi.com/news/minimax-agent) showed audio tutorials and front-end animation pages.
+
+**Steps:**
+
+1. Pro.
+2. Name page count, audience, and format (HTML / PDF / PPTX / DOCX).
+3. Ask for an outline first. The Team article splits office docs into Planner → Writer → Formatter → Evaluator.
+4. For a fixed layout, check the [skill marketplace](https://agent.minimaxi.com/skills) for a deck / DOCX / PowerPoint skill.
+
+```
+Write an 8-slide product intro for frontend engineers.
+They already use Cursor and have never opened MiniMax Agent.
+Give an outline first. After I confirm, generate HTML slides and a PDF export.
+Do not include MiniMax Code install steps.
+```
+
+**Pitfall:** Do not run this in Lightning. Official copy puts it on Pro.
+
+## 3. Decide whether Agent Team is worth it
+
+**Goal:** Skip a wasted "the single agent finished writing but nothing is shippable" loop.
+
+| Signal | Action |
+|--------|--------|
+| You want one answer | No Team. Lightning is enough |
+| Multi-source research + verify + synthesize | Team on |
+| IM task, humans will not wait for the final file | Team on. Officially the lead replies immediately |
+| Typo / one sentence | Off. Officially cheaper as a single agent |
+
+**Steps:** Turn on **Agent Team** on the home page, then send one goal. Do not pack three unrelated epics into one message.
+
+**Pitfall:** Team has handoff cost. The official article names handoff, sharing, and aggregation as new costs. A vague goal makes Worker and Verifier spin.
+
+## 4. Install a skill before repeating the same job
+
+**Goal:** The second similar deliverable should not start from a blank prompt.
+
+**Steps:**
+
+1. Open [skills](https://agent.minimaxi.com/skills).
+2. Search by job type (deck, research report, Excel, landing page).
+3. Install, then refer to that skill in the next task.
+4. If the market has nothing, but you have already run the flow twice, create a skill or import from GitHub. Both are in the official marketplace copy.
+
+**Pitfalls:**
+
+- The catalog and use counts move. Do not treat a screenshot in this repo as the index.
+- The Code plugin marketplace (finance data, company lookup, Office, Notion, …) is documented in desktop release notes, not in this recipe.
+
+## 5. Switch products instead of forcing the web Agent
+
+| You actually want | Go here | Do not |
+|-------------------|---------|--------|
+| Local repo, terminal, diffs, git | [MiniMax Code](https://agent.minimaxi.com/docs/code/welcome) | Pretend the web Agent has a workspace panel |
+| One video | [Hailuo](https://hailuoai.com/) | Detour through Agent "because it can generate video" |
+| Voice / music | [Audio](https://www.minimaxi.com/audio) | Treat Audio as an Agent mode |
+| Roleplay | [Xingye](https://www.xingyeai.com/) / [Talkie](https://www.talkie-ai.com/) | Write a companion app up as a workbench |
+| Storyboard-to-film canvas | [Design](https://design.minimaxi.com/) | Treat the old Hub name as Agent |
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./minimax-agent.md)
+- [Cheatsheet](./minimax-agent-cheatsheet.md)
+- [Glossary](./minimax-agent-glossary.md)

--- a/docs/products/minimax-agent/minimax-agent-glossary.md
+++ b/docs/products/minimax-agent/minimax-agent-glossary.md
@@ -1,0 +1,105 @@
+---
+title: MiniMax Agent glossary
+description: "No how-to. Separate Agent / Code / Hub / Design / Mini-Agent, then Lightning, Pro, and Agent Team."
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# MiniMax Agent glossary
+
+No procedures. This page explains why the names collide. Which surface to open: [learning map](./index.md).
+
+## Concept map
+
+```
+Vendor MiniMax
+├── General workbench MiniMax Agent (web)
+│   ├── Modes: Lightning / Pro
+│   ├── Collaboration: Agent Team (Leader / Worker / Verifier)
+│   ├── Extension: Skill
+│   └── On-site entries: MaxHermes / MaxClaw
+├── Desktop coding MiniMax Code        ← not this directory
+├── Creation MiniMax Design (EN About still says Hub)
+├── Video Hailuo / speech Audio / characters Xingye·Talkie
+└── Open Platform API + Token Plan
+```
+
+## Everything named MiniMax or Agent
+
+| Name | What it is | Where |
+|------|------------|-------|
+| **MiniMax Agent** | General long-horizon workbench | agent.minimaxi.com / agent.minimax.io |
+| MiniMax Code | Desktop AI agent app | [welcome](https://agent.minimaxi.com/docs/code/welcome) |
+| MiniMax Hub | First-level name in EN About | `hub.minimaxi.com` currently loads Design |
+| MiniMax Design | Multimodal creation studio / canvas | design.minimaxi.com |
+| Hailuo | Video product | hailuoai.com |
+| MiniMax Audio | Speech and music | minimaxi.com/audio |
+| Xingye | Immersive agent community | xingyeai.com |
+| Talkie | Xingye overseas | talkie-ai.com |
+| Mini-Agent | Open-platform sample | GitHub MiniMax-AI/Mini-Agent |
+| MaxHermes | On-site "cloud assistant" entry | changelog 2026-04-16 |
+| MaxClaw | On-site settings / channels / persona entry | changelog 2026-04-11 |
+| Token Plan | Subscription and quota | Company Product nav |
+| MiniMax M2 / M3 | Driving models, not product surfaces | News and home; internals in [Learn LLM](https://llm.zenheart.site/chapters/) |
+
+**Not official product names. Do not write them as facts:**
+
+- "MiniMax Agent is just the web skin of Code" — desktop was renamed to Code on its own.
+- "Hub equals Agent" — Hub aligns with Design, not Agent.
+- Treating the Mini-Agent sample repo as the product download.
+
+## What MiniMax Agent is / why it exists
+
+**What it is:** A browser agent that takes a goal, splits work, and hands back files or pages. Official contrast: a reliable coworker, not an autocomplete box.
+
+**Why it exists:** A chat assistant stops at Q&A. An agent has to plan, call tools, test, and return something you can open. The [launch post](https://www.minimaxi.com/news/minimax-agent) frames this as "Code is cheap, show me the requirement."
+
+**What it is not:** Not a local IDE, not a Hailuo reskin, not Xingye.
+
+## Lightning and Pro
+
+**What they are:** Two modes of one product, not two products.
+
+**Why they exist:** The [M2 post](https://www.minimaxi.com/en/news/minimax-m2) described contemporary agent products as expensive or slow. Lightning keeps short tasks fast. Pro keeps long tasks capable.
+
+**Difference:**
+
+| | Lightning | Pro |
+|--|-----------|-----|
+| Official jobs | Q&A, light search, light code | Research, full-stack, PPT, reports, sites |
+| Cost | Weak on long deliverables | Heavy for a one-line question |
+
+## Agent Team
+
+**What it is:** A multi-agent system led by one agent. Official roles: Leader, Worker, Verifier. The user still sends one message.
+
+**Why it exists:** A single agent is both player and referee. Long jobs stop early, drift, or go silent on IM. Team turns split, parallel, and review into system behavior.
+
+**What it is not:** Not "open three chat tabs." Not every sub-agent toggle in the Code docs.
+
+The official article also names Team Engine states: `producing` / `verifying` / `done`. That is design language, not a command you type.
+
+## Skill
+
+**What it is:** An installable, reusable domain flow. Market: [skills](https://agent.minimaxi.com/skills).
+
+**Why it exists:** Role-play is not role split. The Team article lists tools, context, memory, and Skill as four dimensions of division of labor. Without a skill you re-teach the flow every time.
+
+**Versus plugins:** The skill marketplace is a page the Agent web app opens. The plugin marketplace launch is in MiniMax Code release notes. Do not merge the two tables.
+
+## Hub and Design
+
+**What they are:** Creation products: canvas, storyboard, finished film, local assets.
+
+**Why this entry exists:** EN About still lists **MiniMax Hub** as a first-level product. CN About lists **MiniMax Design**. Opening `hub.minimaxi.com` loads Design. When two official pages disagree, this site quotes both and treats the live landing page as Design.
+
+**What they are not:** Not another name for MiniMax Agent.
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./minimax-agent.md)
+- [Cookbook](./minimax-agent-cookbook.md)
+- [Cheatsheet](./minimax-agent-cheatsheet.md)

--- a/docs/products/minimax-agent/minimax-agent.md
+++ b/docs/products/minimax-agent/minimax-agent.md
@@ -1,0 +1,152 @@
+---
+title: MiniMax Agent tutorial
+description: "Open agent.minimax.io, pick Lightning or Pro, and send the first long-horizon task. This is not the MiniMax Code desktop tutorial."
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# MiniMax Agent tutorial
+
+> Goal: finish one deliverable in the web workbench in about 15 minutes.
+>
+> Non-goals: install MiniMax Code, configure a workspace / terminal / permission mode, or explain model internals. Desktop: [Code welcome](https://agent.minimaxi.com/docs/code/welcome). Internals: [Learn LLM](https://llm.zenheart.site/chapters/).
+
+## Prerequisites
+
+- You can open [agent.minimax.io](https://agent.minimax.io/) or [agent.minimaxi.com](https://agent.minimaxi.com/).
+- A MiniMax account. The button on the product page is **Sign in** / **登录**.
+- No local repo. No CLI.
+
+## Learning objectives
+
+1. Tell Agent (web) apart from Code (desktop).
+2. Pick Lightning or Pro from task length.
+3. Send a task that names a deliverable, and know when to add Agent Team or a skill.
+
+## What it is
+
+MiniMax Agent is a general-purpose agent in the browser. The [launch post](https://www.minimaxi.com/news/minimax-agent) designs it as a "reliable person" and lists three bars:
+
+| Bar | Official wording |
+|-----|------------------|
+| Programming | More components and complex jumps; simulate user actions for tests; care about UI |
+| Multimodal | Understand long text, video, audio, images; built-in image / audio / video generation |
+| MCP | Built-in MiniMax MCP; also lists GitHub / GitLab / Slack / Figma |
+
+The home page currently says "MiniMax makes your work easier" and exposes an **Agent Team** control plus a model picker (MiniMax-M3 was visible on 2026-08-19).
+
+It is **not**:
+
+- MiniMax Code (desktop; [welcome](https://agent.minimaxi.com/docs/code/welcome): conversation, project workspace, files, terminal, browser, skills, memory, and automation in one local environment)
+- MiniMax Design / Hub (creation canvas)
+- Hailuo, Xingye / Talkie, or Audio (see the [map](./index.md))
+
+## Step 1: Open the workbench
+
+1. Open [agent.minimax.io](https://agent.minimax.io/) (international) or [agent.minimaxi.com](https://agent.minimaxi.com/) (China).
+2. Click **Sign in**.
+3. Describe the goal in the home input. On 2026-08-19 the international home showed shortcuts such as **Video generation**, **Document**, **Website**, **Image Generation**.
+4. If you need the desktop app, the home page has **Download desktop**. The [download page](https://agent.minimaxi.com/download) is currently titled **MiniMax Code**. That is the desktop brand, not the next step of this tutorial.
+
+## Step 2: Pick Lightning or Pro
+
+From the [M2 post](https://www.minimaxi.com/news/minimax-m2) (EN: [M2 & Agent](https://www.minimaxi.com/en/news/minimax-m2)):
+
+| Mode | Official positioning | Official examples |
+|------|----------------------|-------------------|
+| **Lightning** | High-efficiency, high-speed agent | Conversational Q&A, lightweight search, simple coding |
+| **Pro** | Professional agent quality on complex, long-running tasks | In-depth research, full-stack development, PPTs / reports, web development |
+
+How to choose:
+
+- One question, one lookup, a small code tweak → Lightning.
+- A sourced report, a slide deck, a working page, a full-stack handoff → Pro.
+- Unsure → Lightning first. Switch to Pro if the deliverable is thin. Do not default every task to Pro.
+
+These names come from the official product post. The exact toggle label is whatever you see after sign-in. This page does not invent a click path.
+
+## Step 3: Send the first task
+
+The official line is to show the requirement. Put the **deliverable** in the first message.
+
+```
+Research the official difference between MiniMax Agent and MiniMax Code.
+Use only pages on minimaxi.com, minimax.io, agent.minimaxi.com, and agent.minimax.io.
+Deliver:
+1. A Markdown comparison table (product, entry, fit, not-fit)
+2. An 8-slide HTML outline for frontend engineers
+Do not describe model internals.
+```
+
+Watch three things:
+
+1. Does the agent confirm the goal before dumping text?
+2. Are citations stable official URLs? The [Agent Team](https://agent.minimaxi.com/docs/techblog/agent-team.md) note says formal sources should use stable URLs; search caches are clues only.
+3. Can you open or download the file? A chat transcript is not the deliverable.
+
+Use **Pro** for this first task. It is long-horizon research with two outputs.
+
+## Step 4: Turn on Agent Team only for work that must split
+
+The [Agent Team article](https://agent.minimaxi.com/docs/techblog/agent-team.md): the user still sends one message; the system decides whether to split, which roles can run in parallel, and which results must be verified.
+
+Official roles:
+
+- **Leader** — turn the goal into a task structure.
+- **Worker** — run a sub-task; tools / context / output contract can differ.
+- **Verifier** — turn "done" into "shippable". Officially adversarial to the Worker.
+
+Turn Team on when:
+
+- You need parallel research, cross-checks, then a synthesis.
+- A document must go from "generated" to "shippable" (official office pipeline: Planner / Writer / Formatter / Evaluator).
+- You are on IM and cannot stare at a spinner. Officially the lead agent replies first and runs the rest in the background.
+
+Leave Team off when:
+
+- You are fixing a typo, checking one fact, or making one image. The official article says a single agent is cheaper there.
+- You have not written an acceptance bar. Team amplifies a vague goal.
+
+The home page has an **Agent Team** control. A `/team` mention appears in the desktop changelog. On the web, use the control you can see. Do not copy Code slash commands into this tutorial as required steps.
+
+## Step 5: Extend with the skill marketplace
+
+Open [agent.minimaxi.com/skills](https://agent.minimaxi.com/skills) (also on the `.io` host). Official copy: explore, install, and use capabilities built by developers and the community. Custom creation and GitHub import are listed.
+
+On 2026-08-19 the marketplace showed first-party skills for decks, industry research, DOCX, long-form posts, image prompts, equity analysis, Excel, and PowerPoint. **The catalog changes.** Trust the live page.
+
+How to use it:
+
+1. Search for an existing skill before starting a long task.
+2. After you have run the same flow twice, consider saving it as a skill. The Team article treats memory and Skill as the long-term value of a run.
+3. Do not merge this page with the Code plugin marketplace. Plugin launch notes live in the Code changelog.
+
+## Billing: quote both official lines
+
+| Source | Wording | How to read it |
+|--------|---------|----------------|
+| [M2 post](https://www.minimaxi.com/en/news/minimax-m2) | MiniMax Agent is offered free "until our servers can't keep up" | A time-boxed launch policy, not an SLA |
+| [Skill marketplace](https://agent.minimaxi.com/skills) | Unified billing through Token Plan | Quota is whatever the signed-in plan page shows |
+| [Download page](https://agent.minimaxi.com/download) | Plus ¥49 / Max ¥119 / Ultra ¥469 | The page brand is MiniMax Code. Do not treat those prices as Agent-web-only |
+
+Use **See Plan and pricing** after sign-in. This page does not invent token-pack sizes.
+
+## Common pitfalls
+
+| Pitfall | Do this instead |
+|---------|-----------------|
+| Turning this tutorial into a Code CLI guide | Stop at the browser. Workspace / terminal / Coding mode belong in #72 |
+| Pro or Team on every prompt | Lightning for short Q&A |
+| Citing a reseller blog | Official stable URLs only |
+| Writing "always free" | Link the live plan page |
+| Treating Hub as another name for Agent | Hub currently lands on Design |
+| Explaining MSA / attention | [Learn LLM](https://llm.zenheart.site/chapters/) |
+
+## Next steps
+
+- Recipes: [Cookbook](./minimax-agent-cookbook.md)
+- Entries and sources: [Cheatsheet](./minimax-agent-cheatsheet.md)
+- Names: [Glossary](./minimax-agent-glossary.md)
+- Local repo: [Code welcome](https://agent.minimaxi.com/docs/code/welcome)

--- a/docs/zh/products/minimax-agent/index.md
+++ b/docs/zh/products/minimax-agent/index.md
@@ -1,0 +1,141 @@
+---
+title: MiniMax Agent 学习地图
+description: "MiniMax Agent 是通用 Agent 工作台，不是 MiniMax Code。本目录只写网页工作台；Code / Hailuo / 星野只在家族图占一行。"
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# MiniMax Agent 学习地图
+
+> **MiniMax Agent** 是 MiniMax 的通用智能体工作台。官方定义（[靠谱](https://www.minimaxi.com/news/minimax-agent)）：
+> 「一个能完成长程（Long Horizon）复杂任务的通用智能体，也就是能多步规划出专家级解决方案、能灵活拆解任务需求、并能执行多个子任务从而交付最终结果。」
+>
+> 国内入口：[agent.minimaxi.com](https://agent.minimaxi.com/)。海外入口：[agent.minimax.io](https://agent.minimax.io/)。
+>
+> **本目录不写 MiniMax Code 主教程。** 桌面端编程 Agent 见官方 [Code 欢迎页](https://agent.minimaxi.com/docs/code/welcome)，本站另 issue #72。
+
+## 产品全景
+
+MiniMax 官网、Agent 站和文档站用了好几套名字。它们**不是**同一个产品的四张皮。本目录的**主学习路径**是 **MiniMax Agent**（网页通用工作台）。
+
+```
+MiniMax 家族
+├── MiniMax Agent — 通用 Agent 工作台（本目录）
+│   ├── 网页：agent.minimaxi.com / agent.minimax.io
+│   ├── Lightning / Pro 两种模式
+│   ├── 技能市场 /skills
+│   └── 站内入口：MaxHermes、MaxClaw
+├── MiniMax Code — 桌面端 Coding Agent（#72，不在本目录展开）
+├── MiniMax Design / Hub — 多模态创作画布
+├── Hailuo / 海螺视频 — 视频生成
+├── MiniMax Audio — 语音与音乐
+├── 星野 / Talkie — 沉浸式角色社区
+└── 开放平台 / Token Plan — API 与计费
+```
+
+| 官方一级入口 | 是什么 | 官方 URL | 本站去向 |
+|--------------|--------|----------|----------|
+| **MiniMax Agent** | 通用长程智能体工作台 | [agent.minimaxi.com](https://agent.minimaxi.com/) | 独立页：本目录 |
+| MiniMax Code | 桌面端 AI Agent，面向本地项目 / 终端 / 浏览器 | [Code 欢迎页](https://agent.minimaxi.com/docs/code/welcome) | 地图一行。主教程另 #72 |
+| MiniMax Design / Hub | 多模态创作平台。英文 About 仍写 Hub；`hub.minimaxi.com` 当前加载 Design | [design.minimaxi.com](https://design.minimaxi.com/)、[hub.minimaxi.com](https://hub.minimaxi.com/) | 地图一行 |
+| Hailuo / 海螺视频 | 文/图生视频 | [hailuoai.com](https://hailuoai.com/) | 地图一行 |
+| MiniMax Audio | 语音合成与音乐 | [minimaxi.com/audio](https://www.minimaxi.com/audio) | 地图一行 |
+| 星野 | 沉浸式 AI 内容社区 | [xingyeai.com](https://www.xingyeai.com/) | 地图一行 |
+| Talkie | 星野海外对应 | [talkie-ai.com](https://www.talkie-ai.com/) | 地图一行 |
+| 开放平台 / API | 模型 HTTP API | [platform.minimaxi.com](https://platform.minimaxi.com/) | 地图一行 |
+| Token Plan | 订阅与额度 | 厂商站 Product nav「Token Plan」 | 地图一行 |
+| About / News / IR | 公司栏目 | [minimaxi.com](https://www.minimaxi.com/) | 非本站 |
+
+来源：[www.minimaxi.com](https://www.minimaxi.com/) 关于我们、[www.minimaxi.com/en](https://www.minimaxi.com/en) Product / About、[agent.minimaxi.com](https://agent.minimaxi.com/)、[docs/llms.txt](https://agent.minimaxi.com/docs/llms.txt)。2026-08-19 打开。
+
+**容易撞名的几条：**
+
+- **MiniMax Agent ≠ MiniMax Code。** Agent 是通用工作台。Code 是桌面端应用。changelog [v3.0.33](https://agent.minimaxi.com/docs/changelog) 原文：「桌面端正式更名为 MiniMax Code」。
+- **MiniMax Hub ≠ MiniMax Agent。** 英文 About 把 Hub 和 Code / Audio / Talkie 并列。当前 `hub.minimaxi.com` 打开后写的是 MiniMax Design。
+- **Mini-Agent ≠ MiniMax Agent。** `MiniMax-AI/Mini-Agent` 是开放平台上的示例项目，不是这款产品。
+- **MaxHermes / MaxClaw** 出现在 Agent 首页，不是厂商一级产品。见 [术语表](./minimax-agent-glossary.md)。
+
+模型内部（MSA、注意力、训练）见 [Learn LLM](https://llm.zenheart.site/chapters/)。本目录不写机制。
+
+### 快速决策：我该用哪个？
+
+```
+我要做什么？
+├── 在网页里把一个长任务做完（研究、PPT、报告、网页、多模态交付）
+│   └── → MiniMax Agent（本目录）
+│       ├── 问答 / 轻搜索 / 轻代码 → Lightning
+│       └── 长程研究 / 全栈 / PPT / 报告 / 网页 → Pro；复杂拆解开 Agent Team
+├── 对着本机仓库写代码、看 diff、跑终端
+│   └── → MiniMax Code（官方桌面端文档；本站 #72）
+├── 只做视频
+│   └── → Hailuo / 海螺视频
+├── 只做语音 / 音乐
+│   └── → MiniMax Audio
+├── 角色扮演 / 沉浸社区
+│   └── → 星野（国内）/ Talkie（海外）
+├── 短剧 / 分镜 / 成片画布
+│   └── → MiniMax Design（域名仍可能显示 Hub）
+└── 在自己的程序里调模型
+    └── → 开放平台 API
+```
+
+## 什么时候值得试 MiniMax Agent
+
+**什么情况下值得试？**
+
+- 你要的是**网页里可交付的长程任务**：深度研究、PPT、报告、网页，而不是终端里改仓库。
+- 你已经在用 Claude.ai / Cowork 一类工作台，想对照国内入口。
+- 任务需要多模态输出（图 / 音 / 视频）或 MCP 扩展。官方 [靠谱](https://www.minimaxi.com/news/minimax-agent) 把编程、多模态、MCP 列为设计标准。
+
+**什么情况下先别急？**
+
+- 你要的是本机项目、终端、Git 工作区 —— 那是 **MiniMax Code**，不要在这套网页教程里找 CLI。
+- 你只要出一条视频 —— 走 Hailuo，不要绕 Agent。
+- 你要角色陪伴 —— 走 星野 / Talkie。
+- 你需要把命令、权限模式、flag 写成可复制手册 —— 官方没有给 Agent 网页单独的 Commands 页。本站只写能打开的官方原文。
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 打开能用 | [MiniMax Agent 教程](./minimax-agent.md) | 登录网页，发出第一个任务 |
+| 2. 选对模式 | 教程里的 Lightning / Pro，[Cookbook](./minimax-agent-cookbook.md) | 短问答不走 Pro，长程不走 Lightning |
+| 3. 用技能和 Team | Cookbook + 官方 [技能市场](https://agent.minimaxi.com/skills) | 知道何时装 Skill、何时开 Team |
+| 4. 回查入口 | [速查表](./minimax-agent-cheatsheet.md) | 域名、模式、数据源 |
+| 5. 理清名字 | [术语表](./minimax-agent-glossary.md) | Agent / Code / Hub / Design / Mini-Agent |
+
+## 功能速查表
+
+下表只列能在官方页找到原文的能力。
+
+| 能力 | 一句话 | 官方原文 |
+|------|--------|----------|
+| 长程任务 | 多步规划、拆解、交付最终结果 | [靠谱](https://www.minimaxi.com/news/minimax-agent) |
+| Lightning | 对话问答 / 轻量级搜索 / 轻量级代码，极速输出 | [M2 新闻](https://www.minimaxi.com/news/minimax-m2) |
+| Pro | 深度研究 / 全栈开发 / PPT / 报告 / 网页制作 | [M2 新闻](https://www.minimaxi.com/news/minimax-m2) |
+| Agent Team | 主 Agent 拆任务；Leader / Worker / Verifier | [Agent Team](https://agent.minimaxi.com/docs/techblog/agent-team.md) |
+| 技能市场 | 浏览、安装、自定义或从 GitHub 导入技能 | [skills](https://agent.minimaxi.com/skills) |
+| 编程 | 复杂跳转、模拟用户操作做测试、重视界面 | [靠谱](https://www.minimaxi.com/news/minimax-agent) |
+| 多模态 | 理解长文本 / 视频 / 音频 / 图片；内置生图、音频、视频 | [靠谱](https://www.minimaxi.com/news/minimax-agent) |
+| MCP | 内置 MiniMax MCP；官方还写了 GitHub / GitLab / Slack / Figma 等集成 | [靠谱](https://www.minimaxi.com/news/minimax-agent) |
+| 写作 / 语音 / 图像 / 文档 / 翻译 | 功能页列出的消费向能力 | [features](https://agent.minimax.io/features/zh.html) |
+
+驱动模型会随产品改版。2026-08-19 首页可见「尝试全新 M3」。模型原理见 [Learn LLM](https://llm.zenheart.site/chapters/)。
+
+## 资源链接
+
+- 产品：<https://agent.minimaxi.com/>
+- 海外：<https://agent.minimax.io/>
+- 厂商：<https://www.minimaxi.com/>
+- 文档索引：<https://agent.minimaxi.com/docs/llms.txt>
+- 完整信息源见 [速查表](./minimax-agent-cheatsheet.md#高质量信息源)
+
+## 相关页面
+
+- [MiniMax Agent 教程](./minimax-agent.md)
+- [实战 Cookbook](./minimax-agent-cookbook.md)
+- [速查表](./minimax-agent-cheatsheet.md)
+- [术语表](./minimax-agent-glossary.md)
+- [AI 编程工具总览](../index.md)

--- a/docs/zh/products/minimax-agent/minimax-agent-cheatsheet.md
+++ b/docs/zh/products/minimax-agent/minimax-agent-cheatsheet.md
@@ -1,0 +1,122 @@
+---
+title: MiniMax Agent 速查表
+description: "只查不学。入口、模式、撞名和数据源。没有官方 Commands 页，就不编命令表。"
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# MiniMax Agent 速查表
+
+只查不学。覆盖 2026-08-19 打开的官方页。命令、flag、积分日签若只出现在 Code changelog，不抄进本表。
+
+## 入口
+
+| 用途 | URL |
+|------|-----|
+| 国内工作台 | https://agent.minimaxi.com/ |
+| 海外工作台 | https://agent.minimax.io/ |
+| 技能市场 | https://agent.minimaxi.com/skills |
+| 文档索引 | https://agent.minimaxi.com/docs/llms.txt |
+| Changelog | https://agent.minimaxi.com/docs/changelog |
+| 下载桌面端（当前品牌 Code） | https://agent.minimaxi.com/download |
+| 厂商站 | https://www.minimaxi.com/ |
+| 海外厂商站 | https://www.minimax.io/ |
+
+## 模式
+
+来源：[M2 新闻](https://www.minimaxi.com/news/minimax-m2)
+
+| 模式 | 官方原文 | 选它当 |
+|------|----------|--------|
+| Lightning 高效模式 | 对话问答 / 轻量级搜索 / 轻量级代码，极速输出 | 短任务 |
+| Pro 专业模式 | 复杂长程任务；深度研究 / 全栈开发 / PPT / 报告 / 网页 | 要交付物的长任务 |
+
+## 决策：Agent 还是别的门
+
+| 场景 | 选 |
+|------|----|
+| 网页里做完研究 / PPT / 报告 / 站点 | Agent |
+| 本机仓库 + 终端 | Code |
+| 只出视频 | Hailuo |
+| 只出语音 / 音乐 | Audio |
+| 角色社区 | 星野 / Talkie |
+| 创作画布 | Design（Hub 为英文 About / 旧域名） |
+| 自己的程序调模型 | 开放平台 |
+
+术语索引（一句话，详见 [术语表](./minimax-agent-glossary.md)）：
+
+| 术语 | 钩子 |
+|------|------|
+| MiniMax Agent | 通用网页工作台 |
+| MiniMax Code | 桌面端，不是本页主教程 |
+| Hub / Design | 创作产品；两份官方名打架，以落地页为准 |
+| Mini-Agent | GitHub 示例，不是产品 |
+| Lightning / Pro | 两种官方模式 |
+| Agent Team | Leader / Worker / Verifier |
+| MaxHermes / MaxClaw | Agent 站内入口，不是一级产品 |
+| Token Plan | 计费，不是产品 |
+
+## 计费（并列原文，不合并）
+
+| 声明 | 出处 |
+|------|------|
+| 限时免费，直到服务器撑不住 | [M2 新闻](https://www.minimaxi.com/news/minimax-m2) |
+| 统一计费，打通 Token Plan | [技能市场](https://agent.minimaxi.com/skills) |
+| Plus ¥49 / Max ¥119 / Ultra ¥469 | [下载页](https://agent.minimaxi.com/download)（页面标题是 MiniMax Code） |
+
+以登录后的套餐页为准。
+
+## 常见错误
+
+| 症状 | 原因 | 处理 |
+|------|------|------|
+| 在本教程里找 `minimax` CLI / 工作区 | 那是 Code | 打开 [Code 欢迎页](https://agent.minimaxi.com/docs/code/welcome) |
+| 短问答又慢又贵 | 开了 Pro / Team | 改 Lightning |
+| 长报告做到一半停 | 单 Agent 提前汇报 | 写验收条件，或开 Team |
+| 把 Hub 教程和 Agent 写在一起 | 英文 About 仍写 Hub | Hub 当前是 Design |
+| 引用转载站数字 | 无官方原文 | 删掉或标待核实 |
+
+## 高质量信息源
+
+最后核实：2026-08-19。只收录亲自打开的页面。
+
+### 一手官方
+
+| 来源 | 用途 |
+|------|------|
+| [agent.minimaxi.com](https://agent.minimaxi.com/) | 国内产品入口 |
+| [agent.minimax.io](https://agent.minimax.io/) | 海外产品入口 |
+| [skills](https://agent.minimaxi.com/skills) | 技能市场 |
+| [features/zh.html](https://agent.minimax.io/features/zh.html) | 消费向功能说明 |
+| [faq/en.html](https://agent.minimax.io/faq/en.html) | 海外 FAQ（偏生活向，不是工程参考） |
+| [changelog](https://agent.minimaxi.com/docs/changelog) | 更新记录；后期主体是 Code |
+| [llms.txt](https://agent.minimaxi.com/docs/llms.txt) | 文档树索引 |
+| [Agent Team](https://agent.minimaxi.com/docs/techblog/agent-team.md) | Team 设计与何时使用 |
+| [靠谱](https://www.minimaxi.com/news/minimax-agent) | 产品定位（2025-06-19） |
+| [M2 & Agent](https://www.minimaxi.com/news/minimax-m2) | Lightning / Pro、限时免费原文 |
+| [Code 欢迎页](https://agent.minimaxi.com/docs/code/welcome) | 用来划清边界，不是本目录教程 |
+| [design.minimaxi.com](https://design.minimaxi.com/) | Design 当前落地页 |
+| [hub.minimaxi.com](https://hub.minimaxi.com/) | 打开后加载 Design |
+| [hailuoai.com](https://hailuoai.com/) | Hailuo |
+| [minimaxi.com/audio](https://www.minimaxi.com/audio) | Audio |
+| [xingyeai.com](https://www.xingyeai.com/) | 星野 |
+| [talkie-ai.com](https://www.talkie-ai.com/) | Talkie |
+| [platform.minimaxi.com](https://platform.minimaxi.com/) | 开放平台 |
+
+### 待核实
+
+| 名称 | URL | 为什么怀疑 |
+|------|-----|------------|
+| Agent 网页是否仍免费 | 套餐页（需登录） | M2 新闻的限时免费和 Token Plan 打通同时存在 |
+| 插件市场是否已进网页 Agent | changelog / 首页弹层 | 公告写的是 MiniMax Code |
+
+**访问提示**（2026-08-19）：部分抓取器访问 `minimaxi.com` / `agent.minimaxi.com` 会落到 198.18 代理或被拦截。用浏览器或页面阅读器。`docs/llms.txt` 可读。
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./minimax-agent.md)
+- [Cookbook](./minimax-agent-cookbook.md)
+- [术语表](./minimax-agent-glossary.md)

--- a/docs/zh/products/minimax-agent/minimax-agent-cookbook.md
+++ b/docs/zh/products/minimax-agent/minimax-agent-cookbook.md
@@ -1,0 +1,106 @@
+---
+title: MiniMax Agent 实战手册
+description: "已经能登录网页后再看。每个配方只解决一个问题，步骤必须能在官方页找到依据。"
+domain: product
+tags:
+  - coding-agent
+role: cookbook
+---
+
+# MiniMax Agent 实战手册
+
+面向已经打开 [agent.minimaxi.com](https://agent.minimaxi.com/) 的读者。每个配方先写目标，再写步骤，最后写坑。
+
+基础安装与模式说明在 [教程](./minimax-agent.md)。本页不重复。
+
+## 1. 写一份带出处的调研报告
+
+**目标：** 得到一份能转给同事的 Markdown / PDF，而不是聊天记录。
+
+**何时用：** Pro。资料要并行核验时再开 Agent Team。
+
+**步骤：**
+
+1. 切到 Pro。
+2. 第一句写清范围、禁用源、交付格式。
+3. 要求列出每条结论对应的官方 URL。
+4. 如果任务同时要 HTML / PPT 第二份交付，在同一条消息里写完，避免中途改需求污染上下文。
+
+```
+基于 2026 年官方页面，整理 MiniMax Agent 能做什么、不能做什么。
+允许来源：minimaxi.com、agent.minimaxi.com、agent.minimax.io。
+禁止：转载站、评测博客、社交截图。
+交付 Markdown 报告，每条论断后面跟原文链接。
+```
+
+**坑：** 单 Agent 会在完成一半时停下来汇报。官方 [Agent Team](https://agent.minimaxi.com/docs/techblog/agent-team.md) 把这写成上下文焦虑。要完整交付就写「未完成验收条件不许结束」，或开 Team。
+
+## 2. 做 PPT / 报告 / 网页，而不是只要正文
+
+**目标：** 拿到可下载的幻灯片、文档或可打开的页面。
+
+**依据：** [M2 新闻](https://www.minimaxi.com/news/minimax-m2) 把 PPT、报告撰写、网页制作列为 Pro 场景。[靠谱](https://www.minimaxi.com/news/minimax-agent) 展示过带音频的教程和前端动画页面。
+
+**步骤：**
+
+1. Pro。
+2. 指定页数、受众、格式（HTML / PDF / PPTX / DOCX）。
+3. 先要大纲，确认后再出成片。Agent Team 文把办公文档拆成 Planner → Writer → Formatter → Evaluator。
+4. 需要固定版式时，先到 [技能市场](https://agent.minimaxi.com/skills) 看有没有演示文稿 / DOCX / PowerPoint 技能。
+
+```
+给前端工程师写一份 8 页产品介绍。
+受众：已经会用 Cursor，第一次听说 MiniMax Agent。
+先给大纲，我确认后再生成 HTML 幻灯片，并提供 PDF 导出。
+不要写 MiniMax Code 的安装步骤。
+```
+
+**坑：** 不要在 Lightning 里做这件事。官方把这类任务放在 Pro。
+
+## 3. 判断要不要开 Agent Team
+
+**目标：** 少浪费一轮「单 Agent 写完但交不了货」。
+
+| 信号 | 动作 |
+|------|------|
+| 只要一段回答 | 不开 Team，Lightning 即可 |
+| 要多源研究 + 核验 + 合成 | 开 Team |
+| IM 里发任务、人等不及最终结果 | 开 Team。官方写主 Agent 先秒回，后台跑 |
+| 改错别字、换一句文案 | 不开。官方说这类更便宜走单 Agent |
+
+**步骤：** 首页打开 **Agent 团队**，再发任务。不要同时塞三个互不相关的大目标。
+
+**坑：** Team 有交接成本。官方技术文把交接、共享、聚合写成新成本。目标含糊会让 Worker 和 Verifier 空转。
+
+## 4. 先装技能，再开始重复劳动
+
+**目标：** 第二次做同类交付时不要从零描述流程。
+
+**步骤：**
+
+1. 打开 [skills](https://agent.minimaxi.com/skills)。
+2. 用任务类型搜（演示文稿、研究报告、Excel、网页）。
+3. 安装后再在对话里引用该技能。
+4. 市场没有、但你已经跑通两次的流程，再考虑自定义或从 GitHub 导入。官方市场文案支持这两条。
+
+**坑：**
+
+- 技能名单和「uses」计数每天都可能变，不要把本页截图当目录。
+- Code 插件市场（金融数据、企查查、Office、Notion 等）写在桌面端更新说明里，不是本配方的安装步骤。
+
+## 5. 网页 Agent 做不了时，换门，不要硬凑
+
+| 你真正要的 | 去哪 | 不要做什么 |
+|------------|------|------------|
+| 本机仓库、终端、diff、Git | [MiniMax Code](https://agent.minimaxi.com/docs/code/welcome) | 不要在网页 Agent 里假装有工作区面板 |
+| 一条视频 | [Hailuo](https://hailuoai.com/) | 不要为了「也能生视频」强行走 Agent |
+| 配音 / 音乐 | [Audio](https://www.minimaxi.com/audio) | 不要把 Audio 当 Agent 模式 |
+| 角色扮演 | [星野](https://www.xingyeai.com/) / [Talkie](https://www.talkie-ai.com/) | 不要把陪伴产品写成工作台 |
+| 分镜成片画布 | [Design](https://design.minimaxi.com/) | 不要把 Hub 旧名当成 Agent |
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./minimax-agent.md)
+- [速查表](./minimax-agent-cheatsheet.md)
+- [术语表](./minimax-agent-glossary.md)

--- a/docs/zh/products/minimax-agent/minimax-agent-glossary.md
+++ b/docs/zh/products/minimax-agent/minimax-agent-glossary.md
@@ -1,0 +1,105 @@
+---
+title: MiniMax Agent 术语表
+description: "不教操作。先分清 Agent / Code / Hub / Design / Mini-Agent，再理解 Lightning、Pro 和 Agent Team。"
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# MiniMax Agent 术语表
+
+不教操作，只解释「为什么这些名字会撞」。选哪个产品面看 [学习地图](./index.md)。
+
+## 概念关系
+
+```
+厂商 MiniMax
+├── 通用工作台 MiniMax Agent（网页）
+│   ├── 模式：Lightning / Pro
+│   ├── 协作：Agent Team（Leader / Worker / Verifier）
+│   ├── 扩展：Skill
+│   └── 站内入口：MaxHermes / MaxClaw
+├── 桌面编程 MiniMax Code        ← 不是本目录
+├── 创作 MiniMax Design（英文 About 仍写 Hub）
+├── 视频 Hailuo / 语音 Audio / 角色 星野·Talkie
+└── 开放平台 API + Token Plan
+```
+
+## 都叫 MiniMax / Agent 的东西
+
+| 名字 | 是什么 | 在哪用 |
+|------|--------|--------|
+| **MiniMax Agent** | 通用长程智能体工作台 | agent.minimaxi.com / agent.minimax.io |
+| MiniMax Code | 桌面端 AI Agent 应用 | [welcome](https://agent.minimaxi.com/docs/code/welcome) |
+| MiniMax Hub | 英文 About 里的一级产品名 | 当前 `hub.minimaxi.com` 加载 Design |
+| MiniMax Design | 多模态创作平台 / 画布 | design.minimaxi.com |
+| Hailuo / 海螺视频 | 视频生成产品 | hailuoai.com |
+| MiniMax Audio | 语音与音乐 | minimaxi.com/audio |
+| 星野 | 沉浸式智能体社区 | xingyeai.com |
+| Talkie | 星野海外对应 | talkie-ai.com |
+| Mini-Agent | 开放平台示例项目 | GitHub MiniMax-AI/Mini-Agent |
+| MaxHermes | Agent 站内「云端助手」入口 | changelog 2026-04-16 |
+| MaxClaw | Agent 站内设置 / 渠道 / 人设入口 | changelog 2026-04-11 |
+| Token Plan | 订阅与额度 | 厂商站 Product nav |
+| MiniMax M2 / M3 | 驱动模型，不是产品面 | 新闻与首页；机制见 [Learn LLM](https://llm.zenheart.site/chapters/) |
+
+**不是官方产品名，正文不要当事实写：**
+
+- 「MiniMax Agent 就是 Code 的网页版」——官方把桌面端单独更名为 Code。
+- 「Hub 等于 Agent」——Hub 与 Design 对齐，不与 Agent 对齐。
+- 把 Mini-Agent 示例仓写成产品下载地址。
+
+## MiniMax Agent 是什么 / 为什么需要
+
+**是什么：** 网页上的通用智能体，接收目标，拆步骤，交付文件或页面。官方对照的是「靠谱的人」，不是补全框。
+
+**为什么需要：** 对话助手停在问答。Agent 要在长程任务里规划、调用工具、做测试、给出可打开的结果。[靠谱](https://www.minimaxi.com/news/minimax-agent) 把「Code is cheap，show me the requirement」写成生产关系变化。
+
+**不是什么：** 不是本机 IDE，不是 Hailuo 的套皮，不是星野。
+
+## Lightning 和 Pro
+
+**是什么：** 同一产品上的两种模式，不是两个产品。
+
+**为什么需要：** [M2 新闻](https://www.minimaxi.com/news/minimax-m2) 把「又贵又慢」写成当时 Agent 产品的普遍问题。Lightning 保短任务速度，Pro 保长程质量。
+
+**区别：**
+
+| | Lightning | Pro |
+|--|-----------|-----|
+| 官方场景 | 问答、轻搜索、轻代码 | 研究、全栈、PPT、报告、网页 |
+| 代价 | 长程交付容易不够 | 短任务可能过重 |
+
+## Agent Team
+
+**是什么：** 主 Agent 牵头的多 Agent 系统。官方角色是 Leader、Worker、Verifier。用户仍只发一条消息。
+
+**为什么需要：** 单 Agent 既当选手又当裁判；长任务会提前停、会越做越偏、在 IM 里无法秒回。Team 把拆分、并行、验收变成系统行为。
+
+**不是什么：** 不是「多开几个聊天窗口」。也不是 Code 文档里的每一个子 Agent 开关都自动等于网页 Team。
+
+官方还写了 Team Engine 状态：`producing` / `verifying` / `done`。这是设计描述，不是你要输入的命令。
+
+## Skill
+
+**是什么：** 可安装、可复用的领域流程。市场在 [skills](https://agent.minimaxi.com/skills)。
+
+**为什么需要：** 角色扮演不等于角色分工。官方 Team 文把工具、上下文、记忆、Skill 列为分工的四个维度。没有 Skill，每次都要从头教流程。
+
+**与插件的区别：** 技能市场是 Agent 网页可打开的页面。插件市场首发说明写在 MiniMax Code 更新里。两套扩展不要抄成一张表。
+
+## Hub 和 Design
+
+**是什么：** 创作向产品。画布、分镜、成片、本地素材。
+
+**为什么单独写：** 英文 About 仍把 **MiniMax Hub** 列为一级产品；中文 About 写 **MiniMax Design**；`hub.minimaxi.com` 打开后是 Design。两份官方页打架时，本站同时引用，落地页以 Design 为准。
+
+**不是什么：** 不是 MiniMax Agent 的别名。
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./minimax-agent.md)
+- [Cookbook](./minimax-agent-cookbook.md)
+- [速查表](./minimax-agent-cheatsheet.md)

--- a/docs/zh/products/minimax-agent/minimax-agent.md
+++ b/docs/zh/products/minimax-agent/minimax-agent.md
@@ -1,0 +1,154 @@
+---
+title: MiniMax Agent 教程
+description: "打开 agent.minimaxi.com，选 Lightning 或 Pro，发出第一个长程任务。这不是 MiniMax Code 桌面教程。"
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# MiniMax Agent 教程
+
+> 目标：15 分钟内在网页工作台跑完一次可交付任务。
+>
+> 非目标：安装 MiniMax Code、配置工作区 / 终端 / 权限模式、解释模型内部。桌面端见 [Code 欢迎页](https://agent.minimaxi.com/docs/code/welcome)。机制见 [Learn LLM](https://llm.zenheart.site/chapters/)。
+
+## 先决条件
+
+- 能打开 [agent.minimaxi.com](https://agent.minimaxi.com/)（国内）或 [agent.minimax.io](https://agent.minimax.io/)（海外）。
+- 一个 MiniMax 账号。登录按钮在产品页右上角，原文是「登录」/「Sign in」。
+- 不需要本机仓库，不需要 CLI。
+
+## 学习目标
+
+1. 分清 Agent 网页和 Code 桌面端。
+2. 按任务长度选 Lightning 或 Pro。
+3. 发出一个带交付物的任务，并知道何时改用 Agent Team 或技能市场。
+
+## 它是什么
+
+MiniMax Agent 是网页上的通用智能体。官方 [靠谱](https://www.minimaxi.com/news/minimax-agent) 用「靠谱的人」当设计标准，列了三块：
+
+| 标准 | 官方原文在说什么 |
+|------|------------------|
+| 编程 | 更多组件和复杂跳转；模拟用户操作做测试；重视界面与交互 |
+| 多模态 | 理解长文本、视频、音频、图片；内置生图、音频、视频 |
+| MCP | 内置 MiniMax MCP；并写了 GitHub / GitLab / Slack / Figma 等办公扩展 |
+
+首页当前文案是「MiniMax，让工作更简单」，并提供 **Agent 团队** 开关和模型选择（2026-08-19 可见 MiniMax-M3）。
+
+它**不是**：
+
+- MiniMax Code（桌面端；[welcome](https://agent.minimaxi.com/docs/code/welcome) 原文：「把对话、项目工作区、文件操作、终端、浏览器、技能、记忆和自动化任务放在同一个本地工作环境里」）
+- MiniMax Design / Hub（创作画布）
+- Hailuo、星野、Audio（见 [学习地图](./index.md)）
+
+## 第一步：打开工作台
+
+1. 打开 [agent.minimaxi.com](https://agent.minimaxi.com/)。
+2. 点 **登录**。
+3. 用首页输入框描述目标。2026-08-19 首页可见快捷入口：**视频生成**、**调研报告**、**文档**、**教育学习**。
+4. 需要装桌面端时，首页有「下载桌面端」。注意：[下载页](https://agent.minimaxi.com/download) 当前标题是 **MiniMax Code - 下载**。那是桌面端品牌，不是本教程的下一步。
+
+海外站点步骤相同，入口换成 [agent.minimax.io](https://agent.minimax.io/)，按钮原文是 **Sign in** / **Download desktop**。
+
+## 第二步：选 Lightning 或 Pro
+
+[M2 新闻](https://www.minimaxi.com/news/minimax-m2) 原文：
+
+| 模式 | 官方定位 | 官方举例 |
+|------|----------|----------|
+| **Lightning 高效模式** | 高效极速版 Agent | 对话问答 / 轻量级搜索 / 轻量级代码 |
+| **Pro 专业模式** | 专业 agent 能力，复杂长程任务上最佳表现 | 深度研究 / 全栈开发 / PPT / 报告撰写 / 网页制作 |
+
+怎么选：
+
+- 一问一答、查一条资料、改一小段代码 → Lightning。
+- 要一份带出处的报告、一套 PPT、一个可打开的网页、一次全栈交付 → Pro。
+- 不确定就先 Lightning；交付物不够再开 Pro。不要把「所有任务都开 Pro」当成默认。
+
+两种模式是官方产品声明。界面上的具体开关文案以你登录后看到的为准；本页不臆造按钮路径。
+
+## 第三步：发出第一个任务
+
+官方要求「show me the requirement」。把**交付物**写进第一句话。
+
+```
+帮我调研 MiniMax Agent 和 MiniMax Code 的官方区别。
+只使用 minimaxi.com 与 agent.minimaxi.com 上的页面。
+交付：
+1. 一份 Markdown 对照表（产品、入口、适合做什么、不适合做什么）
+2. 不超过 8 张幻灯片的 HTML 提纲，给前端工程师 internally share
+不要写模型内部结构。
+```
+
+发送后盯三件事：
+
+1. Agent 有没有先确认目标，而不是直接堆字。
+2. 引用是不是官方 URL。Verifier 思路见 [Agent Team](https://agent.minimaxi.com/docs/techblog/agent-team.md)：正式来源应尽量使用稳定 URL，搜索缓存只能当线索。
+3. 交付物能不能下载或打开。不要只收下一段聊天记录。
+
+第一个任务建议用 **Pro**。这是长程调研 + 双交付。
+
+## 第四步：复杂任务再开 Agent Team
+
+[Agent Team 技术文](https://agent.minimaxi.com/docs/techblog/agent-team.md) 原文：用户仍然只发出一条消息；系统判断是否拆分、哪些角色并行、哪些结果必须验证。
+
+三类角色（官方命名）：
+
+- **Leader**：把目标变成任务结构。
+- **Worker**：执行子任务，工具 / 上下文 / 输出要求可以不同。
+- **Verifier**：把「完成了」变成「可以交付」，和 Worker 是对抗关系。
+
+什么时候开 Team：
+
+- 要并行检索、交叉核验、再合成。
+- 文档要过「能生产 → 能交付」（官方办公文档场景：Planner / Writer / Formatter / Evaluator）。
+- 你在 IM 里等秒回，但任务本身要跑很久。官方写：主 Agent 先快速响应，后台拆分执行。
+
+什么时候不要开：
+
+- 改一处文案、查一个事实、生成一张图。官方自己说单 Agent 更便宜。
+- 你还没写清验收标准。Team 会放大一个含糊目标。
+
+首页有 **Agent 团队** 开关。技术文还提到显式 `/team` 出现在桌面端 changelog 语境里；网页以你看到的开关为准，不要把 Code 斜杠命令抄过来当网页必经步骤。
+
+## 第五步：用技能市场扩展，而不是每次重写流程
+
+打开 [agent.minimaxi.com/skills](https://agent.minimaxi.com/skills)。官方描述：「探索、安装和使用由开发者和社区构建的强大能力。」支持自定义创建或从 GitHub 导入。
+
+2026-08-19 市场里能直接看到的官方技能包括：演示文稿、行业研究报告、DOCX、热点长文、图像提示词、股票分析、Excel、PowerPoint 等。**技能名单会变**，以市场页为准。
+
+用法：
+
+1. 先搜有没有现成技能，再开始长任务。
+2. 重复做过两次的流程，再考虑沉淀为自己的技能。Agent Team 文把「经验沉淀为记忆、Skill」写成 Team 的长期价值。
+3. 不要把技能市场和 Code 的插件市场混成一页。插件市场上线公告写在 Code 更新说明里。
+
+## 计费：只抄两份官方原文
+
+| 来源 | 原文 | 怎么用 |
+|------|------|--------|
+| [M2 新闻](https://www.minimaxi.com/news/minimax-m2) | 「我们目前在免费提供 MiniMax Agent, 直到我们的服务器撑不住为止。」 | 这是发布当时的限时政策，不是长期 SLA |
+| [技能市场](https://agent.minimaxi.com/skills) | 「统一计费：全面打通 Token Plan」 | 额度以账号内套餐页为准 |
+| [下载页](https://agent.minimaxi.com/download) | Plus ¥49 / Max ¥119 / Ultra ¥469 | 页面品牌是 MiniMax Code，不要写成 Agent 网页专用价 |
+
+登录后点首页的「查看套餐与价格」。本页不臆造 token 包大小。
+
+## 常见陷阱
+
+| 陷阱 | 正确做法 |
+|------|----------|
+| 把 Agent 网页教程写成 Code CLI | 本页停在浏览器。工作区 / 终端 / Coding 模式去 #72 |
+| 所有任务都开 Pro 或 Team | 短问答用 Lightning；Team 留给要验收的长程 |
+| 把搜索摘要当出处 | 只要官方稳定 URL |
+| 把限时免费写成永远免费 | 链回套餐页 |
+| 把 Hub 当成 Agent 的别名 | Hub 当前落地页是 Design |
+| 写 MSA / 注意力细节 | 链 [Learn LLM](https://llm.zenheart.site/chapters/) |
+
+## 下一步
+
+- 场景配方：[Cookbook](./minimax-agent-cookbook.md)
+- 入口与数据源：[速查表](./minimax-agent-cheatsheet.md)
+- 名字：[术语表](./minimax-agent-glossary.md)
+- 本机仓库：[Code 欢迎页](https://agent.minimaxi.com/docs/code/welcome)


### PR DESCRIPTION
Closes #73

## 做了什么

从零建立 **MiniMax Agent / Hub** 手册（ZH + EN），主路径是通用 Agent **网页工作台**，不是 MiniMax Code。

```
docs/zh/products/minimax-agent/
docs/products/minimax-agent/
  index.md
  minimax-agent.md
  minimax-agent-cookbook.md
  minimax-agent-cheatsheet.md
  minimax-agent-glossary.md
```

维护参考：`.claude/skills/doc-research/references/minimax-agent.md`（先写形态调研再动笔）。

侧栏挂在 `docs/.vitepress/sidebars/ai-coding.mjs`（地图 / 核心 / 附录）。**未改** `products-gallery.js`（执行约束：禁止改 gallery）。未改 `config.mjs` 大侧栏。

## 家族图（官方一级 → 本站去向）

| 官方一级入口 | 本站去向 |
|--------------|----------|
| MiniMax Agent | 独立页（本目录） |
| MiniMax Code | 地图一行（另 #72，不写主教程） |
| MiniMax Design / Hub | 地图一行。英文 About 仍写 Hub；`hub.minimaxi.com` 当前加载 Design |
| Hailuo / 海螺视频 | 地图一行 |
| MiniMax Audio | 地图一行 |
| 星野 / Talkie | 地图一行 |
| 开放平台 / Token Plan | 地图一行 |
| About / News / IR | 非本站 |

Retrieve 起点：https://agent.minimaxi.com/ 、https://www.minimaxi.com/ 。文档树 `agent.minimaxi.com/docs/llms.txt` 当前主体是 **MiniMax Code**；changelog v3.0.33 原文「桌面端正式更名为 MiniMax Code」。本目录不把 `/docs/code/*` 抄成 Agent 网页教程。

## 密度与结构

官方没有 Agent 网页的 Commands / Settings 页，所以没有硬凑 CLI 五件套命令表。Lightning / Pro 来自 [M2 新闻](https://www.minimaxi.com/news/minimax-m2)；Agent Team 来自官方 techblog；技能市场来自 `/skills`。计费两套官方说法并列（限时免费 vs Token Plan），不猜哪套赢。

机制（MSA / 注意力）不写，链 Learn LLM。

## 验收

- [x] 维护参考里先有产品形态调研
- [x] 本目录无 Code / Hailuo / 星野完整教程
- [x] 家族图一级 AI 入口都有去向
- [x] 反杜撰：无「应该是 / 通常」事实句；命令与档位只抄能打开的官方页
- [x] `pnpm docs:build` 通过（47s）
- [x] 适合前端工程师当**调研 / PPT / 落地页 / 轻量交付工作台**；不适合当终端编程主路径（那是 Code / #72）。没有硬凑 CLI 手册。

## 自审（doc-quality-auditor）

- 完整性 P0：家族图覆盖本次打开的官方一级 AI 入口。
- 易撞名已写「不是什么」：Agent ≠ Code ≠ Hub/Design ≠ Mini-Agent ≠ Hailuo ≠ 星野。
- 两份官方页打架：Hub vs Design 同时引用，落地页以 Design 为准。