### PR TITLE
docs(bailian): add Bailian handbook for #85

### DIFF
--- a/.claude/skills/doc-research/references/bailian.md
+++ b/.claude/skills/doc-research/references/bailian.md
@@ -1,0 +1,129 @@
+# 阿里云百炼（Model Studio）维护参考
+
+> 本文件只记录百炼文档特有的维护事实。通用维护流程见 [`maintenance-workflow.md`](./maintenance-workflow.md)，Diataxis 四象限见 [`documentation-architecture.md`](./documentation-architecture.md)。读者可见的数据源写在 `docs/zh/products/bailian/bailian-cheatsheet.md` 的「高质量信息源」，不要在本文件再抄一份。
+
+## 产品形态调研（先于动笔，2026-08-19）
+
+**结论**：百炼是**企业级大模型服务与应用开发平台**，不是聊天 App，也不是 IDE 插件。前端接 Qwen / 第三方模型 API、在控制台搭 Agent / RAG、用 Coding Plan / Token Plan 给编程工具供电，都走这里。
+
+| 形态 | 官方入口 | 本站处理 |
+|------|----------|----------|
+| Web 控制台 / 模型体验 | [bailian.console.aliyun.com](https://bailian.console.aliyun.com/) | Tutorial 主路径 |
+| 模型 HTTP API（OpenAI 兼容 / Anthropic 兼容 / DashScope） | [首次调用](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen) | Tutorial + Cookbook |
+| Token Plan / Coding Plan 订阅 | [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview)、[Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan) | Cheatsheet 决策表；Cookbook 防混用 |
+| 可视化应用（Agent 1.0 / 2.0、工作流、知识库、MCP） | 文档站「用户指南（应用）」 | Cookbook 一条；不拆独立教程 |
+| 百炼 CLI（`bl` / `bailian`，npm `bailian-cli`） | [安装说明](https://bailian.aliyun.com/cli/install.md)、[落地页](https://bailian.console.aliyun.com/cli) | Cookbook；地图一行 |
+| 模型调优 / 部署 / 评测 | 文档站 Fine-tuning / Deployment / Evaluation | 地图一行，轴 B 偏 ML 平台，不写操作教程 |
+| 接入第三方编程工具 | [接入客户端/开发工具](https://help.aliyun.com/zh/model-studio/use-chat-client-or-development-tool/) | Cookbook 只写「去官方页填 Key + Base URL」 |
+
+**本站只收**：大模型服务平台百炼（Alibaba Cloud Model Studio）。
+
+**明确不收正文**（家族图一行或标「非本站」）：
+
+- 通义千问（对话产品，#83）
+- 通义灵码 / Qoder CN（原 Lingma，#84）
+- 析言 GBI、全妙（落地页兄弟入口，密度是营销/模板）
+- PAI、DashVector、ECS、OSS 及帮助中心侧栏其它非 AI 云产品
+
+## 基本信息
+
+- 工具名：大模型服务平台百炼（Alibaba Cloud Model Studio）
+- 中国站产品页：<https://www.aliyun.com/product/bailian>
+- 中国站文档根：<https://help.aliyun.com/zh/model-studio/>
+- 国际站文档根：<https://www.alibabacloud.com/help/en/model-studio/>
+- 控制台：<https://bailian.console.aliyun.com/>
+- 发版节奏：模型清单与套餐页按周级更新；Key 格式、Base URL、套餐名会静默改
+- 当前覆盖：以 2026-08-19 打开的中国站帮助文档 + 国际站侧栏为准
+
+## 官方一级导航（产品家族）
+
+> 排轴 A/B 之前先填完。规则见 [`family-completeness.md`](./family-completeness.md)。
+>
+> 百炼文档站（国际站「User Guide (Models)」侧栏，2026-08-19）的一级分组如下。同厂其它 AI 产品不在这棵树上。
+
+| 官方一级入口 | 官方 URL | 本站去向 | 不拆页理由（若一行） |
+|--------------|----------|----------|----------------------|
+| 产品简介 / What is Model Studio | https://help.aliyun.com/zh/model-studio/what-is-model-studio | 独立页 `index` + `bailian` | |
+| 首次调用 API | https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen | 独立页 `bailian` | |
+| 选择模型 / Models | https://help.aliyun.com/zh/model-studio/models | 地图一行 + Cheatsheet 链官方 | 清单周更，禁止抄全表 |
+| 计费 / 新人免费额度 / Token Plan / Coding Plan | https://help.aliyun.com/zh/model-studio/billing-for-model-studio 等 | Cheatsheet + Cookbook | |
+| 模型体验 / Playground | 控制台模型体验 | Tutorial 一步 | |
+| 接入客户端/开发工具 | https://help.aliyun.com/zh/model-studio/use-chat-client-or-development-tool/ | Cookbook 一行 + 官方链 | 每个工具官方已有专页 |
+| 智能体 / 工作流 / 知识库 / MCP | Agent 2.0、workflow、RAG、MCP 简介 | Cookbook + Glossary | |
+| 调优 / 部署 / 评测 | 文档站 Fine-tuning / Deployment / Evaluation | 地图一行 | 轴 B：训练平台，非前端主路径 |
+| 百炼 CLI | https://bailian.aliyun.com/cli/install.md | Cookbook | 安装说明足够，不拆第三套 CLI 教程 |
+| 通义千问 | 另产品 | 地图一行 → #83 | 本 issue 禁止写完整教程 |
+| 通义灵码 / Qoder CN（原 Lingma） | https://help.aliyun.com/zh/model-studio/lingma-agent | 地图一行 → #84 | 本 issue 禁止写完整教程 |
+| 析言 GBI / 全妙 | 产品页 Tab | 地图一行「非本站」 | 营销/模板，不是编码主线 |
+| ECS / OSS / PAI / DashVector 等 | 帮助中心侧栏 | 地图一行「非本站」 | 非本站、非本 issue |
+
+易撞名：
+
+- **百炼 ≠ 千问 ≠ 灵码**。百炼是平台；千问是模型/对话产品；灵码已改名为 Qoder CN，是 IDE。
+- **`bl` / `bailian`（npm `bailian-cli`）≠ `aliyun bailian`（阿里云 CLI 的 OpenAPI 插件）**。
+- **`DASHSCOPE_API_KEY` 是环境变量名，不是产品名**。DashScope 是旧接口品牌，现文档仍用这个变量。
+- **三种 Key 前缀不要混**：按量 `sk-` / `sk-ws`；Coding Plan / Token Plan 专属 `sk-sp-`。专属 Key 必须配专属 Base URL。
+- **Coding Plan ≠ Token Plan**。官方写两者无法迁移；Token Plan 页推荐新用户走 Token Plan。
+- **中国站与国际站地域、免费额度、Base URL 不是同一张表**。中国站新人额度在北京；国际站简介写新加坡。禁止把一边的数字抄到另一边。
+
+两份官方页打架时的取舍：
+
+| 事实 | 以谁为准 | 另一份 |
+|------|----------|--------|
+| 数据是否用于训练 | [产品简介「重要」](https://help.aliyun.com/zh/model-studio/what-is-model-studio) + [Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan) + [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview)：按量与 Token Plan **团队版**不用于训练；Token Plan **个人版**与 Coding Plan 会用于服务改进 | FAQ / 国际站简介写「never」是简化口径 |
+| 美国（弗吉尼亚）OpenAI 兼容 Base URL | [选择模型](https://help.aliyun.com/zh/model-studio/models) 写 `https://dashscope-us.aliyuncs.com/compatible-mode/v1` | 产品简介示例仍出现 `{WorkspaceId}.us-east-1.maas.aliyuncs.com`。教程示例用模型清单页 |
+| 按量付费北京 OpenAI 兼容 Base URL | [首次调用](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen) / 模型清单：`https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` | Coding Plan 页仍写旧主机 `https://dashscope.aliyuncs.com/compatible-mode/v1`。写清「旧主机仍出现在套餐页，新调用以首次调用/模型清单为准」 |
+| 新人免费额度在哪 | 中国站 [新人免费额度](https://help.aliyun.com/zh/model-studio/new-free-quota)：仅华北 2（北京） | 国际站产品简介：新加坡。分区站引用 |
+
+## 文档文件结构（Diataxis）
+
+```
+docs/zh/products/bailian/       # 英文同构 docs/products/bailian/
+├── index.md                    # 🗺️ 学习地图 + 家族图
+├── bailian.md                  # 📘 Tutorial — 控制台 + 第一次 API
+├── bailian-cookbook.md         # 🔧 How-to
+├── bailian-cheatsheet.md       # 📐 Reference
+└── bailian-glossary.md         # 📖 Explanation
+```
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 | 家族图、决策树、千问/灵码一行 | 操作步骤、模型全表 |
+| `bailian.md` | Tutorial | 开通、Key、第一次 Node 调用、选模型档 | 套餐数字、每个第三方工具逐步配置 |
+| `bailian-cookbook.md` | How-to | 防混用 Key、免费额度用完即停、控制台问答、装 CLI | 灵码/千问完整教程、ECS/OSS |
+| `bailian-cheatsheet.md` | Reference | 决策表、Key/URL、地域、数据源 | 概念散文 |
+| `bailian-glossary.md` | Explanation | 撞名、Workspace、三种协议、两套套餐 | 参数清单 |
+
+轴 A：先地图，再 Tutorial（控制台 + API 是后续所有页的前提），Cookbook / Cheatsheet / Glossary 紧跟。
+轴 B：调优/部署/评测、析言/全妙、云主机往后压或一行。
+
+## 监控页面
+
+- 产品简介：https://help.aliyun.com/zh/model-studio/what-is-model-studio
+- 模型清单：https://help.aliyun.com/zh/model-studio/models
+- 计费项：https://help.aliyun.com/zh/model-studio/billing-for-model-studio
+- 新人免费额度：https://help.aliyun.com/zh/model-studio/new-free-quota
+- Token Plan：https://help.aliyun.com/zh/model-studio/token-plan-overview
+- Coding Plan：https://help.aliyun.com/zh/model-studio/coding-plan
+- API Key：https://help.aliyun.com/zh/model-studio/get-api-key
+- 接入客户端：https://help.aliyun.com/zh/model-studio/use-chat-client-or-development-tool/
+- 百炼 CLI 安装：https://bailian.aliyun.com/cli/install.md
+- FAQ：https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio
+- 国际站简介：https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio
+
+## Git 提交 scope
+
+```
+docs(bailian): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+- **模型 ID 与套餐白名单必须逐字匹配**。Coding Plan 官方写「禁止做版本兼容推理」：`qwen3-coder-max` 不在清单就不能当 `qwen3-coder-plus` 用。
+- **Key 与 Base URL 必须成对**。Coding Plan 官方：通用 Key 配套餐 URL → `invalid_api_key`；通用 Key 配按量 URL → **不抵扣套餐、按量扣费**。
+- **Coding Plan 严禁当普通后端 API 用**。官方：仅限编程工具，批量/脚本视为违规。
+- **新 Key 只展示一次**，前缀 `sk-ws`（美国弗吉尼亚除外）。旧 `sk-` 仍可用。
+- **北京 / 新加坡 / 东京 / 法兰克福** 的新 MaaS URL 要填 `{WorkspaceId}`；美国弗吉尼亚以模型清单页为准。
+- **不要在正文写「通常」补全价格**。单价只链 [模型调用价格](https://help.aliyun.com/zh/model-studio/model-pricing) / [计费项](https://help.aliyun.com/zh/model-studio/billing-for-model-studio)。
+- 机制（注意力、训练）不写，链 Learn LLM：`https://llm.zenheart.site/chapters/` 与本站 `/zh/tech/fundamentals/LLM`。
+- 禁止改 `products-gallery.js`（本轮用户硬约束）。导航只改 `docs/.vitepress/sidebars/ai-coding.mjs`。

--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -12,5 +12,6 @@
 | Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
 | Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
 | Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| Bailian | [`bailian.md`](./bailian.md) | `docs/zh/products/bailian/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/docs/.vitepress/sidebars/ai-coding.mjs
+++ b/docs/.vitepress/sidebars/ai-coding.mjs
@@ -192,6 +192,27 @@ export const enAiCodingItems = [
                                     },
                                  ]
                               },
+                              {
+                                 text: 'Bailian', link: '/products/bailian/', items: [
+                                    { text: '🗺️ Learning Map', link: '/products/bailian/' },
+                                    {
+                                       text: 'Core',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Getting Started', link: '/products/bailian/bailian' },
+                                          { text: 'Cookbook', link: '/products/bailian/bailian-cookbook' },
+                                       ]
+                                    },
+                                    {
+                                       text: 'Reference',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Cheatsheet', link: '/products/bailian/bailian-cheatsheet' },
+                                          { text: 'Glossary', link: '/products/bailian/bailian-glossary' },
+                                       ]
+                                    },
+                                 ]
+                              },
                               { text: 'Pi Agent', link: '/products/ai-coding/pi-agent' },
                               { text: 'Other Tools', link: '/products/ai-coding/othertools' },
 ]
@@ -378,6 +399,27 @@ export const zhAiCodingItems = [
                                        items: [
                                           { text: '速查表', link: '/zh/products/ai-coding/grok/grok-cheatsheet' },
                                           { text: '术语表', link: '/zh/products/ai-coding/grok/grok-glossary' },
+                                       ]
+                                    },
+                                 ]
+                              },
+                              {
+                                 text: '百炼', link: '/zh/products/bailian/', items: [
+                                    { text: '🗺️ 学习地图', link: '/zh/products/bailian/' },
+                                    {
+                                       text: '核心产品',
+                                       collapsed: false,
+                                       items: [
+                                          { text: '上手教程', link: '/zh/products/bailian/bailian' },
+                                          { text: '实战 Cookbook', link: '/zh/products/bailian/bailian-cookbook' },
+                                       ]
+                                    },
+                                    {
+                                       text: '速查与参考',
+                                       collapsed: false,
+                                       items: [
+                                          { text: '速查表', link: '/zh/products/bailian/bailian-cheatsheet' },
+                                          { text: '术语表', link: '/zh/products/bailian/bailian-glossary' },
                                        ]
                                     },
                                  ]

--- a/docs/products/bailian/bailian-cheatsheet.md
+++ b/docs/products/bailian/bailian-cheatsheet.md
@@ -1,0 +1,185 @@
+---
+title: Model Studio cheatsheet
+description: Regions, keys, base URLs, plan comparison. Full model tables and unit prices stay on official pages.
+domain: product
+tags:
+  - model-platform
+role: cheatsheet
+---
+
+# Model Studio cheatsheet
+
+> Lookup only. Learn on the [map](./index) and [tutorial](./bailian). Concepts in the [glossary](./bailian-glossary).
+
+**Last verified: 2026-08-19.** Trust the official page you have open for IDs, prices, and hosts.
+
+## Which path
+
+| Job | Use | Official page |
+|-----|-----|----------------|
+| Call models from your service | PAYG API, OpenAI-compatible | [First API call](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen) |
+| Monthly quota inside coding tools | Token Plan (recommended for new buys) or Coding Plan | [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview), [Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan) |
+| No-code Q&A / agent | Console app, prefer Agent 2.0 | [Agent 2.0](https://help.aliyun.com/zh/model-studio/new-single-agent-application) |
+| Local agent, multimodal tools | CLI `bl` | [Install](https://bailian.aliyun.com/cli/install.md) |
+| Chat only | Qwen (#83) | Not Model Studio |
+| Alibaba coding IDE | Qoder CN / Lingma (#84) | [Attach page](https://help.aliyun.com/zh/model-studio/lingma-agent) |
+
+## Regions
+
+China-site intro (2026-08-19): China (Beijing), US (Virginia), Singapore, Germany (Frankfurt), Japan (Tokyo).
+
+| Fact | Source |
+|------|--------|
+| Keys, endpoints, models, features, prices are per region | [Intro](https://help.aliyun.com/zh/model-studio/what-is-model-studio) |
+| China-site new-user quota is Beijing only | [Free quota](https://help.aliyun.com/zh/model-studio/new-free-quota) |
+| International intro puts free quota in Singapore | [What is Model Studio](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio) |
+| Token Plan is Beijing only | [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview) |
+| International sidebar also lists China (Hong Kong) | International intro; absent from the China-site intro. Use the site you are on |
+
+You cannot turn the service off after activation. Stop calls by deleting keys. [FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+
+## API keys
+
+| Item | Official value |
+|------|----------------|
+| Env var | `DASHSCOPE_API_KEY` |
+| PAYG after the security upgrade | `sk-ws…`, shown once |
+| PAYG from before the upgrade | `sk-…`, still valid |
+| Coding Plan / Token Plan dedicated | `sk-sp-` |
+| Beijing / Singapore / Tokyo / Frankfurt | 50 keys per primary account per region |
+| US (Virginia) | 20 per owning account; no disable/reset |
+| Expiry | None; delete to revoke |
+| RAM user deleted | That user's keys die |
+
+Source: [Get an API key](https://help.aliyun.com/zh/model-studio/get-api-key).
+
+## Base URL
+
+Replace `{WorkspaceId}` with the workspace ID from the console.
+
+| Region | OpenAI-compatible (model list / first call) | Anthropic-compatible (model list) |
+|--------|---------------------------------------------|-----------------------------------|
+| China (Beijing) | `https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` | `https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/apps/anthropic` |
+| Singapore | `https://{WorkspaceId}.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` | `https://{WorkspaceId}.ap-southeast-1.maas.aliyuncs.com/apps/anthropic` |
+| Japan (Tokyo) | `https://{WorkspaceId}.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1` | `https://{WorkspaceId}.ap-northeast-1.maas.aliyuncs.com/apps/anthropic` |
+| Germany (Frankfurt) | `https://{WorkspaceId}.eu-central-1.maas.aliyuncs.com/compatible-mode/v1` | `https://{WorkspaceId}.eu-central-1.maas.aliyuncs.com/apps/anthropic` |
+| US (Virginia) | `https://dashscope-us.aliyuncs.com/compatible-mode/v1` ([model list](https://help.aliyun.com/zh/model-studio/models)) | `https://dashscope-us.aliyuncs.com/apps/anthropic` |
+
+DashScope native hosts use `/api/v1` on the same model-list page.
+
+**Official pages disagree — this table picks a winner:**
+
+- The intro sample still shows `{WorkspaceId}.us-east-1.maas.aliyuncs.com` for Virginia. The US row follows the **model list**.
+- Coding Plan still lists PAYG OpenAI as `https://dashscope.aliyuncs.com/compatible-mode/v1`. New code follows **first call / model list**.
+
+Coding Plan dedicated:
+
+- OpenAI: `https://coding.dashscope.aliyuncs.com/v1`
+- Anthropic: `https://coding.dashscope.aliyuncs.com/apps/anthropic`
+
+Token Plan dedicated hosts come from the Token Plan console. Do not reuse the Coding Plan row.
+
+## How to look up models
+
+Do not maintain a full catalog here.
+
+- [Models (ZH)](https://help.aliyun.com/zh/model-studio/models) / [Models (EN)](https://www.alibabacloud.com/help/en/model-studio/models)
+- [Pricing](https://help.aliyun.com/zh/model-studio/model-pricing)
+
+Intro tiers: Max = strongest; Plus = default recommendation; Flash = low latency. The 2026-08 intro names `qwen3.8-max`. The first-call sample uses `qwen-plus`.
+
+FAQ: `qwen-plus-latest` is Qwen3, **not** an alias of Qwen3.5 / Qwen3.7. Those are sibling series.
+
+## Plan comparison (numbers move; checkout wins)
+
+From [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview) and [Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan) as opened 2026-08-19:
+
+| | Token Plan Personal | Token Plan Team | Coding Plan Pro |
+|--|---------------------|-----------------|-----------------|
+| Meter | Credits, 7-day window | Credits / seat / month | Request counts (5-hour / week / month caps; first hit wins) |
+| List price on that day | Lite CNY 39/mo promo (60); Standard 139 (180); Pro 499 (600) | Standard seat 150 promo (198); Pro 550 (698); Max 1,398 | CNY 200/mo; the page has mentioned a 39.90 first month — checkout wins |
+| Region | Beijing only | Beijing only | See that page |
+| Training data | Personal **is** used to improve the service (intro "Important") | Team: no training-use commitment | Inputs and outputs **are** used to improve the service |
+| Refunds | That page / the agreement | That page / the agreement | Official: **no refunds** |
+| Status | Official recommendation for new buys | Multi-seat | Lite: no new buys after 2026-03-20, no renewals after 2026-04-13; Pro is limited stock |
+
+Coding Plan Pro caps on that page: 6,000 / 5 hours, 45,000 / week, 90,000 / month. Simple tasks ~5–10 requests; hard ones ~10–30+.
+
+PAYG realtime offset order: new-user quota > resource pack > savings plan > account balance. [Free quota](https://help.aliyun.com/zh/model-studio/new-free-quota), [Billing](https://help.aliyun.com/zh/model-studio/billing-for-model-studio)
+
+Batch is 50% of realtime and **cannot** use free quota / savings / packs.
+
+Wanxiang membership does not offset Model Studio API. [FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+
+## Model Studio CLI
+
+| Item | Official value |
+|------|----------------|
+| npm package | `bailian-cli` |
+| Commands | `bl`, `bailian` |
+| Node | ≥ 22.12.0 |
+| Install | `npm install -g bailian-cli` (not pnpm / yarn for this package) |
+| Login | `bl auth login --console` |
+| Smoke test | `bl text chat --message "ping" --non-interactive --output json` |
+| Region flag | `--region cn\|us\|intl`, default `cn` |
+
+Not `aliyun bailian`.
+
+## Glossary index
+
+One line each; definitions on the glossary page.
+
+| Term | Hook |
+|------|------|
+| [Model Studio](./bailian-glossary#model-studio) | Platform, not a chat window |
+| [Qwen](./bailian-glossary#qwen) | Model family and another product |
+| [Lingma / Qoder CN](./bailian-glossary#lingma--qoder-cn) | IDE |
+| [DashScope](./bailian-glossary#dashscope) | Legacy API brand; the env var remains |
+| [Workspace](./bailian-glossary#workspace) | Isolation for ACL and bills |
+| [Three protocols](./bailian-glossary#three-call-protocols) | OpenAI / Anthropic / DashScope |
+| [Token Plan vs Coding Plan](./bailian-glossary#token-plan-vs-coding-plan) | Two subscriptions that cannot migrate |
+| [Agent 1.0 vs 2.0](./bailian-glossary#agent-10-vs-20) | No upgrade path |
+| [Two CLIs](./bailian-glossary#model-studio-cli-vs-alibaba-cloud-cli) | `bl` ≠ `aliyun bailian` |
+
+## Sources
+
+**Last systematic pass: 2026-08-19.**
+
+### S: official source of truth
+
+| Source | Use |
+|--------|-----|
+| [What is Model Studio (ZH)](https://help.aliyun.com/zh/model-studio/what-is-model-studio) | Definition, regions, billing boundary |
+| [What is Model Studio (EN)](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio) | International nav and regions |
+| [Models](https://help.aliyun.com/zh/model-studio/models) | IDs, regions, three base URLs |
+| [First API call](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen) | Activation, samples |
+| [Get an API key](https://help.aliyun.com/zh/model-studio/get-api-key) | Key format, caps, env var |
+| [Billing items](https://help.aliyun.com/zh/model-studio/billing-for-model-studio) | Inference / train / deploy |
+| [Pricing](https://help.aliyun.com/zh/model-studio/model-pricing) | Unit prices |
+| [Free quota](https://help.aliyun.com/zh/model-studio/new-free-quota) | 90 days, stop switch |
+| [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview) | Credits plans |
+| [Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan) | Request plans, dedicated URL |
+| [Clients](https://help.aliyun.com/zh/model-studio/use-chat-client-or-development-tool/) | Third-party tools |
+| [CLI install](https://bailian.aliyun.com/cli/install.md) | `bailian-cli` |
+| [FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio) | Activate / cannot disable / vs Qwen |
+
+### A: official but marketing or slow
+
+| Source | Use |
+|--------|-----|
+| [China product page](https://www.aliyun.com/product/bailian) | Positioning; numbers lose to the help center |
+| [Console](https://bailian.console.aliyun.com/) | Real activation and quota |
+| [CLI landing](https://bailian.console.aliyun.com/cli) | CLI capabilities |
+| [Privacy](https://help.aliyun.com/zh/model-studio/privacy-notice) | Cross-check plan data-use text |
+| [Service agreement](https://terms.alicdn.com/legal-agreement/terms/common_platform_service/20230728213935489/20230728213935489.html) | §5.2 (named by Coding Plan) |
+
+### B: verify
+
+Community posts. IDs and hosts rot fast. Commands come from S only.
+
+## Related
+
+- [Map](./index)
+- [Tutorial](./bailian)
+- [Cookbook](./bailian-cookbook)
+- [Glossary](./bailian-glossary)

--- a/docs/products/bailian/bailian-cookbook.md
+++ b/docs/products/bailian/bailian-cookbook.md
@@ -1,0 +1,100 @@
+---
+title: Model Studio cookbook
+description: Recipes for key mix-ups, quota stop, no-code Q&A, and the Model Studio CLI. No full Lingma or Qwen chat tutorial.
+domain: product
+tags:
+  - model-platform
+role: cookbook
+---
+
+# Model Studio cookbook
+
+> You can already send one request. These are problem-shaped. Activation is in the [tutorial](./bailian).
+
+## Move existing OpenAI code
+
+Official rule: change the **API key, base URL, and model name**. [Intro](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio)
+
+1. Read `process.env.DASHSCOPE_API_KEY`.
+2. Point `baseURL` at that region's OpenAI-compatible host and fill `{WorkspaceId}` (Beijing / Singapore / Tokyo / Frankfurt). US Virginia follows the [model list](https://help.aliyun.com/zh/model-studio/models).
+3. Use an ID from the list. `gpt-4o` will not resolve.
+4. Streaming and tools exist only if that model lists them. Compatible ≠ feature-parity.
+
+Copy Node / Python / curl from [First API call](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen).
+
+## Do not mix the three credential pairs
+
+This is the usual source of `invalid_api_key` and surprise invoices. [Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan), [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview)
+
+| Billing | Key looks like | Where the base URL comes from |
+|---------|----------------|-------------------------------|
+| Pay-as-you-go | `sk-` or `sk-ws` | [First API call](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen) / [Models](https://help.aliyun.com/zh/model-studio/models) |
+| Coding Plan | `sk-sp-` from the plan page | OpenAI `https://coding.dashscope.aliyuncs.com/v1`; Anthropic `https://coding.dashscope.aliyuncs.com/apps/anthropic` |
+| Token Plan | Dedicated key (official prefix `sk-sp-`) | **Whatever the Token Plan console shows that day** — not the Coding Plan host |
+
+Official failure modes:
+
+- PAYG key + plan host → `invalid_api_key`.
+- PAYG key + PAYG host → **no plan credit, PAYG bill**.
+- You bought Coding Plan and still see arrears: the tool still has `sk-` and `dashscope.aliyuncs.com`.
+
+Coding Plan is **coding tools only** (official examples: Claude Code, Qoder, Qoder CN, OpenClaw). Using the plan key as your app backend or for batch jobs is a policy violation.
+
+Token Plan requires a real OpenAI or Anthropic protocol. A look-alike UI that does not speak those APIs cannot burn plan credits — use a PAYG `sk-` / `sk-ws` key instead.
+
+When filling a client, open the official page for that client. Do not reconstruct screenshots here:
+
+- Index: [Clients and developer tools](https://help.aliyun.com/zh/model-studio/use-chat-client-or-development-tool/)
+- Examples: [Claude Code](https://help.aliyun.com/zh/model-studio/claude-code), [Chatbox](https://help.aliyun.com/zh/model-studio/chatbox)
+
+The full Qoder CN / Lingma IDE tutorial is #84. One official fact belongs here: personal Community / Pro can attach Model Studio; **Enterprise cannot**. [Qoder CN](https://help.aliyun.com/zh/model-studio/lingma-agent)
+
+## Stop PAYG after the new-user quota
+
+China-site [free quota](https://help.aliyun.com/zh/model-studio/new-free-quota):
+
+1. **Beijing only**. Valid **90 days** from the later of activation, model launch, or approval.
+2. Realtime inference only. Not Batch, fine-tune, deploy, or custom models.
+3. Each model (including dated snapshots) has its own pool. The page says a model is "usually" 1 million tokens — believe the console row, not the marketing "70 million+" headline.
+4. Verified accounts: turn on **Free quota only**. Exhaustion returns `AllocationQuota.FreeTierOnly`.
+5. Unverified accounts already have that switch forced on.
+6. An overdue account cannot call *any* model, even one that still has free tokens.
+
+The official page advises against Free-quota-only in production (the service just stops). Use spend alerts and key deletion there.
+
+Token Plan / Coding Plan dedicated keys **do not** consume this free-tier pool.
+
+## No-code knowledge-base Q&A
+
+1. Open the console and confirm the region.
+2. Follow [Build a Q&A app without code](https://help.aliyun.com/zh/model-studio/build-knowledge-base-qa-assistant-without-coding/).
+3. Prefer [Agent 2.0](https://help.aliyun.com/zh/model-studio/new-single-agent-application) when you have no 1.0 dependency. **No in-place upgrade** from 1.0.
+4. Publish before you call the app API or channels.
+5. Knowledge base billing is **separate** from model inference and does not use savings plans or resource packs. [Intro](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+
+Fine-tune and dedicated deploy stay on the official pages: [training](https://help.aliyun.com/zh/model-studio/model-training-overview), [deploy](https://help.aliyun.com/zh/model-studio/model-deployment-introduction).
+
+## Install the Model Studio CLI
+
+This is Model Studio's own CLI (multimodal tools for local agents), not the Alibaba Cloud OpenAPI plugin `aliyun bailian`.
+
+Official install: [bailian.aliyun.com/cli/install.md](https://bailian.aliyun.com/cli/install.md)
+
+```bash
+# Node.js ≥ 22.12.0 — npm only
+npm install -g bailian-cli
+bl --version
+
+# Browser login (preferred)
+bl auth login --console
+
+# Smoke test
+bl auth status --output json
+bl text chat --message "ping" --non-interactive --output json
+```
+
+Commands are `bl` and `bailian`. Official skills install: `npx skills add modelstudioai/cli --all -g`.
+
+Headless / SSH: `bl auth login --api-key <pasted-key>`. Do not write the key into the repo or the chat log.
+
+Region flag: `--region cn|us|intl`, default `cn`.

--- a/docs/products/bailian/bailian-glossary.md
+++ b/docs/products/bailian/bailian-glossary.md
@@ -1,0 +1,117 @@
+---
+title: Model Studio glossary
+description: Model Studio, Qwen, and Lingma are not the same product. Neither are the three protocols, two plans, or two CLIs.
+domain: product
+tags:
+  - model-platform
+role: glossary
+---
+
+# Model Studio glossary
+
+No procedures. Just the collisions. Paths live on the [map](./index).
+
+## Model Studio
+
+**What**: Alibaba Cloud's model-service and application platform. Chinese name 百炼. APIs, console apps, subscription plans. [Intro](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio)
+
+**Not**: the Tongyi chat window, the Lingma IDE, or ECS / OSS.
+
+**Why this handbook exists**: a front-end that calls Qwen talks to this platform's API and billing, not to the chat site.
+
+## Qwen
+
+**What**: Alibaba's model family, and a separate chat product. FAQ: Model Studio is a platform that *includes* the Qwen series. [FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+
+**Here**: only "a model you can call on Studio". Chat-product prose is #83.
+
+## Lingma / Qoder CN
+
+**What**: Alibaba Cloud's coding assistant / standalone IDE. Current official name **Qoder CN (formerly Lingma)**. [Attach page](https://help.aliyun.com/zh/model-studio/lingma-agent)
+
+**Relation**: can take a Studio Token Plan / Coding Plan / PAYG key. Official: Enterprise cannot attach Studio.
+
+**Here**: one line. Full tutorial is #84.
+
+## DashScope
+
+**What**: the old API brand. The env var is still `DASHSCOPE_API_KEY`. US hosts still say `dashscope-us.aliyuncs.com`. Coding Plan still mentions `dashscope.aliyuncs.com`.
+
+**Not**: a second product you activate beside Model Studio.
+
+## Workspace
+
+**What**: a container that isolates project / team resources and ACL. `{WorkspaceId}` in the new MaaS URLs is this ID. [First API call](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen), [Get an API key](https://help.aliyun.com/zh/model-studio/get-api-key)
+
+**Official ACL**:
+
+- Keys in the same workspace share the same rights. You do not split keys by text vs image.
+- Default workspace: all standard models + apps in that workspace.
+- Child workspace: only authorized standard models + its own apps.
+- Fine-tuned models: only the workspace they live in.
+
+Primary accounts see every workspace's keys. RAM users see only workspaces they joined.
+
+## Three call protocols
+
+The model list often prints three hosts for one ID:
+
+| Protocol | Path | When |
+|----------|------|------|
+| OpenAI-compatible | `/compatible-mode/v1` | Existing `openai` SDK, most desktop clients |
+| Anthropic-compatible | `/apps/anthropic` | Tools that speak Messages (Claude Code, …) |
+| DashScope | `/api/v1` | Official DashScope SDK, some multimodal generate APIs |
+
+Source: [Models](https://help.aliyun.com/zh/model-studio/models). The three hosts are **not** interchangeable. Plans add a fourth dedicated host.
+
+## Token Plan vs Coding Plan
+
+Two Studio subscriptions. **No migrate / upgrade path between them.** [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview)
+
+| | Token Plan | Coding Plan |
+|--|------------|-------------|
+| Meter | Credits | Request counts |
+| Official stance (2026-08) | Preferred for new buys | Lite stopped; Pro limited |
+| Personal vs team | Personal has a 7-day window; Team is per-seat and commits not to train | Page is Pro-centric |
+| Data | Personal used to improve the service; Team commits not to | Inputs and outputs used to improve the service |
+| Allowed use | Tools that speak OpenAI / Anthropic | **Coding tools only**, not your backend API |
+
+"We never train on your data" in the FAQ / international intro is the short version. The intro's **Important** box and the two plan pages win.
+
+## Agent 1.0 vs 2.0
+
+| | 1.0 | 2.0 |
+|--|-----|-----|
+| Scheduling | Retrieve the knowledge base, then maybe MCP | Knowledge base and MCP are tools; the model orders them |
+| Trace | Final answer only | Plan → act → reflect |
+| Migration | — | **Cannot** upgrade 1.0; create a new app |
+
+Source: [Agent 2.0](https://help.aliyun.com/zh/model-studio/new-single-agent-application). Official default when you have no 1.0 dependency.
+
+A workflow is a different console app type (a fixed graph), not another name for Agent 2.0. [Workflow](https://help.aliyun.com/zh/model-studio/workflow-application/)
+
+## Knowledge base (RAG)
+
+Retrieve private documents, then generate. Billed separately from model inference; no savings plan or resource pack. [Intro](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+
+One official anti-hallucination tool (FAQ). Mechanism lives in [LLM fundamentals](/tech/fundamentals/LLM).
+
+## MCP
+
+Model Context Protocol. Studio agents and workflows can attach official or custom MCP servers. [MCP intro](https://help.aliyun.com/zh/model-studio/mcp-introduction)
+
+Some official MCPs (image, video, speech, web search) bill on their own. Custom MCP has basic / turbo time-based prices. Whether deploy is still "temporarily free" is that page's job.
+
+## Model Studio CLI vs Alibaba Cloud CLI
+
+| | Model Studio CLI | Alibaba Cloud CLI plugin |
+|--|------------------|--------------------------|
+| Package / command | npm `bailian-cli`; `bl` / `bailian` | `aliyun bailian …` |
+| Job | Local agent calls to models and multimodal tools | OpenAPI: categories, files, connectors |
+| Docs | [install.md](https://bailian.aliyun.com/cli/install.md) | [OpenAPI CLI](https://next.api.aliyun.com/api-tools/cli/bailian/2023-12-29) |
+
+Wrong binary: `aliyun bailian list-file` works, `bl text chat` does not exist.
+
+## High-code apps
+
+Deploy a Python project as a managed backend. Official: [high-code apps](https://help.aliyun.com/zh/model-studio/rich-code-application/). Axis B — no tutorial here.

--- a/docs/products/bailian/bailian.md
+++ b/docs/products/bailian/bailian.md
@@ -1,0 +1,128 @@
+---
+title: Getting started with Model Studio
+description: Activate the console, create an API key, send the first OpenAI-compatible request. Model internals live in Learn LLM.
+domain: product
+tags:
+  - model-platform
+role: tutorial
+---
+
+# Getting started with Model Studio
+
+> This is a **tutorial**. Finish it and you will have sent one Model Studio request from your machine.
+>
+> URLs and plans: [cheatsheet](./bailian-cheatsheet). Names: [glossary](./bailian-glossary). Concrete problems: [Cookbook](./bailian-cookbook).
+
+Goal: go from "I have heard of Qwen" to "my Node service can hit a pinned model".
+
+Attention, tokenization, and training are in [LLM fundamentals](/tech/fundamentals/LLM) and [Learn LLM](https://llm.zenheart.site/chapters/). Not here.
+
+## Step 0: Confirm you want Model Studio
+
+| You want | Go |
+|----------|-----|
+| HTTP API, console apps, quota for coding tools | **This page** |
+| Only Tongyi chat | Qwen (#83), not this tutorial |
+| An Alibaba coding IDE | Qoder CN / Lingma (#84), not this tutorial |
+
+Model Studio has **no** official standalone mobile app. The entry is the web console. [FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+
+## Step 1: Activate and pick a region
+
+1. Sign in with the **Alibaba Cloud primary account** and open the [console](https://bailian.console.aliyun.com/).
+2. Switch region in the top-right. The China-site intro lists China (Beijing), US (Virginia), Singapore, Germany (Frankfurt), Japan (Tokyo). [ZH intro](https://help.aliyun.com/zh/model-studio/what-is-model-studio). The [international intro](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio) also lists China (Hong Kong).
+3. Accept the agreement. No dialog means that region is already on. [FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+4. Complete identity verification if the console asks.
+
+**Keys, base URLs, catalogs, and prices do not cross regions.**
+
+China-site [free quota](https://help.aliyun.com/zh/model-studio/new-free-quota) is **Beijing only**. The international intro places new-user quota in **Singapore**. Do not copy one site's numbers onto the other.
+
+Activation is free. Inference, fine-tuning, and deployment bill. [Intro](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio)
+
+## Step 2: Create an API key and put it in the environment
+
+Follow [Get an API key](https://help.aliyun.com/zh/model-studio/get-api-key) (China-site; same product):
+
+1. Pick the region → **API Key** → **Create**.
+2. Prefer the default workspace.
+3. Permission **All** unless you need an IP or model allowlist.
+4. The plaintext key is shown **once**. Copy it.
+
+The official env var is `DASHSCOPE_API_KEY` (legacy DashScope name, not a second product):
+
+```bash
+# macOS / zsh — replace YOUR_DASHSCOPE_API_KEY
+echo "export DASHSCOPE_API_KEY='YOUR_DASHSCOPE_API_KEY'" >> ~/.zshrc
+source ~/.zshrc
+```
+
+Bash and Windows variants are on the same official page.
+
+New PAYG keys start with `sk-ws` (except US Virginia). Older `sk-` keys still work.
+
+Beijing / Singapore / Tokyo / Frankfurt MaaS URLs also need a **WorkspaceId**. Copy it from workspace management. [First API call](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen)
+
+## Step 3: Send the first request
+
+Install the official Node path:
+
+```bash
+npm install openai
+```
+
+Replace `{WorkspaceId}`. This is the Node.js sample from [First API call to Qwen](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen):
+
+```js
+import OpenAI from "openai";
+
+try {
+    const openai = new OpenAI(
+        {
+            // If the env var is unset, replace with: apiKey: "sk-xxx",
+            apiKey: process.env.DASHSCOPE_API_KEY,
+            // China (Beijing). Other regions differ. Replace {WorkspaceId}.
+            baseURL: "https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+        }
+    );
+    const completion = await openai.chat.completions.create({
+        model: "qwen-plus",
+        messages: [
+            { role: "system", content: "You are a helpful assistant." },
+            { role: "user", content: "Who are you?" }
+        ],
+    });
+    console.log(completion.choices[0].message.content);
+} catch (error) {
+    console.log(`Error: ${error}`);
+    console.log("See https://help.aliyun.com/model-studio/developer-reference/error-code");
+}
+```
+
+Other OpenAI-compatible hosts: [cheatsheet · Base URL](./bailian-cheatsheet#base-url) and [Models](https://help.aliyun.com/zh/model-studio/models). Do not invent hostnames.
+
+If you do not want to write code, the official pointer is [Chatbox](https://help.aliyun.com/zh/model-studio/chatbox).
+
+## Step 4: Pick a tier, then a real model ID
+
+The intro's three Qwen tiers (not the same thing as a `model` string):
+
+| Tier | Official line | First use |
+|------|---------------|-----------|
+| **Max** | Strongest; complex multi-step work. The intro names `qwen3.8-max` | Hard tasks, tool use |
+| **Plus** | Balance of quality, speed, cost — **recommended for most cases** | **Use the sample's `qwen-plus`** |
+| **Flash** | Cheap and low-latency | High QPS, short answers |
+
+Source: [intro](https://help.aliyun.com/zh/model-studio/what-is-model-studio).
+
+Live IDs, regional availability, and the three protocol URLs live only on [Models](https://help.aliyun.com/zh/model-studio/models). This tutorial does not copy that table.
+
+Plan catalogs are **exact-string allowlists**. Coding Plan forbids version-compatibility guesses. [Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan)
+
+## Step 5: Stop surprise PAYG before you explore
+
+Verified accounts flip to PAYG when the free quota ends. Turn on **Free quota only**. China-site: Beijing, and only while the quota is still valid. [Free quota](https://help.aliyun.com/zh/model-studio/new-free-quota)
+
+To stop calls entirely: delete every key in that region. There is no "disable auto-billing" switch. [Intro](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+
+Next: [Cookbook](./bailian-cookbook).

--- a/docs/products/bailian/index.md
+++ b/docs/products/bailian/index.md
@@ -1,0 +1,96 @@
+---
+title: Alibaba Cloud Model Studio map
+description: Model Studio is the API and app platform, not the chat app and not the IDE. Decide API vs plan vs console first.
+domain: product
+tags:
+  - model-platform
+role: map
+---
+
+# Alibaba Cloud Model Studio map
+
+> **Alibaba Cloud Model Studio** (百炼) is a one-stop model and application platform: developers call OpenAI-compatible APIs; operators build agents and knowledge-base Q&A in the console. [Product introduction](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio)
+>
+> This page only answers "what am I doing → which slice of Model Studio". Operations live in the [tutorial](./bailian). Tables live in the [cheatsheet](./bailian-cheatsheet). Name collisions live in the [glossary](./bailian-glossary).
+>
+> Model internals are out of scope. See [LLM fundamentals](/tech/fundamentals/LLM) and [Learn LLM](https://llm.zenheart.site/chapters/).
+
+## Product map
+
+```
+Alibaba Cloud AI (this directory documents Model Studio only)
+├── Model Studio (this set)
+│   ├── Console / playground
+│   ├── Model APIs (OpenAI-compatible / Anthropic-compatible / DashScope)
+│   ├── Token Plan / Coding Plan
+│   ├── Agents / workflows / knowledge base / MCP
+│   ├── Model Studio CLI (`bl` / `bailian`)
+│   └── Fine-tune / deploy / evaluate (one line, no how-to)
+├── Qwen chat — separate product, issue #83, no tutorial here
+├── Tongyi Lingma / Qoder CN (formerly Lingma) — IDE, issue #84, no tutorial here
+└── Not this site: ECS / OSS / PAI / DashVector / GBI / Quanmiao
+```
+
+| Official first-level entry | This site |
+|----------------------------|-----------|
+| Product intro, first API call, playground | [Tutorial](./bailian) |
+| Model list, billing, Token Plan, Coding Plan, regions | [Cheatsheet](./bailian-cheatsheet) |
+| Clients / tools, free-quota stop, CLI, no-code Q&A | [Cookbook](./bailian-cookbook) |
+| Agent 1.0 / 2.0, workspace, three protocols, two plans | [Glossary](./bailian-glossary) |
+| Fine-tune / deploy / evaluate | Official docs only |
+| Qwen chat | One line → #83 |
+| Qoder CN (formerly Lingma) | One line → #84 |
+| ECS / OSS / PAI / GBI / Quanmiao | **Not this site** |
+
+### Quick decision
+
+```
+What am I trying to do?
+├── Call Qwen or a third-party model from my front end / Node service
+│   └── → Model Studio API (OpenAI-compatible) → [tutorial](./bailian)
+├── Feed Alibaba Cloud quota into Claude Code / Cursor / Chatbox
+│   └── → Token Plan (what the official overview recommends for new buys) or Coding Plan
+│       └── Key and base URL must be a pair → [Cookbook](./bailian-cookbook)
+├── No code, a knowledge-base Q&A or agent
+│   └── → Console apps (prefer Agent 2.0)
+├── Let a local agent drive image / video / speech tools
+│   └── → Model Studio CLI (`bl`)
+├── Just chat with Tongyi, no API
+│   └── → Qwen (#83), not Model Studio
+├── An Alibaba-branded coding IDE
+│   └── → Qoder CN / Lingma (#84), not Model Studio
+└── A VM or object storage
+    └── → Not this site. No ECS / OSS handbook here
+```
+
+Three expensive mix-ups:
+
+| Easy to confuse | Difference |
+|-----------------|------------|
+| **Model Studio** vs **Qwen** | Studio is the platform. Qwen is a model family and a separate chat product. [FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio) |
+| **Model Studio** vs **Lingma / Qoder CN** | Qoder CN is the IDE. It can *consume* a Studio key. It is not Studio. [Official page](https://help.aliyun.com/zh/model-studio/lingma-agent) |
+| **Pay-as-you-go key** vs **plan key** | PAYG is `sk-` / `sk-ws`. Coding Plan / Token Plan dedicated keys are `sk-sp-`. A mismatched host either returns `invalid_api_key` or **bills PAYG**. [Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan) |
+
+## Which page
+
+| Page | Type | When |
+|------|------|------|
+| [Tutorial](./bailian) | Tutorial | First time: activate → key → first Node call |
+| [Cookbook](./bailian-cookbook) | How-to | You can already call; you have a concrete problem |
+| [Cheatsheet](./bailian-cheatsheet) | Reference | Regions, URLs, plan table, official links |
+| [Glossary](./bailian-glossary) | Explanation | Two names collided, or two official pages disagree |
+
+## Suggested order
+
+1. Use the tree above. Confirm you want the platform, not Qwen chat or Lingma.
+2. Walk the [tutorial](./bailian): primary account, key, env var, one `qwen-plus` call.
+3. Product integration → [Cookbook · OpenAI-compatible](./bailian-cookbook). Coding tools → [Cookbook · do not mix keys](./bailian-cookbook).
+4. Look up IDs only on the [cheatsheet](./bailian-cheatsheet) and the official model list. Do not pin a full model table in notes.
+
+## Official links
+
+- [China product page](https://www.aliyun.com/product/bailian)
+- [What is Model Studio (EN)](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio)
+- [What is Model Studio (ZH)](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+- [Models](https://www.alibabacloud.com/help/en/model-studio/models)
+- [Console](https://bailian.console.aliyun.com/)

--- a/docs/zh/products/bailian/bailian-cheatsheet.md
+++ b/docs/zh/products/bailian/bailian-cheatsheet.md
@@ -1,0 +1,185 @@
+---
+title: 阿里云百炼速查表
+description: 查地域、Key、Base URL、套餐对照。模型全表和单价只链官方页。
+domain: product
+tags:
+  - model-platform
+role: cheatsheet
+---
+
+# 阿里云百炼速查表
+
+> 查阅用。学习走 [地图](./index) 和 [教程](./bailian)。概念走 [术语表](./bailian-glossary)。
+
+**最后核实：2026-08-19。** 模型 ID、套餐价、主机名以当时打开的官方页为准。
+
+## 选哪条路
+
+| 我要做的事 | 用 | 官方页 |
+|------------|----|--------|
+| 自己的服务里调模型 | 按量 API + OpenAI 兼容 | [首次调用](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen) |
+| 编程工具里包月用模型 | Token Plan（官方推荐新订）或 Coding Plan | [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview)、[Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan) |
+| 无代码问答 / 智能体 | 控制台应用，优先 Agent 2.0 | [Agent 2.0](https://help.aliyun.com/zh/model-studio/new-single-agent-application) |
+| 本机 Agent 调度多模态能力 | 百炼 CLI `bl` | [安装说明](https://bailian.aliyun.com/cli/install.md) |
+| 只聊天 | 通义千问（#83） | 不是百炼 |
+| 阿里云编码 IDE | Qoder CN / 灵码（#84） | [接入说明](https://help.aliyun.com/zh/model-studio/lingma-agent) |
+
+## 地域
+
+中国站产品简介（2026-08-19）：华北 2（北京）、美国（弗吉尼亚）、新加坡、德国（法兰克福）、日本（东京）。
+
+| 事实 | 出处 |
+|------|------|
+| Key、Endpoint、模型、功能、价格按地域隔离 | [产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio) |
+| 中国站新人免费额度只在北京 | [新人免费额度](https://help.aliyun.com/zh/model-studio/new-free-quota) |
+| 国际站简介把免费额度写在新加坡 | [What is Model Studio](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio) |
+| Token Plan 目前仅北京 | [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview) |
+| 国际站侧栏还出现中国（香港） | 国际站简介；中国站简介未列。用哪一站就认哪一站 |
+
+开通后不支持关闭服务。停调用 = 删 Key。[FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+
+## API Key
+
+| 项 | 官方值 |
+|----|--------|
+| 环境变量 | `DASHSCOPE_API_KEY` |
+| 按量（升级后新建） | `sk-ws` 开头，只展示一次 |
+| 按量（升级前） | `sk-` 开头，仍可用 |
+| Coding Plan / Token Plan 专属 | `sk-sp-` |
+| 北京 / 新加坡 / 东京 / 法兰克福 | 每主账号每地域最多 50 个 |
+| 美国（弗吉尼亚） | 每归属账号最多 20 个；无禁用/重置 |
+| 有效期 | 无过期；删除即失效 |
+| 子账号被删 | 其创建的 Key 全部失效 |
+
+来源：[获取 API Key](https://help.aliyun.com/zh/model-studio/get-api-key)。
+
+## Base URL
+
+把 `{WorkspaceId}` 换成控制台里的业务空间 ID。
+
+| 地域 | OpenAI 兼容（模型清单 / 首次调用） | Anthropic 兼容（模型清单） |
+|------|-----------------------------------|----------------------------|
+| 华北 2（北京） | `https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` | `https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/apps/anthropic` |
+| 新加坡 | `https://{WorkspaceId}.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` | `https://{WorkspaceId}.ap-southeast-1.maas.aliyuncs.com/apps/anthropic` |
+| 日本（东京） | `https://{WorkspaceId}.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1` | `https://{WorkspaceId}.ap-northeast-1.maas.aliyuncs.com/apps/anthropic` |
+| 德国（法兰克福） | `https://{WorkspaceId}.eu-central-1.maas.aliyuncs.com/compatible-mode/v1` | `https://{WorkspaceId}.eu-central-1.maas.aliyuncs.com/apps/anthropic` |
+| 美国（弗吉尼亚） | `https://dashscope-us.aliyuncs.com/compatible-mode/v1`（[模型清单](https://help.aliyun.com/zh/model-studio/models)） | `https://dashscope-us.aliyuncs.com/apps/anthropic` |
+
+DashScope 原生主机把路径换成 `/api/v1`，见同一张模型清单。
+
+**两份官方页不一致，写在这里避免各抄各的：**
+
+- 产品简介的美国示例仍出现 `{WorkspaceId}.us-east-1.maas.aliyuncs.com`。本表美国行跟**模型清单**。
+- Coding Plan 页把按量 OpenAI 主机写成 `https://dashscope.aliyuncs.com/compatible-mode/v1`。新代码跟**首次调用 / 模型清单**。
+
+Coding Plan 专属：
+
+- OpenAI：`https://coding.dashscope.aliyuncs.com/v1`
+- Anthropic：`https://coding.dashscope.aliyuncs.com/apps/anthropic`
+
+Token Plan 专属主机以控制台为准，不要复用上表 Coding Plan 行。
+
+## 模型怎么查
+
+禁止在本站维护一份「当前全量模型表」。打开：
+
+- [选择模型](https://help.aliyun.com/zh/model-studio/models)
+- [模型调用价格](https://help.aliyun.com/zh/model-studio/model-pricing)
+
+产品简介的档位：Max = 最强；Plus = 多数场景推荐；Flash = 低延迟。2026-08 简介点名最新旗舰 `qwen3.8-max`。首次调用示例用的是 `qwen-plus`。
+
+FAQ：`qwen-plus-latest` 属于 Qwen3 系列，**不是** Qwen3.5 / Qwen3.7 的别名。Qwen3.5、Qwen3.7 是并列系列。
+
+## 套餐对照（数字会变，下单页优先）
+
+核实日打开的 [Token Plan 概述](https://help.aliyun.com/zh/model-studio/token-plan-overview) 与 [Coding Plan 概述](https://help.aliyun.com/zh/model-studio/coding-plan)：
+
+| | Token Plan 个人版 | Token Plan 团队版 | Coding Plan Pro |
+|--|-------------------|-------------------|-----------------|
+| 计量 | Credits，7 天窗口 | Credits / 座席 / 月 | 请求次数（5 小时 / 周 / 月三档封顶，先到先停） |
+| 2026-08-19 页上标价 | Lite 限时 39 元/月（原价 60）；Standard 139（180）；Pro 499（600） | 标准座席限时 150 元/座席/月（198）；高级 550（698）；尊享 1,398 | 200 元/月；官方写过首月 39.90，以下单页为准 |
+| 地域 | 仅北京 | 仅北京 | 见该页 |
+| 数据训练 | 个人版**会**用于服务改进（产品简介「重要」） | 团队版承诺不用于训练 | **会**用于服务改进与模型优化 |
+| 退款 | 以该页 / 协议为准 | 以该页 / 协议为准 | 官方写**不支持退款** |
+| 现状 | 官方推荐新订 | 多席位 | Lite 2026-03-20 停新购，2026-04-13 停续费；Pro 限量 |
+
+Coding Plan Pro 页上的用量封顶（核实日）：每 5 小时 6,000 次、每周 45,000、每月 90,000。简单任务约 5–10 次，复杂约 10–30+ 次。
+
+抵扣顺序（按量实时推理）：新人免费额度 > 资源包 > 节省计划 > 账户余额。[新人免费额度](https://help.aliyun.com/zh/model-studio/new-free-quota)、[计费项](https://help.aliyun.com/zh/model-studio/billing-for-model-studio)
+
+Batch 为实时价的 50%，且**不能**用免费额度 / 节省计划 / 资源包。[计费项](https://help.aliyun.com/zh/model-studio/billing-for-model-studio)
+
+万相会员不能抵扣百炼 API。[FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+
+## 百炼 CLI
+
+| 项 | 官方值 |
+|----|--------|
+| npm 包 | `bailian-cli` |
+| 命令 | `bl`、`bailian` |
+| Node | ≥ 22.12.0 |
+| 安装 | `npm install -g bailian-cli`（不要用 pnpm / yarn 装这个包） |
+| 登录 | `bl auth login --console` |
+| 验活 | `bl text chat --message "ping" --non-interactive --output json` |
+| 地域开关 | `--region cn\|us\|intl`，默认 `cn` |
+
+不是 `aliyun bailian`。
+
+## 术语索引
+
+一行一个，解释在术语表。
+
+| 术语 | 钩子 |
+|------|------|
+| [百炼 / Model Studio](./bailian-glossary#百炼-model-studio) | 平台，不是聊天窗口 |
+| [千问](./bailian-glossary#千问-qwen) | 模型，也是另一款产品 |
+| [灵码 / Qoder CN](./bailian-glossary#灵码--qoder-cn) | IDE |
+| [DashScope](./bailian-glossary#dashscope) | 旧接口品牌；变量名还在 |
+| [业务空间](./bailian-glossary#业务空间-workspace) | 隔离权限和账单 |
+| [三种协议](./bailian-glossary#三种调用协议) | OpenAI / Anthropic / DashScope |
+| [Token Plan vs Coding Plan](./bailian-glossary#token-plan-vs-coding-plan) | 两套不能迁移的订阅 |
+| [Agent 1.0 vs 2.0](./bailian-glossary#agent-10-vs-20) | 不能升级，只能新建 |
+| [百炼 CLI vs 阿里云 CLI](./bailian-glossary#百炼-cli-vs-阿里云-cli) | `bl` ≠ `aliyun bailian` |
+
+## 高质量信息源
+
+**最后一次系统性核实：2026-08-19。**
+
+### S 级：官方唯一真相源
+
+| 来源 | 用途 |
+|------|------|
+| [什么是阿里云百炼](https://help.aliyun.com/zh/model-studio/what-is-model-studio) | 产品定义、地域、计费边界 |
+| [选择模型](https://help.aliyun.com/zh/model-studio/models) | 模型 ID、地域、三种 Base URL |
+| [首次调用](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen) | 开通、示例代码 |
+| [获取 API Key](https://help.aliyun.com/zh/model-studio/get-api-key) | Key 格式、限额、环境变量 |
+| [计费项](https://help.aliyun.com/zh/model-studio/billing-for-model-studio) | 推理 / 训练 / 部署 |
+| [模型调用价格](https://help.aliyun.com/zh/model-studio/model-pricing) | 单价 |
+| [新人免费额度](https://help.aliyun.com/zh/model-studio/new-free-quota) | 90 天、用完即停 |
+| [Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview) | Credits 套餐 |
+| [Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan) | 请求次套餐、专属 URL |
+| [接入客户端](https://help.aliyun.com/zh/model-studio/use-chat-client-or-development-tool/) | 第三方工具 |
+| [CLI 安装说明](https://bailian.aliyun.com/cli/install.md) | `bailian-cli` 命令 |
+| [FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio) | 开通/关闭/千问区别 |
+
+### A 级：官方但偏营销或更新慢
+
+| 来源 | 用途 |
+|------|------|
+| [产品落地页](https://www.aliyun.com/product/bailian) | 能力宣传；数字以帮助文档为准 |
+| [国际站简介](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio) | 国际地域与侧栏家族 |
+| [控制台](https://bailian.console.aliyun.com/) | 实际开通与额度 |
+| [CLI 落地页](https://bailian.console.aliyun.com/cli) | CLI 能力介绍 |
+| [合规与隐私](https://help.aliyun.com/zh/model-studio/privacy-notice) | 与套餐页对照数据用途 |
+| [服务协议](https://terms.alicdn.com/legal-agreement/terms/common_platform_service/20230728213935489/20230728213935489.html) | 第 5.2 条（Coding Plan 点名） |
+
+### B 级：需交叉验证
+
+开发者社区文章、第三方博客。模型 ID 和 Base URL 过期极快，只当线索，命令以 S 级为准。
+
+## 相关页面
+
+- [学习地图](./index)
+- [教程](./bailian)
+- [Cookbook](./bailian-cookbook)
+- [术语表](./bailian-glossary)

--- a/docs/zh/products/bailian/bailian-cookbook.md
+++ b/docs/zh/products/bailian/bailian-cookbook.md
@@ -1,0 +1,100 @@
+---
+title: 阿里云百炼 Cookbook
+description: 按场景抄：别混用 Key、挡住扣费、无代码问答、装百炼 CLI。不写灵码/千问完整教程。
+domain: product
+tags:
+  - model-platform
+role: cookbook
+---
+
+# 阿里云百炼 Cookbook
+
+> 已经会发第一条请求。这里按问题给步骤。基础开通见 [教程](./bailian)。
+
+## 把现有 OpenAI 代码迁到百炼
+
+官方口径：改 **API Key、base_url、模型名称**。[产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+
+1. `apiKey` 读 `process.env.DASHSCOPE_API_KEY`。
+2. `baseURL` 换成该地域的 OpenAI 兼容主机，并填入 `{WorkspaceId}`（北京 / 新加坡 / 东京 / 法兰克福）。美国弗吉尼亚以[模型清单](https://help.aliyun.com/zh/model-studio/models)为准。
+3. `model` 换成清单里的 ID。不要沿用 `gpt-4o` 这类名字。
+4. 流式、tools 是否可用，看该模型在清单页标注的协议，不要假设「兼容 = 全功能对等」。
+
+完整 Node / Python / curl 以[首次调用](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen)为准。
+
+## 不要把三套凭证混在一起
+
+这是扣费和 `invalid_api_key` 的第一来源。[Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan)、[Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview)
+
+| 计费方式 | Key 长什么样 | Base URL 认哪张纸 |
+|----------|--------------|-------------------|
+| 按量付费 | `sk-` 或 `sk-ws` | [首次调用](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen) / [模型清单](https://help.aliyun.com/zh/model-studio/models) 的 OpenAI 或 Anthropic 主机 |
+| Coding Plan | `sk-sp-`（套餐页） | OpenAI：`https://coding.dashscope.aliyuncs.com/v1`；Anthropic：`https://coding.dashscope.aliyuncs.com/apps/anthropic` |
+| Token Plan | 套餐专属 Key（官方写 `sk-sp-` 前缀） | **以 Token Plan 控制台当时展示的 URL 为准**，不要抄 Coding Plan 的主机 |
+
+官方点名的混用后果：
+
+- 通用 Key + 套餐 URL → `invalid_api_key`。
+- 通用 Key + 按量 URL → **不抵扣套餐，按量出账**。
+- 已买 Coding Plan 仍欠费：多半是工具里还留着 `sk-` 和 `dashscope.aliyuncs.com`。
+
+Coding Plan **只允许编程工具**（官方举例：Claude Code、Qoder、Qoder CN、OpenClaw）。用套餐 Key 打自己的后端、脚本、批量任务，官方视为违规，可能停订阅或封 Key。
+
+Token Plan 要求工具支持 OpenAI 或 Anthropic 协议。界面长得像官方工具但不通标准 API 的，不能抵扣套餐，应改用按量 `sk-` / `sk-ws`。
+
+把 Key 填进某个客户端时，只打开官方对应页，不要在本站复制逐步截图：
+
+- 总入口：[接入客户端/开发工具](https://help.aliyun.com/zh/model-studio/use-chat-client-or-development-tool/)
+- 例：[Claude Code](https://help.aliyun.com/zh/model-studio/claude-code)、[Chatbox](https://help.aliyun.com/zh/model-studio/chatbox)、[Cursor](https://help.aliyun.com/zh/model-studio/use-chat-client-or-development-tool/)
+
+通义灵码 / Qoder CN 的完整 IDE 教程不在本目录，见 #84。这里只记一句：官方说个人社区版 / 个人专业版可接入百炼，**企业版不支持**。[Qoder CN](https://help.aliyun.com/zh/model-studio/lingma-agent)
+
+## 挡住新人额度耗尽后的按量账单
+
+中国站规则见[新人免费额度](https://help.aliyun.com/zh/model-studio/new-free-quota)：
+
+1. 额度只在**北京**，有效期 **90 天**，从开通、模型发布或申请通过之日取较晚者。
+2. 只抵扣**实时推理**。不抵扣 Batch、调优、部署、自定义模型。
+3. 每个模型（含带日期的快照）额度独立。官方写各模型「通常为 100 万 Token」——以控制台该模型详情为准，不要把营销页「超 7000 万」理解成一个池子。
+4. 已认证账号：控制台打开「**免费额度用完即停**」，耗尽返回 `AllocationQuota.FreeTierOnly`，不再转按量。
+5. 未认证账号：系统强制用完即停。
+6. 账户一旦欠费，其它模型即使还有免费额度也调不了。
+
+生产环境官方不建议开「用完即停」（额度耗尽服务会停）。生产用余额预警和删 Key。
+
+Token Plan / Coding Plan 专属 Key **不消耗**这套新人免费额度。
+
+## 零代码做一个知识库问答
+
+1. 打开控制台，确认地域。
+2. 按 [0 代码构建问答应用](https://help.aliyun.com/zh/model-studio/build-knowledge-base-qa-assistant-without-coding/) 建应用并挂知识库。
+3. 新项目优先 [Agent 2.0](https://help.aliyun.com/zh/model-studio/new-single-agent-application)。官方：无旧版依赖时推荐新版。1.0 和 2.0 **不能互转**。
+4. 发布后才能用 API / 渠道。未发布的草稿调不通。
+5. 知识库和模型推理**分开计费**。知识库不支持节省计划 / 资源包。[产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+
+不要在这里展开调优、专属部署。那是另一条轴，官方入口：[模型调优](https://help.aliyun.com/zh/model-studio/model-training-overview)、[模型部署](https://help.aliyun.com/zh/model-studio/model-deployment-introduction)。
+
+## 安装百炼 CLI
+
+这是**百炼自己的**命令行（给 Agent 调多模态原子能力），不是阿里云 OpenAPI 的 `aliyun bailian`。
+
+官方安装说明：[bailian.aliyun.com/cli/install.md](https://bailian.aliyun.com/cli/install.md)
+
+```bash
+# Node.js ≥ 22.12.0，只用 npm 全局安装
+npm install -g bailian-cli
+bl --version
+
+# 本机浏览器登录（推荐）
+bl auth login --console
+
+# 最小验证
+bl auth status --output json
+bl text chat --message "ping" --non-interactive --output json
+```
+
+命令名是 `bl` 和 `bailian`。装 Skills 的官方命令是 `npx skills add modelstudioai/cli --all -g`。
+
+无法弹浏览器时：`bl auth login --api-key <用户粘贴的 Key>`。不要把 Key 写进仓库或聊天记录。
+
+全球地域开关官方写的是 `--region cn|us|intl`，默认 `cn`。

--- a/docs/zh/products/bailian/bailian-glossary.md
+++ b/docs/zh/products/bailian/bailian-glossary.md
@@ -1,0 +1,117 @@
+---
+title: 阿里云百炼术语表
+description: 百炼、千问、灵码不是同一个东西。三种协议、两套套餐、两套 CLI 也不是。
+domain: product
+tags:
+  - model-platform
+role: glossary
+---
+
+# 阿里云百炼术语表
+
+不教操作。只把容易撞车的名字拆开。选哪条路见 [学习地图](./index)。
+
+## 百炼 / Model Studio
+
+**是什么**：阿里云的大模型服务与应用开发平台。英文名 Alibaba Cloud Model Studio。提供模型调用、可视化应用、订阅套餐。[产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+
+**不是什么**：不是通义聊天窗口，不是通义灵码 IDE，不是 ECS / OSS。
+
+**为什么单独成页**：前端把 Qwen 接进自己的站点，走的是这个平台的 API 和计费，不是聊天站。
+
+## 千问 Qwen
+
+**是什么**：阿里的模型系列，也是独立的对话产品。FAQ 原句：百炼是大模型服务平台，提供包括千问系列在内的多种大模型。[FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+
+**本目录**：只把它当「百炼上可调用的模型」。对话产品正文见 #83。
+
+## 灵码 / Qoder CN
+
+**是什么**：阿里云智能编码助手 / 独立 IDE。官方现名 **Qoder CN（原 Lingma）**。[接入页](https://help.aliyun.com/zh/model-studio/lingma-agent)
+
+**和百炼的关系**：可以填百炼的 Token Plan / Coding Plan / 按量 Key。企业版官方写不支持接入百炼。
+
+**本目录**：一行。完整教程见 #84。
+
+## DashScope
+
+**是什么**：旧的模型接口品牌。环境变量仍叫 `DASHSCOPE_API_KEY`，美国主机仍出现 `dashscope-us.aliyuncs.com`，Coding Plan 页仍出现 `dashscope.aliyuncs.com`。
+
+**不是什么**：不是另一个要单独开通的「DashScope 产品教程」。对本站读者，它是百炼 API 的历史名字。
+
+## 业务空间 Workspace
+
+**是什么**：隔离项目 / 团队资源和权限的容器。新 MaaS Base URL 里的 `{WorkspaceId}` 就是它。[首次调用](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen)、[获取 API Key](https://help.aliyun.com/zh/model-studio/get-api-key)
+
+**权限规则（官方）**：
+
+- 同一空间内的 API Key 权限相同，不必按文生文 / 文生图拆 Key。
+- 默认空间：可调标准模型 + 该空间应用。
+- 子空间：只能调已授权的标准模型 + 该空间应用。
+- 调优后的模型：只用它所在空间的 Key。
+
+主账号能看所有空间的 Key；子账号只能看已加入的空间。
+
+## 三种调用协议
+
+同一模型在清单页常同时给出三条主机：
+
+| 协议 | 路径特征 | 什么时候用 |
+|------|----------|------------|
+| OpenAI 兼容 | `/compatible-mode/v1` | 已有 `openai` SDK、多数桌面客户端 |
+| Anthropic 兼容 | `/apps/anthropic` | Claude Code 等走 Messages 的工具 |
+| DashScope | `/api/v1` | 官方 DashScope SDK、部分多模态生成 |
+
+来源：[选择模型](https://help.aliyun.com/zh/model-studio/models)。三条主机**不能**互换；Coding Plan / Token Plan 还有第四套专属主机。
+
+## Token Plan vs Coding Plan
+
+都是百炼卖的订阅，**不能互相迁移或升级**。[Token Plan](https://help.aliyun.com/zh/model-studio/token-plan-overview)
+
+| | Token Plan | Coding Plan |
+|--|------------|-------------|
+| 计量 | Credits | 请求次数 |
+| 官方态度（2026-08） | 推荐新订，模型与 Harness 更多 | Lite 已停；Pro 限量 |
+| 个人 vs 团队 | 个人版有 7 天窗口；团队版按座席包月、承诺不训练 | 页上以 Pro 为主 |
+| 数据 | 个人版用于改进；团队版承诺不用 | 输入和输出都用于改进 |
+| 合法用法 | 兼容 OpenAI / Anthropic 的工具 | **仅限**编程工具，禁止当后端 API |
+
+FAQ / 国际站简介里「绝不会用你的数据训练」是简化口径。以产品简介「重要」框和两份套餐页为准。
+
+## Agent 1.0 vs 2.0
+
+| | 1.0 | 2.0 |
+|--|-----|-----|
+| 调度 | 先检索知识库，再决定是否调 MCP | 知识库和 MCP 都是工具，由模型规划顺序 |
+| 过程 | 只给最终结果 | 展示规划-执行-反思 |
+| 迁移 | — | **不能**从 1.0 升级，只能新建 |
+
+来源：[新版智能体](https://help.aliyun.com/zh/model-studio/new-single-agent-application)。无旧依赖时官方推荐 2.0。
+
+工作流是另一类可视化应用（固定节点图），不是 Agent 2.0 的别名。[工作流](https://help.aliyun.com/zh/model-studio/workflow-application/)
+
+## 知识库 RAG
+
+把私有文档检索后喂给模型。和「直接调模型」是两个计费项：知识库按规格时长 + 调用计费，不吃节省计划 / 资源包。[产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+
+降低幻觉的官方手段之一，见 FAQ「模型幻觉」。原理见 [LLM 基础](/zh/tech/fundamentals/LLM)，不要在本页展开注意力。
+
+## MCP
+
+模型上下文协议。百炼的智能体 / 工作流可挂官方 MCP 或自定义 MCP。[MCP 简介](https://help.aliyun.com/zh/model-studio/mcp-introduction)
+
+部分官方 MCP（文生图、文生视频、语音、联网搜索）会单独计费。自定义 MCP 有基础 / 极速两种时长计费。部署费用是否仍「限时免费」以该页为准。
+
+## 百炼 CLI vs 阿里云 CLI
+
+| | 百炼 CLI | 阿里云 CLI 插件 |
+|--|----------|-----------------|
+| 包 / 命令 | npm `bailian-cli`，命令 `bl` / `bailian` | `aliyun bailian ...` |
+| 用途 | 给本机 Agent 调模型与多模态原子能力 | 管类目、文件、连接器等 OpenAPI |
+| 文档 | [install.md](https://bailian.aliyun.com/cli/install.md) | [OpenAPI CLI 中心](https://next.api.aliyun.com/api-tools/cli/bailian/2023-12-29) |
+
+装错的典型症状：能 `aliyun bailian list-file`，却没有 `bl text chat`。
+
+## 高代码应用
+
+把 Python 项目部署成带运维和日志的后端服务。官方入口：[高代码应用](https://help.aliyun.com/zh/model-studio/rich-code-application/)。轴 B 偏后端平台，本站不写教程。

--- a/docs/zh/products/bailian/bailian.md
+++ b/docs/zh/products/bailian/bailian.md
@@ -1,0 +1,128 @@
+---
+title: 阿里云百炼上手
+description: 开通控制台、拿到 API Key、用 OpenAI 兼容接口发出第一条请求。模型内部机制见 Learn LLM。
+domain: product
+tags:
+  - model-platform
+role: tutorial
+---
+
+# 阿里云百炼上手
+
+> 这是一份**教程**。按顺序做完，你会在自己的机器上用百炼发出第一条模型请求。
+>
+> 查 URL / 套餐去 [速查表](./bailian-cheatsheet)。名词撞了去 [术语表](./bailian-glossary)。已经会调用、要解决具体问题去 [Cookbook](./bailian-cookbook)。
+
+目标：把百炼从「听说过千问」用成「我的 Node 服务能稳定打到一个 pin 住的模型」。
+
+注意力、分词、训练过程见 [LLM 基础](/zh/tech/fundamentals/LLM) 与 [Learn LLM](https://llm.zenheart.site/chapters/)。本页不写模型内部。
+
+## 第 0 步：确认你要的是百炼
+
+| 你要的 | 去哪 |
+|--------|------|
+| HTTP API、控制台应用、给编程工具供电 | **本页** |
+| 只和通义聊天 | 通义千问（#83），不是本教程 |
+| 阿里云出品的编码 IDE | Qoder CN / 通义灵码（#84），不是本教程 |
+
+百炼**没有**官方独立手机 App，入口是 Web 控制台。[FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+
+## 第 1 步：开通并选地域
+
+1. 用**阿里云主账号**打开 [百炼控制台](https://bailian.console.aliyun.com/)。
+2. 右上角切换地域。中国站文档列出的模型服务地域：华北 2（北京）、美国（弗吉尼亚）、国际（新加坡）、德国（法兰克福）、日本（东京）。[产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+3. 阅读并同意协议后自动开通。没有弹协议 = 这个地域已经开通。[FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio)
+4. 若提示未实名认证，先完成认证。
+
+**地域一旦选定，后面的 API Key、Base URL、模型清单、价格都不通用。** 不要用北京的 Key 打新加坡的主机。
+
+中国站的[新人免费额度](https://help.aliyun.com/zh/model-studio/new-free-quota)只在**华北 2（北京）**。国际站简介把免费额度写在**新加坡**。两站不要混抄。
+
+开通本身不收费。调用、微调、部署才计费。[产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+
+## 第 2 步：创建 API Key 并放进环境变量
+
+按 [获取 API Key](https://help.aliyun.com/zh/model-studio/get-api-key)：
+
+1. 控制台右上角选好地域 → **API Key** → **创建 API Key**。
+2. **归属业务空间**建议先用默认业务空间。
+3. **权限**建议先选「全部」。需要锁 IP / 锁模型再改「自定义」。
+4. 弹窗里的明文 Key **只出现一次**。立刻复制。关掉就看不到了。
+
+环境变量名是官方指定的 `DASHSCOPE_API_KEY`（历史品牌 DashScope，不是要你再找另一个产品）：
+
+```bash
+# macOS / zsh，把 YOUR_DASHSCOPE_API_KEY 换成真实 Key
+echo "export DASHSCOPE_API_KEY='YOUR_DASHSCOPE_API_KEY'" >> ~/.zshrc
+source ~/.zshrc
+```
+
+官方还写了 bash / Windows 的永久与临时写法，见 [获取 API Key](https://help.aliyun.com/zh/model-studio/get-api-key)。
+
+升级后新 Key 以 `sk-ws` 开头；升级前的 `sk-` 仍可用。美国（弗吉尼亚）不走这套升级。[获取 API Key](https://help.aliyun.com/zh/model-studio/get-api-key)
+
+北京 / 新加坡 / 东京 / 法兰克福的新 Base URL 还要 **业务空间 ID（WorkspaceId）**。在控制台业务空间管理页复制，稍后填进 URL。[首次调用](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen)
+
+## 第 3 步：发出第一条请求
+
+前端仓库优先用官方 Node 示例（OpenAI 兼容）。先装 SDK：
+
+```bash
+npm install openai
+```
+
+把 `{WorkspaceId}` 换成第 2 步复制的业务空间 ID。下面这段来自[首次调用千问 API](https://help.aliyun.com/zh/model-studio/first-api-call-to-qwen) 的 Node.js 示例：
+
+```js
+import OpenAI from "openai";
+
+try {
+    const openai = new OpenAI(
+        {
+            // 若没有配置环境变量，请用阿里云百炼 API Key 将下行替换为: apiKey: "sk-xxx",
+            apiKey: process.env.DASHSCOPE_API_KEY,
+            // 以下为华北 2（北京）地域的 URL。各地域不同。将 {WorkspaceId} 换成真实业务空间 ID。
+            baseURL: "https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+        }
+    );
+    const completion = await openai.chat.completions.create({
+        model: "qwen-plus",
+        messages: [
+            { role: "system", content: "You are a helpful assistant." },
+            { role: "user", content: "你是谁？" }
+        ],
+    });
+    console.log(completion.choices[0].message.content);
+} catch (error) {
+    console.log(`错误信息：${error}`);
+    console.log("请参考文档：https://help.aliyun.com/model-studio/developer-reference/error-code");
+}
+```
+
+其它地域的 OpenAI 兼容主机见 [速查表 · Base URL](./bailian-cheatsheet#base-url) 和 [选择模型](https://help.aliyun.com/zh/model-studio/models)。不要发明主机名。
+
+不会写代码时，官方指引是用 [Chatbox](https://help.aliyun.com/zh/model-studio/chatbox)，不要自己猜桌面客户端。
+
+## 第 4 步：先选档，再认具体模型 ID
+
+产品简介对千问三档的定位（不要把它理解成具体 `model` 字符串）：
+
+| 档 | 官方怎么说 | 起步建议 |
+|----|------------|----------|
+| **Max** | 效果最好，复杂、多步骤任务。简介点名最新 `qwen3.8-max` | 难任务、强工具调用 |
+| **Plus** | 效果、速度、成本均衡，**多数场景推荐** | **第一条请求用官方示例的 `qwen-plus`** |
+| **Flash** | 高性价比、低延迟，简单且要快的任务 | 高 QPS、短回复 |
+
+来源：[产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio)。
+
+具体能用的 ID、各地域是否上架、三种协议的 Base URL，只认 [选择模型](https://help.aliyun.com/zh/model-studio/models)。那一页更新很快，本教程不抄全表。
+
+套餐还有**字符串白名单**。Coding Plan 官方写：必须逐字符完全匹配，禁止做版本兼容推理。[Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan)
+
+## 第 5 步：先挡住意外扣费，再继续玩
+
+认证用户的免费额度用完后会**自动转按量**。新用户应打开「免费额度用完即停」。只对北京、且在免费额度有效期内。[新人免费额度](https://help.aliyun.com/zh/model-studio/new-free-quota)
+
+不想再产生调用：到该地域的 API Key 页**删除 Key**。百炼没有「自动扣费开关」。[产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+
+下一步按场景走 [Cookbook](./bailian-cookbook)。

--- a/docs/zh/products/bailian/index.md
+++ b/docs/zh/products/bailian/index.md
@@ -1,0 +1,96 @@
+---
+title: 阿里云百炼学习地图
+description: 百炼是模型与应用平台，不是聊天 App，也不是 IDE。先分清「调 API / 订套餐 / 搭应用」，再进教程。
+domain: product
+tags:
+  - model-platform
+role: map
+---
+
+# 阿里云百炼学习地图
+
+> **阿里云百炼**（Alibaba Cloud Model Studio）是一站式大模型开发与应用平台：开发者走兼容 OpenAI 的 API，业务人员在控制台搭智能体和知识库问答。[产品简介](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+>
+> 本页只回答「我要做什么 → 用百炼的哪一块」。操作进 [教程](./bailian)，查表进 [速查](./bailian-cheatsheet)，撞名进 [术语表](./bailian-glossary)。
+>
+> 模型内部机制不在这里写，见 [LLM 基础](/zh/tech/fundamentals/LLM) 与 [Learn LLM](https://llm.zenheart.site/chapters/)。
+
+## 产品全景图
+
+```
+阿里云 AI（本站这一目录只写百炼）
+├── 大模型服务平台百炼（本目录）
+│   ├── 控制台 / 模型体验
+│   ├── 模型 API（OpenAI 兼容 / Anthropic 兼容 / DashScope）
+│   ├── Token Plan / Coding Plan
+│   ├── 智能体 / 工作流 / 知识库 / MCP
+│   ├── 百炼 CLI（命令 bl / bailian）
+│   └── 调优 / 部署 / 评测（地图一行，不写操作）
+├── 通义千问 — 对话产品，另 issue #83，本目录不写教程
+├── 通义灵码 / Qoder CN（原 Lingma） — IDE，另 issue #84，本目录不写教程
+└── 非本站：ECS / OSS / PAI / DashVector / 析言 GBI / 全妙
+```
+
+| 官方一级入口 | 本站去向 |
+|--------------|----------|
+| 产品简介、首次 API、模型体验 | [教程](./bailian) |
+| 选择模型、计费、Token Plan、Coding Plan、地域 | [速查表](./bailian-cheatsheet) |
+| 接入客户端/开发工具、免费额度用完即停、百炼 CLI、控制台问答 | [Cookbook](./bailian-cookbook) |
+| 智能体 1.0 / 2.0、Workspace、三种协议、两套套餐 | [术语表](./bailian-glossary) |
+| 调优 / 部署 / 评测 | 官方页；本站不拆教程 |
+| 通义千问 | 地图一行，正文见 #83 |
+| 通义灵码 / Qoder CN（原 Lingma） | 地图一行，正文见 #84 |
+| ECS / OSS / PAI / 析言 GBI / 全妙 | **非本站** |
+
+### 快速决策：我该用哪个？
+
+```
+我要做什么？
+├── 在自己的前端 / Node 服务里调 Qwen 或第三方模型
+│   └── → 百炼 API（OpenAI 兼容最省事）→ [教程](./bailian)
+├── 在 Claude Code / Cursor / Chatbox 里用阿里云的模型额度
+│   └── → Token Plan（官方推荐新订）或 Coding Plan
+│       └── Key 和 Base URL 必须成对，见 [Cookbook](./bailian-cookbook)
+├── 不想写代码，先做一个知识库问答 / 智能体
+│   └── → 控制台应用（优先 Agent 2.0）
+├── 让本机 Agent 调图像 / 视频 / 语音等原子能力
+│   └── → 百炼 CLI（`bl`）
+├── 只是和通义聊天，不接 API、不搭应用
+│   └── → 通义千问（#83），不是百炼
+├── 要一个阿里云出品的编码 IDE
+│   └── → Qoder CN / 通义灵码（#84），不是百炼
+└── 买云主机 / 对象存储
+    └── → 非本站。本目录不写 ECS / OSS
+```
+
+三个最容易付的税：
+
+| 容易混的 | 区别 |
+|---------|------|
+| **百炼** vs **千问** | 百炼是平台（API + 控制台 + 套餐）。千问是模型，也是独立对话产品。[FAQ](https://help.aliyun.com/zh/model-studio/faq-about-alibaba-cloud-model-studio) |
+| **百炼** vs **灵码 / Qoder CN** | 灵码已改名为 Qoder CN，是 IDE；可以*接入*百炼的 Key，本身不是百炼。[官方接入页](https://help.aliyun.com/zh/model-studio/lingma-agent) |
+| **按量 Key** vs **套餐 Key** | 按量是 `sk-` / `sk-ws`；Coding Plan / Token Plan 专属是 `sk-sp-`。配错主机要么报 `invalid_api_key`，要么**悄悄按量扣费**。[Coding Plan](https://help.aliyun.com/zh/model-studio/coding-plan) |
+
+## 该读哪一篇
+
+| 文档 | 类型 | 什么时候看 |
+|------|------|-----------|
+| [上手教程](./bailian) | Tutorial | 第一次：开通 → Key → 第一次 Node 调用 |
+| [实战 Cookbook](./bailian-cookbook) | How-to | 已经会调用，要解决混用、扣费、CLI、无代码应用 |
+| [Cheatsheet](./bailian-cheatsheet) | Reference | 查地域、URL、套餐对照、官方链接 |
+| [术语表](./bailian-glossary) | Explanation | 名词撞了，或两份官方页口径不一致 |
+
+## 建议学习顺序
+
+1. **先读本页决策树**，确认你要的是平台而不是千问/灵码。
+2. **跟 [教程](./bailian) 走一遍**：主账号开通、建 Key、环境变量、发一条 `qwen-plus`。
+3. 要把模型接进产品，翻 [Cookbook · OpenAI 兼容](./bailian-cookbook)。要把额度接到编程工具，翻 [Cookbook · 不要混用 Key](./bailian-cookbook)。
+4. 查参数只认 [速查表](./bailian-cheatsheet) 和官方模型清单。模型名过期极快，**不要在笔记里写死全表**。
+
+## 官方资源
+
+- [产品页](https://www.aliyun.com/product/bailian)
+- [什么是阿里云百炼](https://help.aliyun.com/zh/model-studio/what-is-model-studio)
+- [选择模型](https://help.aliyun.com/zh/model-studio/models)
+- [国际站 Model Studio](https://www.alibabacloud.com/help/en/model-studio/)
+- [控制台](https://bailian.console.aliyun.com/)


### PR DESCRIPTION
Closes #85

## 做了什么

按 `doc-research` 先 Retrieve 官方一级导航，再写 Diataxis 手册。形态调研写在 `.claude/skills/doc-research/references/bailian.md`，然后才动正文。

中英同构：

- `docs/zh/products/bailian/`
- `docs/products/bailian/`

文件：`index`（地图）/ `bailian`（Tutorial）/ `bailian-cookbook` / `bailian-cheatsheet` / `bailian-glossary`。

侧栏挂到 `docs/.vitepress/sidebars/ai-coding.mjs`（地图 / 核心 / 参考三组）。**没有改 `products-gallery.js`**（本轮任务硬约束）。

## 家族图

官方 Model Studio 一级入口都有去向：

| 入口 | 本站 |
|------|------|
| 产品简介、首次 API、模型体验 | Tutorial |
| 模型清单、计费、Token Plan、Coding Plan、地域 | Cheatsheet |
| 接入客户端、免费额度用完即停、百炼 CLI、无代码问答 | Cookbook |
| Agent 1.0/2.0、Workspace、三种协议、两套套餐 | Glossary |
| 调优 / 部署 / 评测 | 地图一行，不写操作 |
| 通义千问 | 地图一行，#83 |
| 通义灵码 / Qoder CN（原 Lingma） | 地图一行，#84 |
| ECS / OSS / PAI / 析言 GBI / 全妙 | 非本站 |

## 反杜撰

- 命令、Key 前缀、Base URL、套餐数字都能在 2026-08-19 打开的官方页找到原文。
- 模型全表和单价不抄，只链官方清单 / 价格页。
- 两份官方页打架已写清取舍：数据是否用于训练以产品简介「重要」+ 套餐页为准；美国 Base URL 以模型清单为准；按量新主机以首次调用 / 模型清单为准。
- 没有灵码 / 千问完整教程，没有 ECS/OSS 教程。

## 构建

`pnpm docs:build` 已通过。