### PR TITLE
docs(zhipu-chat): add Zhipu chat handbook for #74

### DIFF
--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -6,11 +6,12 @@
 
 | 工具 | 文件 | 读者文档 |
 |------|------|----------|
-| Claude | [`claude-code.md`](./claude-code.md) | `docs/zh/products/ai-coding/claude/` |
-| Codex | [`codex.md`](./codex.md) | `docs/zh/products/ai-coding/codex/` |
-| Cursor | [`cursor.md`](./cursor.md) | `docs/zh/products/ai-coding/cursor/` |
-| Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
-| Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
-| Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| Claude | [`claude-code.md`](./claude-code.md) | `docs/zh/products/claude/` |
+| Codex | [`codex.md`](./codex.md) | `docs/zh/products/codex/` |
+| Cursor | [`cursor.md`](./cursor.md) | `docs/zh/products/cursor/` |
+| Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/gemini/` |
+| Grok | [`grok.md`](./grok.md) | `docs/zh/products/grok/` |
+| Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/copilot/` |
+| 智谱清言 / Z.ai 对话 | [`zhipu-chat.md`](./zhipu-chat.md) | `docs/zh/products/zhipu-chat/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/.claude/skills/doc-research/references/zhipu-chat.md
+++ b/.claude/skills/doc-research/references/zhipu-chat.md
@@ -1,0 +1,134 @@
+# 智谱清言 / Z.ai 对话 维护参考
+
+> 通用维护流程见 [`maintenance-workflow.md`](./maintenance-workflow.md)；高质量数据源清单发布在 `docs/zh/products/zhipu-chat/zhipu-chat-cheatsheet.md` 的「高质量信息源」。文档架构见 [`documentation-architecture.md`](./documentation-architecture.md)。
+
+## 产品形态调研结论（写教程前必须先有这一节）
+
+调研时间：2026-08-19。以下每条都来自一手官方来源，来源标在括号里。
+
+**结论一：本目录只收消费端对话，不写 GLM Coding Plan 安装主教程。**
+
+- 国内对话产品名是 **智谱清言**，入口 [chatglm.cn](https://chatglm.cn)。首页 description 原文：「基于 GLM 大模型，不只是 AI 助手，更是能帮你把事办成的 Agent。」
+- 国际对话产品名是 **Z.ai**，入口 [chat.z.ai](https://chat.z.ai) / [z.ai](https://z.ai)。页面 title 原文：「Z.ai - Advanced AI Chatbot & Agent powered by GLM-5.2」。
+- 官方把这两处并列为「在线体验」，不是同一张安装教程（[zhipuai.cn/zh/research/161](https://www.zhipuai.cn/zh/research/161) 原文：「Z.ai：https://chat.z.ai」「智谱清言 App/网页版：https://chatglm.cn」）。
+- **GLM Coding Plan** 是另一条产品线（[z.ai/subscribe](https://z.ai/subscribe)、[bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding)），给 Claude Code / Cline 等编码工具配 GLM 额度。本站只在家族图占一行，正文不写套餐安装。另 issue #75。
+
+**结论二：适合当 Claude.ai 的对位页，不是仓库 Agent。**
+
+- 清言形态：浏览器网页 + 官方 App（[chatglm.cn/download](https://chatglm.cn/download) description：「智谱清言是基于 GLM-5 的全能 AI 助手，支持精通对话、写作与编程……更能理解图片与文档」；另一条 download 文案：「搭载 GLM-5 Agentic 基座模型，可以对话聊天、也可以调用工具执行复杂任务」）。
+- 还有官方浏览器插件「智谱清言：ChatGLM & AutoGLM」（[Chrome Web Store](https://chromewebstore.google.com/detail/%E6%99%BA%E8%B0%B1%E6%B8%85%E8%A8%80%EF%BC%9Achatglm-autoglm-%E5%B7%A5%E4%BD%9C%E5%AD%A6%E4%B9%A0/mnpdbmgpebfihcndnpgdaihnkmloclkd)）。
+- 对前端工程师：用来调研、写作、看图/文档、对话里写代码片段。真要改 checkout，去 Coding Plan / ZCode / 别的 CLI，不要把清言写成 Claude Code。
+
+**结论三：厂商一级 AI 产品比「清言」多，家族图必须一行收齐，本目录不展开。**
+
+[zhipuai.cn/zh](https://www.zhipuai.cn/zh) 页脚「产品」与「原生产品」列出：
+
+| 官方一级入口 | 官方 URL（2026-08-19 核实） | 本站去向 |
+|--------------|------------------------------|----------|
+| 智谱清言 | https://chatglm.cn | **独立页**（本目录 Tutorial） |
+| Z.ai（对话） | https://chat.z.ai 、 https://z.ai | **独立页**（与清言同一 Tutorial，国际面） |
+| GLM Coding Plan | https://z.ai/subscribe 、 https://bigmodel.cn/glm-coding | 地图一行（#75） |
+| AutoClaw / AutoGLM | https://autoglm.zhipuai.cn | 地图一行 |
+| ZCode | https://zcode.z.ai/cn （[research/161](https://www.zhipuai.cn/zh/research/161)） | 地图一行 |
+| BigModel / 开放平台 | https://bigmodel.cn 、 https://docs.bigmodel.cn | 地图一行（API，不是聊天手册） |
+| Z.ai 开发者文档 | https://docs.z.ai | 地图一行（API） |
+| Zread.ai | 公司页「原生产品」列出；独立 URL 未在本次抓页确认 | 地图一行，链公司页 |
+| AMiner | 公司页列出；页脚邮箱域 `aminer.cn` | 地图一行，链公司页 |
+| 智谱学习中心 | 公司页轮播列出 | 地图一行，链公司页 |
+| 智谱 AI 输入法 | 公司页轮播列出 | 地图一行，链公司页 |
+| CodeGeeX | 官方新闻「端侧智谱清言和 CodeGeeX」（[zhipuai.cn news](https://www.zhipuai.cn/en/news/20)） | 地图一行 |
+| 开源 GLM 权重 | https://github.com/zai-org/GLM-5 （[research/161](https://www.zhipuai.cn/zh/research/161)） | 地图一行 |
+| 商业生态 / 投资者关系 / 加入我们 | 公司页导航 | **非本站** |
+
+**结论四：两套站点、两套法律主体，不要写成一口账号池。**
+
+- 清言付费协议（[chatglm.cn/pay/policy/vipservice](https://chatglm.cn/pay/policy/vipservice)，生效 2026-05-21）把「智谱清言」定义为北京智谱华章科技有限公司经营的生成式人工智能产品；会员在 **chatglm.cn 网站、智谱清言 App** 内使用；权益只进购买时登录的那个账号；与「智谱旗下其他产品（包括但不限于智谱 AI 开放平台）」付费独立、可叠加。
+- Z.ai Terms（[docs.z.ai/legal-agreement/terms-of-use](https://docs.z.ai/legal-agreement/terms-of-use)，Last Update April 14, 2026）签约方是 **JINGSHENG HENGXING TECHNOLOGY PTE.LTD**；定义里的 Z.ai 是该公司运营的平台（含 API）。
+- 官方没有写「一个登录打通清言和 chat.z.ai」。教程必须把它们当两个入口，禁止写成同一订阅。
+
+**结论五：清言没有独立用户文档树；事实源是产品页 + 协议 + 商店页。**
+
+- `docs.z.ai` / `docs.bigmodel.cn` 是开发者 API 站，不是清言 How-to。
+- 清言首页可见能力芯片（2026-08-19）：**Agent / 研究报告 / PPT制作 / 数据分析**，模型名 **GLM-5.2**、**GLM-5.2快速**。
+- 付费协议 1.6 / 4.1 列出的权益种类：各模型相关权益、各类型 Agent 权益、清影生视频、视频通话、更大的云知识库空间、更多 AI 画图功能。**具体额度以会员权益页面为准**，禁止把三方博客的「每日 50 次」写进正文。
+- App Store 官方介绍（[id6450893458](https://apps.apple.com/cn/app/id6450893458)）按场景列了通用问答 / 媒体写作 / 写作 / 学习 / 职场 / 编程 / 教育 / 虚拟对话 / 论文 / 公文 / 生活。内购档位会变，正文只链商店页，不把某一天的 ¥ 价写成现行价目表。
+
+**结论六：Z.ai 对话页是 SPA，抓页几乎只有 title/description；能力以官方营销句和 blog 为准。**
+
+- [z.ai](https://z.ai) / [chat.z.ai](https://chat.z.ai) description：「Meet Z.ai, the AI assistant powered by GLM-5.2. Build websites, write code, handle long-horizon tasks, and get instant answers.」
+- 公开 UI 芯片（2026-08-19）：**Magic Design / Full-Stack / Write Code**。
+- [z.ai/blog/glm-4.5](https://z.ai/blog/glm-4.5) 原文：在 Z.ai 选模型即可聊天；平台支持 artifacts、presentation slide、full-stack development。
+- [z.ai/blog/glm-5.2](https://z.ai/blog/glm-5.2) 原文：「Chat with GLM-5.2 on Z.ai」。同一篇把 Coding Plan / ZCode 写成另一条「Use GLM-5.2 with GLM Coding Plan」路径。
+
+**结论七：文件密度不够五文件同构。**
+
+没有官方 CLI、没有清言 How-to 文档树。本站采用 4 文件：`index` + Tutorial + cheatsheet + glossary。**不写 cookbook**（没有可引用的官方配方密度）。不写 Coding Plan 安装。
+
+## 基本信息
+
+- 工具名：智谱清言（国内）/ Z.ai Chat（国际）
+- 厂商：智谱（Zhipu / Z.ai）。公司站 <https://www.zhipuai.cn/>
+- 官方对话入口：<https://chatglm.cn>、<https://chat.z.ai>
+- 发版节奏：消费端模型名随官方公告换（调研时清言与 Z.ai 页面均写 GLM-5.2）。不要写死「当前只有 GLM-5.2」。
+- 当前覆盖：2026-08-19 抓到的产品页、付费协议、App Store、公司页、GLM-5.2 研究页 / blog。
+
+易撞名：
+
+- **智谱清言 ≠ Z.ai 对话**（国内 vs 国际入口；法律主体不同）。
+- **ChatGLM** 既是历史对话模型名，也出现在清言商店文案里，不等于现在的产品 URL。
+- **Z.ai 对话 ≠ Z.ai API ≠ GLM Coding Plan ≠ ZCode**。
+- **AutoGLM ≠ AutoClaw**（公司页两者都列；AutoClaw 是本地 OpenClaw 客户端营销名）。
+- **对话里写代码 ≠ 仓库 Agent**。
+
+## 官方一级导航（产品家族）
+
+见上文结论三。排轴：本目录主路径是清言 / Z.ai 对话；其余官方 AI 入口全部地图一行。
+
+## 文档文件结构（Diataxis）
+
+```
+docs/zh/products/zhipu-chat/
+├── index.md                    # 🗺️ 学习地图 + 家族图
+├── zhipu-chat.md               # 📘 Tutorial — 两个对话入口怎么用
+├── zhipu-chat-cheatsheet.md    # 📐 Reference — 决策表、入口、信息源
+└── zhipu-chat-glossary.md      # 📖 Explanation — 撞名与「不是什么」
+
+docs/products/zhipu-chat/       # 英文同构
+```
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 | 家族决策树、一行收齐官方一级 AI | 操作步骤、Coding Plan 安装 |
+| `zhipu-chat.md` | Tutorial | 清言 / Z.ai 入口、能做什么、账号边界 | 参数清单、臆造额度 |
+| `zhipu-chat-cheatsheet.md` | Reference | 决策表、官方 URL、数据源 | 概念长文、学习路径 |
+| `zhipu-chat-glossary.md` | Explanation | 是什么 / 不是什么 | 操作步骤 |
+
+无 cookbook。轴 A：先分清产品名。轴 B：前端工程师先打开网页对话，再决定要不要跳到 Coding Plan。
+
+## 监控页面
+
+- 清言产品：<https://chatglm.cn>
+- 清言下载：<https://chatglm.cn/download>
+- 清言付费协议：<https://chatglm.cn/pay/policy/vipservice>
+- Z.ai 对话：<https://chat.z.ai>
+- Z.ai 营销 / 顶栏：<https://z.ai>
+- 公司一级产品：<https://www.zhipuai.cn/zh>
+- 模型在线体验声明：<https://www.zhipuai.cn/zh/research/161>
+- Z.ai API 文档：<https://docs.z.ai>
+- 国内开放平台文档：<https://docs.bigmodel.cn>
+- Coding Plan（只监控，不写教程）：<https://z.ai/subscribe>、<https://bigmodel.cn/glm-coding>
+
+## Git 提交 scope
+
+```
+docs(zhipu-chat): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+1. **`chatglm.cn` / `chat.z.ai` 是 SPA**。无头抓页经常只剩 title。能力以 description、可见芯片、官方 blog / 研究页、付费协议为准，不要用三方评测补功能表。
+2. **`www.zhipuai.cn` 在部分环境会解析到私网地址**，命令行 GET 可能失败。改用页面阅读器。
+3. **禁止把 App Store 某一天的内购价抄成「现行会员价」**。协议写明价格和权益会改，以会员页为准。
+4. **禁止把 `docs.z.ai` 的 API 模型表当成清言聊天里一定能选到的模型。**
+5. **本 issue 禁止改 `products-gallery.js`。** 侧栏可挂 `sidebars/ai-coding.mjs`。不要改其它厂商目录。
+6. **公司页轮播里的「智谱学习中心 / 智谱 AI 输入法 / Zread.ai / AMiner」** 本次未抓到独立产品文档。地图一行链公司页，不要编造二级 URL。

--- a/docs/.vitepress/sidebars/ai-coding.mjs
+++ b/docs/.vitepress/sidebars/ai-coding.mjs
@@ -192,6 +192,26 @@ export const enAiCodingItems = [
                                     },
                                  ]
                               },
+                              {
+                                 text: 'Zhipu Chat', link: '/products/zhipu-chat/', items: [
+                                    { text: '🗺️ Learning Map', link: '/products/zhipu-chat/' },
+                                    {
+                                       text: 'Core',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Qingyan / Z.ai Chat', link: '/products/zhipu-chat/zhipu-chat' },
+                                       ]
+                                    },
+                                    {
+                                       text: 'Reference',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Cheatsheet', link: '/products/zhipu-chat/zhipu-chat-cheatsheet' },
+                                          { text: 'Glossary', link: '/products/zhipu-chat/zhipu-chat-glossary' },
+                                       ]
+                                    },
+                                 ]
+                              },
                               { text: 'Pi Agent', link: '/products/ai-coding/pi-agent' },
                               { text: 'Other Tools', link: '/products/ai-coding/othertools' },
 ]
@@ -378,6 +398,26 @@ export const zhAiCodingItems = [
                                        items: [
                                           { text: '速查表', link: '/zh/products/ai-coding/grok/grok-cheatsheet' },
                                           { text: '术语表', link: '/zh/products/ai-coding/grok/grok-glossary' },
+                                       ]
+                                    },
+                                 ]
+                              },
+                              {
+                                 text: '智谱清言 / Z.ai', link: '/zh/products/zhipu-chat/', items: [
+                                    { text: '🗺️ 学习地图', link: '/zh/products/zhipu-chat/' },
+                                    {
+                                       text: '核心产品',
+                                       collapsed: false,
+                                       items: [
+                                          { text: '清言 / Z.ai 对话', link: '/zh/products/zhipu-chat/zhipu-chat' },
+                                       ]
+                                    },
+                                    {
+                                       text: '速查与参考',
+                                       collapsed: false,
+                                       items: [
+                                          { text: '速查表', link: '/zh/products/zhipu-chat/zhipu-chat-cheatsheet' },
+                                          { text: '术语表', link: '/zh/products/zhipu-chat/zhipu-chat-glossary' },
                                        ]
                                     },
                                  ]

--- a/docs/products/zhipu-chat/index.md
+++ b/docs/products/zhipu-chat/index.md
@@ -1,0 +1,112 @@
+---
+title: Zhipu Qingyan / Z.ai learning map
+description: "Audience: frontend engineers picking a Zhipu chat surface. The path here is Qingyan and Z.ai chat, not GLM Coding Plan."
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# Zhipu Qingyan / Z.ai learning map
+
+> **Zhipu Qingyan** (智谱清言) is Zhipu's China chat assistant. Official line ([chatglm.cn](https://chatglm.cn)):
+> it is based on GLM models, "not just an AI assistant, but an Agent that gets things done."
+>
+> **Z.ai** is the international chat surface. Official title ([chat.z.ai](https://chat.z.ai)):
+> "Z.ai - Advanced AI Chatbot & Agent powered by GLM-5.2"
+>
+> This directory is the Claude.ai analog. It is **not** GLM Coding Plan and not ZCode / AutoClaw. The coding subscription is one row on the map.
+
+## Goals and non-goals
+
+**Audience:** frontend engineers who need the right official door. You need a browser or the Qingyan app, not a repo.
+
+**Goals:** list official first-party AI surfaces and get you into Qingyan / Z.ai chat.
+
+**Non-goals:** Coding Plan install, API quickstart, model internals (see [Learn LLM](/tech/fundamentals/LLM)), invented daily quotas or RMB prices.
+
+## Product landscape
+
+Zhipu (company site [zhipuai.cn](https://www.zhipuai.cn/zh)) ships more than one AI skin. They are **not** the same chat window.
+
+```
+Zhipu / Z.ai
+├── Chat (this directory)
+│   ├── Qingyan — chatglm.cn and the official app
+│   └── Z.ai — chat.z.ai / z.ai
+├── Coding subscription / desktop coding
+│   ├── GLM Coding Plan — quota for Claude Code and similar tools
+│   └── ZCode — official coding tool
+├── Agent / office
+│   ├── AutoGLM
+│   └── AutoClaw (local OpenClaw client)
+├── Open platform / API
+│   ├── BigModel (bigmodel.cn)
+│   └── docs.z.ai
+└── Other official AI entries (one map row each)
+    ├── Zread.ai
+    ├── AMiner
+    ├── Zhipu Learning Center
+    ├── Zhipu AI IME
+    ├── CodeGeeX
+    └── Open GLM weights
+```
+
+| Product | What it is | Entry | This site |
+|---------|------------|-------|-----------|
+| **Qingyan** | China chat / agent assistant | [chatglm.cn](https://chatglm.cn) | [Tutorial](./zhipu-chat.md) |
+| **Z.ai chat** | International chat / agent assistant | [chat.z.ai](https://chat.z.ai) | Same tutorial |
+| **GLM Coding Plan** | Coding-tool subscription, not a chat install | [z.ai/subscribe](https://z.ai/subscribe), [bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding) | One map row (#75) |
+| **ZCode** | Official coding tool | [zcode.z.ai/cn](https://zcode.z.ai/cn) | One map row |
+| **AutoGLM / AutoClaw** | Reports / browser agent / local client | [autoglm.zhipuai.cn](https://autoglm.zhipuai.cn) | One map row |
+| **BigModel / Z.ai API** | Model HTTP APIs | [bigmodel.cn](https://bigmodel.cn), [docs.z.ai](https://docs.z.ai) | One map row |
+| **Zread.ai / AMiner / Learning Center / AI IME** | Named on the company product rail | [zhipuai.cn/zh](https://www.zhipuai.cn/zh) | One map row; use the company page for URLs |
+| **CodeGeeX** | Coding assistant (official news) | [company news](https://www.zhipuai.cn/en/news/20) | One map row |
+| **Open GLM** | Model weights | [github.com/zai-org/GLM-5](https://github.com/zai-org/GLM-5) | One map row |
+| Business / IR / jobs | Not an AI handbook | Company site | **Out of scope** |
+
+Official "try it online" copy ([GLM-5.2 research post](https://www.zhipuai.cn/zh/research/161)): **Z.ai = chat.z.ai**, **Qingyan app/web = chatglm.cn**.
+
+**Name collisions:**
+
+- **Qingyan ≠ Z.ai chat.** Two doors, two legal entities. No official "one login".
+- **ChatGLM** is a historical model / store-copy name, not the URL you type.
+- **In-chat code ≠ GLM Coding Plan.** The latter is quota for Claude Code and similar tools. See #75.
+- **AutoGLM ≠ AutoClaw.** The company page lists both.
+
+Details: [glossary](./zhipu-chat-glossary.md).
+
+### Quick decision
+
+```
+What do you need?
+├── Chat / write / read images or docs / slides or research reports
+│   ├── China product surface → Qingyan (chatglm.cn or the official app)
+│   └── International Z.ai surface → chat.z.ai
+├── GLM quota inside Claude Code / Cline / similar
+│   └── → GLM Coding Plan (not documented here)
+├── Official desktop coding tool
+│   └── → ZCode
+├── Reports / browser automation / local OpenClaw client
+│   └── → AutoGLM / AutoClaw
+└── Call the model from your own software
+    └── → BigModel or docs.z.ai API
+```
+
+## Learning path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Pick the door | Decision tree above | Do not open Coding Plan as if it were Qingyan |
+| 2. Use chat | [Qingyan / Z.ai tutorial](./zhipu-chat.md) | Sign in, send the first message, recognize the chips |
+| 3. Look up URLs | [Cheatsheet](./zhipu-chat-cheatsheet.md) | Entries, decisions, sources |
+| 4. Names collide | [Glossary](./zhipu-chat-glossary.md) | Qingyan / Z.ai / ChatGLM / Coding Plan |
+
+No cookbook: there is no official how-to tree dense enough to split.
+
+## Related pages
+
+- [Qingyan / Z.ai tutorial](./zhipu-chat.md)
+- [Cheatsheet](./zhipu-chat-cheatsheet.md)
+- [Glossary](./zhipu-chat-glossary.md)
+- [All products](../index.md)

--- a/docs/products/zhipu-chat/zhipu-chat-cheatsheet.md
+++ b/docs/products/zhipu-chat/zhipu-chat-cheatsheet.md
@@ -1,0 +1,123 @@
+---
+title: Qingyan / Z.ai cheatsheet
+description: Lookup only. Doors, decisions, official links. Quotas and prices come from the signed-in official page.
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# Qingyan / Z.ai cheatsheet
+
+Lookup only. Numbers and SKUs come from the signed-in official page. Last verified: 2026-08-19.
+
+## Which door
+
+| Job | Open | Do not open |
+|-----|------|-------------|
+| China web chat | [chatglm.cn](https://chatglm.cn) | Coding Plan subscribe |
+| Official app | [chatglm.cn/download](https://chatglm.cn/download) or [App Store](https://apps.apple.com/cn/app/id6450893458) | Unofficial "Qingyan" APK mirrors |
+| International web chat | [chat.z.ai](https://chat.z.ai) | `docs.z.ai` (API) |
+| GLM inside Claude Code etc. | [z.ai/subscribe](https://z.ai/subscribe) or [bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding) | Qingyan membership |
+| HTTP API | [docs.z.ai](https://docs.z.ai) or [docs.bigmodel.cn](https://docs.bigmodel.cn) | The chat box as an SDK |
+| Whole family | [zhipuai.cn/zh](https://www.zhipuai.cn/zh) | Third-party directories |
+
+Term hooks (one line; [glossary](./zhipu-chat-glossary.md) has the rest):
+
+| Term | Hook |
+|------|------|
+| Qingyan | China chat product |
+| Z.ai chat | International chat product |
+| ChatGLM | Historical model / store copy, not the URL |
+| GLM Coding Plan | Coding-tool quota, not a Qingyan install |
+| AutoGLM / AutoClaw | A different agent / client skin |
+| ZCode | Official coding tool |
+
+## Qingyan homepage chips (2026-08-19)
+
+Source: [chatglm.cn](https://chatglm.cn)
+
+| Chip | Note |
+|------|------|
+| Agent | Homepage positioning |
+| Research report | Official entry |
+| Slides | Official entry |
+| Data analysis | Official entry |
+| GLM-5.2 | Model name on the page |
+| GLM-5.2 Fast | Model name on the page |
+
+The download page also names chat / writing / coding / image and document understanding / tool use. The paid agreement also names Qingying video, video calls, cloud knowledge base, and AI images. **This table is not "every free account has every chip."**
+
+## Z.ai chips (2026-08-19)
+
+Source: [chat.z.ai](https://chat.z.ai) description + visible chips; [glm-4.5 blog](https://z.ai/blog/glm-4.5)
+
+| Chip / claim | Note |
+|--------------|------|
+| Magic Design | Page chip |
+| Full-Stack | Page chip |
+| Write Code | Page chip |
+| artifacts / slides / full-stack | Blog wording for the chat surface |
+
+## Account rules (Qingyan agreement)
+
+Source: [paid-service agreement](https://chatglm.cn/pay/policy/vipservice) (2026-05-21)
+
+| Question | Answer |
+|----------|--------|
+| Which account holds benefits | The one you were signed into when you bought |
+| Move to another Qingyan account | No (§3.2.2) |
+| Same pot as BigModel | No; can stack; no refund for overlap (§4.4) |
+| Is the price frozen | No; trust the service page (§4.7) |
+| Default refund | No; duplicate charge / official outage → support (§4.8.1) |
+
+Z.ai terms: [Terms of Use](https://docs.z.ai/legal-agreement/terms-of-use). Do not fill China Qingyan prices from that page.
+
+## High-quality sources
+
+Last verified: 2026-08-19. Official pages we actually opened.
+
+### First-party
+
+| Source | Use |
+|--------|-----|
+| [chatglm.cn](https://chatglm.cn) | Qingyan product, homepage chips |
+| [chatglm.cn/download](https://chatglm.cn/download) | Client copy |
+| [chatglm.cn/pay/policy/vipservice](https://chatglm.cn/pay/policy/vipservice) | Membership / credits / accounts |
+| [chatglm.cn/agreement](https://chatglm.cn/agreement) | User agreement |
+| [chatglm.cn/privacypolicy](https://chatglm.cn/privacypolicy) | Privacy |
+| [chat.z.ai](https://chat.z.ai) | Z.ai chat |
+| [z.ai](https://z.ai) | International top nav |
+| [z.ai/company](https://z.ai/company) | Timeline, Chat / API / Coding Plan |
+| [z.ai/blog/glm-5.2](https://z.ai/blog/glm-5.2) | Chat door vs Coding Plan door |
+| [zhipuai.cn/zh](https://www.zhipuai.cn/zh) | First-party family |
+| [zhipuai.cn/zh/research/161](https://www.zhipuai.cn/zh/research/161) | Official pair of "try it online" URLs |
+| [docs.z.ai](https://docs.z.ai) | API docs |
+| [docs.bigmodel.cn/cn/guide/start/introduction](https://docs.bigmodel.cn/cn/guide/start/introduction) | China open-platform intro |
+| [App Store Qingyan](https://apps.apple.com/cn/app/id6450893458) | Official app copy and IAP list |
+
+### Monitor only (not this handbook)
+
+| Source | Use |
+|--------|-----|
+| [z.ai/subscribe](https://z.ai/subscribe) | GLM Coding Plan (#75) |
+| [bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding) | China Coding Plan |
+| [zcode.z.ai/cn](https://zcode.z.ai/cn) | ZCode |
+| [autoglm.zhipuai.cn](https://autoglm.zhipuai.cn) | AutoGLM / AutoClaw |
+| [github.com/zai-org/GLM-5](https://github.com/zai-org/GLM-5) | Open weights |
+
+### Unverified
+
+| Item | Why |
+|------|-----|
+| Standalone URLs for Learning Center / AI IME / Zread.ai / AMiner | Named on the company page; no independent doc page opened this pass |
+| Whether a Qingyan WeChat mini program is still a first-class door | Third-party copies only; download-page fetch had no body list |
+| Shared login between Qingyan and Z.ai | Official pages do not say |
+
+**Access note (2026-08-19):** `chatglm.cn` / `chat.z.ai` are SPAs; headless fetches often return title only. `www.zhipuai.cn` can resolve to a private address on some networks. Use a browser or page reader.
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./zhipu-chat.md)
+- [Glossary](./zhipu-chat-glossary.md)

--- a/docs/products/zhipu-chat/zhipu-chat-glossary.md
+++ b/docs/products/zhipu-chat/zhipu-chat-glossary.md
@@ -1,0 +1,66 @@
+---
+title: Qingyan / Z.ai glossary
+description: No procedures. Why Qingyan, Z.ai, ChatGLM, and Coding Plan are not the same thing.
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# Qingyan / Z.ai glossary
+
+No procedures. Why the names collide. Pick a door on the [learning map](./index.md).
+
+## Things that say Zhipu / GLM / Z.ai
+
+| Name | What it is | What it is not |
+|------|------------|----------------|
+| **Qingyan** | China consumer assistant. Agreement: a generative AI product operated by Beijing Zhipu Huazhang Technology Co., Ltd. ([paid agreement §1.1](https://chatglm.cn/pay/policy/vipservice)). Door: [chatglm.cn](https://chatglm.cn) | Not Coding Plan, not the API console |
+| **Z.ai chat** | International consumer assistant. [chat.z.ai](https://chat.z.ai) title: Advanced AI Chatbot & Agent | Not the SDK tutorial on `docs.z.ai` |
+| **Z.ai (company usage)** | [zhipuai.cn](https://www.zhipuai.cn/zh) uses Z.ai as both brand and one first-party product | Not "every Zhipu product is Z.ai" |
+| **ChatGLM** | 2023 conversational model / older store copy ([z.ai/company](https://z.ai/company) timeline; App Store) | Not the product URL you type today |
+| **GLM** | Model family. Open-platform intro: General Language Model ([docs.bigmodel.cn](https://docs.bigmodel.cn/cn/guide/start/introduction)) | Not one app |
+| **GLM-5.2** | Flagship name on Qingyan and Z.ai pages on 2026-08-19; the research post hangs it on both chat and Coding Plan | Not "the chat picker has only this forever" |
+| **GLM Coding Plan** | Subscription for Claude Code and similar tools ([z.ai/subscribe](https://z.ai/subscribe)) | Not Qingyan web setup |
+| **ZCode** | Official coding tool ([research/161](https://www.zhipuai.cn/zh/research/161)) | Not the Chat tab on chat.z.ai |
+| **AutoGLM** | Agent / report assistant on the company page and [autoglm.zhipuai.cn](https://autoglm.zhipuai.cn) | Not a nickname for one Qingyan mode — official pages list it as its own product |
+| **AutoClaw** | First-party product on the company page; marketing copy is a local OpenClaw client | Not merely another spelling of AutoGLM — the company page lists both |
+| **CodeGeeX** | Coding assistant in official news | Not Qingyan |
+| **BigModel** | China open platform [bigmodel.cn](https://bigmodel.cn) | Not the chat membership center |
+| **Qingying** | Video-generation benefit named in the paid agreement | Not a separate handbook on this site |
+
+## Two legal entities
+
+| | Qingyan | Z.ai |
+|--|---------|------|
+| Product URL | chatglm.cn | chat.z.ai / z.ai |
+| Operator in the legal text | Beijing Zhipu Huazhang Technology Co., Ltd. | JINGSHENG HENGXING TECHNOLOGY PTE.LTD ([Terms](https://docs.z.ai/legal-agreement/terms-of-use)) |
+| Official "same login" claim | None | None |
+
+So **do not** draw Qingyan membership, Z.ai login, Coding Plan, and an open-platform API key as one pool. The Qingyan agreement only says Qingyan membership and open-platform paid features are independent and can stack (§4.4). It does not say the international site shares that account.
+
+## An in-chat Agent is not a repo agent
+
+Qingyan's homepage calls itself an Agent: understand the goal, call tools, turn answers into deliverables. Z.ai's description says build websites, write code, long-horizon tasks.
+
+That is still a **chat surface**:
+
+- No official "run Qingyan as a repo CLI" steps.
+- Official repo / IDE coding sits on **GLM Coding Plan** and **ZCode** (research post, "Agent" section).
+- A page or script in the thread does not become a git commit on your machine.
+
+Analog: Qingyan / Z.ai chat ≈ Claude.ai. Coding Plan / ZCode power other coding tools. They are **not** this directory's Claude Code tutorial.
+
+## Do not write as fact
+
+- "Qingyan and chat.z.ai share one account"
+- "Free tier is N turns per day" (common on third-party sites; the agreement says trust the membership page)
+- Treating one day's App Store RMB IAP table as the national price list
+- Product name "ChatGLM web install of Coding Plan"
+- Treating the `docs.z.ai` API model table as the Qingyan dropdown
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./zhipu-chat.md)
+- [Cheatsheet](./zhipu-chat-cheatsheet.md)

--- a/docs/products/zhipu-chat/zhipu-chat.md
+++ b/docs/products/zhipu-chat/zhipu-chat.md
@@ -1,0 +1,159 @@
+---
+title: Qingyan / Z.ai chat
+description: "Audience: frontend engineers using Zhipu's assistant in a browser or the official app. No repo required."
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# Qingyan / Z.ai chat
+
+> This page is a product map from official product pages, the paid-service agreement, store listings, and model posts. Claude.ai analog.
+>
+> It is **not** GLM Coding Plan and not ZCode. The coding subscription is one row on the [learning map](./index.md).
+
+## Goals and non-goals
+
+**Audience:** frontend engineers. You need a browser or the Qingyan app.
+
+**Goals:** say what the two official chat doors are, what they claim to do, and where accounts / billing stop.
+
+**Non-goals:** Coding Plan install, API SDKs, invented daily caps / token limits / current membership prices, model internals (see [Learn LLM](/tech/fundamentals/LLM)).
+
+## Prerequisites
+
+- You can open [chatglm.cn](https://chatglm.cn) or [chat.z.ai](https://chat.z.ai)
+- China surface: whatever sign-in Qingyan shows (phone / WeChat, etc.). International surface: whatever Z.ai shows
+- No git checkout. No API key
+
+## Learning objectives
+
+- Pick Qingyan vs Z.ai
+- Send the first message and recognize official chips
+- Know which account holds membership, and why open-platform credit is not Qingyan membership
+
+## What it is
+
+One chat job, two official doors. Official "try it online" wording ([GLM-5.2 research post](https://www.zhipuai.cn/zh/research/161)):
+
+| Door | Official label | URL |
+|------|----------------|-----|
+| China | Qingyan app / web | [chatglm.cn](https://chatglm.cn) |
+| International | Z.ai | [chat.z.ai](https://chat.z.ai) |
+
+Clients (only what official pages name):
+
+| Client | Source |
+|--------|--------|
+| Web | [chatglm.cn](https://chatglm.cn), [chat.z.ai](https://chat.z.ai) |
+| Official app | [chatglm.cn/download](https://chatglm.cn/download); App Store [Qingyan](https://apps.apple.com/cn/app/id6450893458) |
+| Browser extension | Chrome Web Store "智谱清言：ChatGLM & AutoGLM" |
+
+There is **no** official "install Qingyan as a repo CLI" path on these pages. Code in the thread is still chat, not a checkout agent.
+
+## Qingyan: open and talk
+
+1. Open [chatglm.cn](https://chatglm.cn).
+2. Sign in. The paid-service agreement scopes the service to the **chatglm.cn website and the Qingyan app** ([agreement](https://chatglm.cn/pay/policy/vipservice) §1.5).
+3. Ask in the box. The footer points at the [user agreement](https://chatglm.cn/agreement) and [privacy policy](https://chatglm.cn/privacypolicy).
+
+Chips visible on the homepage on 2026-08-19:
+
+| Chip | What the official page actually shows |
+|------|----------------------------------------|
+| **Agent** | Homepage positioning is an Agent that delivers results |
+| **研究报告** (research report) | Homepage entry |
+| **PPT制作** (slides) | Homepage entry |
+| **数据分析** (data analysis) | Homepage entry |
+| **GLM-5.2 / GLM-5.2快速** | Model names on the page; trust what your account can actually select |
+
+The download page adds ([chatglm.cn/download](https://chatglm.cn/download)): chat, writing, programming, understanding images and documents; "chat, or call tools for complex tasks."
+
+Paid-agreement **kinds** of benefits (§1.6, §4.1 — not quota numbers):
+
+- Model-related benefits
+- Agent benefits
+- Qingying video generation
+- Video calls
+- Larger cloud knowledge-base space
+- More AI image-generation features
+
+**Counts, credits, and whether the SKU is still called VIP/SVIP live on the in-product membership page.** The agreement says Zhipu may change benefits and prices; read the live service page.
+
+The App Store listing also groups Q&A, writing, study, workplace, programming, and role-play. That is store copy, not a command list.
+
+### Browser extension
+
+Official name: **智谱清言：ChatGLM & AutoGLM** (Chrome Web Store, publisher zhipuextension). Store copy: sidebar Q&A, page summary, page chat, selection explain/summarize/translate, writing helper, checked-text summary, on-site advanced search. Plugin policy: [chatglm.cn/advanced-authpolicy](https://chatglm.cn/advanced-authpolicy).
+
+## Z.ai: international chat
+
+1. Open [chat.z.ai](https://chat.z.ai) or [z.ai](https://z.ai) (top nav **Chat**).
+2. Sign in as the page asks. The z.ai top nav also has **Chat / API / Coding Plan / Contact / Docs** ([z.ai/company](https://z.ai/company)). **Chat** is this page. **Coding Plan** and **Docs** are not the Qingyan tutorial.
+
+Official description:
+
+> Meet Z.ai, the AI assistant powered by GLM-5.2. Build websites, write code, handle long-horizon tasks, and get instant answers.
+
+Chips visible on 2026-08-19: **Magic Design**, **Full-Stack**, **Write Code**.
+
+Official blog lines that survive a source check:
+
+- [glm-4.5](https://z.ai/blog/glm-4.5): pick the model on Z.ai to chat; the platform supports artifacts, presentation slides, and full-stack development.
+- [glm-5.2](https://z.ai/blog/glm-5.2): "Chat with GLM-5.2 on Z.ai". The same post puts Coding Plan / ZCode on a different path.
+
+Legal text: [Terms of Use](https://docs.z.ai/legal-agreement/terms-of-use) (JINGSHENG HENGXING TECHNOLOGY PTE.LTD). That document covers the platform / API. **Do not** read China Qingyan membership rules out of it.
+
+## Accounts and paid features (agreement text only)
+
+Traps that matter, from the Qingyan paid-service agreement (effective 2026-05-21):
+
+| Rule | Official point |
+|------|----------------|
+| Benefits follow the account | If you have several Qingyan accounts, benefits go to the **account you were signed into when you paid**. Records do **not** move across accounts (§3.1, §3.2.2) |
+| Not the same as the open platform | Qingyan membership and other Zhipu paid products ("including but not limited to the Zhipu AI open platform") are **independent**. Overlap can stack; **no refund** for the overlap (§4.4) |
+| Price is on the page | Fees, discounts, and payment methods can change; trust the service page (§4.7) |
+| Default: no refund | Paid services are not returnable / cashable. Duplicate charges or official technical failure: support appeal (§4.5, §4.8.1) |
+| Devices differ | App version, device, and OS can change which benefits you actually see (§4.6) |
+
+The App Store has listed IAPs (auto-renew month, month card, Qingying agent, etc.). **SKUs move.** Do not treat one day's screenshot as the price list. Check the [App Store page](https://apps.apple.com/cn/app/id6450893458) or the in-product membership page.
+
+**Do not assume** Qingyan membership = Z.ai login = Coding Plan quota. Official pages do not say that.
+
+## Nearby surfaces (do not mix them)
+
+| Surface | What it is | Where |
+|---------|------------|-------|
+| **Qingyan / Z.ai chat** | This page | chatglm.cn / chat.z.ai |
+| **GLM Coding Plan** | Subscription for coding tools | [z.ai/subscribe](https://z.ai/subscribe) — no install steps here |
+| **ZCode** | Official coding tool | [zcode.z.ai/cn](https://zcode.z.ai/cn) |
+| **AutoGLM / AutoClaw** | Report assistant / local client | [autoglm.zhipuai.cn](https://autoglm.zhipuai.cn) |
+| **API** | Model HTTP APIs | [docs.z.ai](https://docs.z.ai), [docs.bigmodel.cn](https://docs.bigmodel.cn) |
+
+## Common pitfalls
+
+- Opening [z.ai/subscribe](https://z.ai/subscribe) or [bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding) and thinking you configured Qingyan web.
+- Buying on account A, signing into the web as B, then assuming the subscription vanished. The agreement says benefits do not migrate.
+- Treating open-platform / Coding Plan balance as Qingyan turns. The agreement says the paid products are independent.
+- Treating HTML or a script in the thread as a commit in your repo.
+- Copying third-party "50 turns / day" or a blog RMB price as official spec.
+
+## Official docs
+
+| Page | Use |
+|------|-----|
+| [chatglm.cn](https://chatglm.cn) | Qingyan product |
+| [chatglm.cn/download](https://chatglm.cn/download) | App / client entry |
+| [Paid-service agreement](https://chatglm.cn/pay/policy/vipservice) | Membership, credits, account rules |
+| [chat.z.ai](https://chat.z.ai) | Z.ai chat |
+| [z.ai](https://z.ai) | International top nav (Chat / API / Coding Plan) |
+| [zhipuai.cn/zh](https://www.zhipuai.cn/zh) | First-party product rail |
+| [GLM-5.2 research post](https://www.zhipuai.cn/zh/research/161) | Official pair of "try it online" URLs |
+| [docs.z.ai](https://docs.z.ai) | API, not a Qingyan how-to |
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Cheatsheet](./zhipu-chat-cheatsheet.md)
+- [Glossary](./zhipu-chat-glossary.md)

--- a/docs/zh/products/zhipu-chat/index.md
+++ b/docs/zh/products/zhipu-chat/index.md
@@ -1,0 +1,112 @@
+---
+title: 智谱清言 / Z.ai 学习地图
+description: 写给谁：要选智谱对话面的前端工程师。主路径是智谱清言和 Z.ai 对话，不是 GLM Coding Plan。
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# 智谱清言 / Z.ai 学习地图
+
+> **智谱清言** 是智谱的国内生成式助手。官方定义（[chatglm.cn](https://chatglm.cn)）：
+> 「基于 GLM 大模型，不只是 AI 助手，更是能帮你把事办成的 Agent。」
+>
+> **Z.ai** 是同一厂商的国际对话面。官方 title（[chat.z.ai](https://chat.z.ai)）：
+> 「Z.ai - Advanced AI Chatbot & Agent powered by GLM-5.2」
+>
+> 本目录对位 Claude.ai。它**不是** GLM Coding Plan，也不是 ZCode / AutoClaw。编码套餐只在下面占一行。
+
+## 目标与非目标
+
+**写给谁：** 前端工程师，要先分清该打开哪个官方入口。你需要浏览器或清言 App，不需要仓库。
+
+**目标：** 画出官方一级 AI 产品，并带你进清言 / Z.ai 对话。
+
+**非目标：** Coding Plan 安装、API 快速开始、模型内部机制（链 [Learn LLM](/zh/tech/fundamentals/LLM)）、臆造每日额度或现行人民币价。
+
+## 产品全景
+
+智谱（公司站 [zhipuai.cn](https://www.zhipuai.cn/zh)）下面有多张 AI 皮。它们**不是**同一个聊天窗口。
+
+```
+智谱 / Z.ai
+├── 对话（本目录主路径）
+│   ├── 智谱清言 — chatglm.cn、官方 App
+│   └── Z.ai — chat.z.ai / z.ai
+├── 编码套餐 / 桌面编码
+│   ├── GLM Coding Plan — 给 Claude Code 等工具配额度
+│   └── ZCode — 官方代码工具
+├── Agent / 办公
+│   ├── AutoGLM
+│   └── AutoClaw（本地 OpenClaw 客户端）
+├── 开放平台 / API
+│   ├── BigModel（bigmodel.cn）
+│   └── docs.z.ai
+└── 其它官方 AI 入口（地图一行）
+    ├── Zread.ai
+    ├── AMiner
+    ├── 智谱学习中心
+    ├── 智谱 AI 输入法
+    ├── CodeGeeX
+    └── 开源 GLM 权重
+```
+
+| 产品 | 是什么 | 入口 | 本站去向 |
+|------|--------|------|----------|
+| **智谱清言** | 国内对话 / Agent 助手 | [chatglm.cn](https://chatglm.cn) | [Tutorial](./zhipu-chat.md) |
+| **Z.ai 对话** | 国际对话 / Agent 助手 | [chat.z.ai](https://chat.z.ai) | 同一 Tutorial |
+| **GLM Coding Plan** | 编码工具订阅，不是聊天安装 | [z.ai/subscribe](https://z.ai/subscribe)、[bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding) | 地图一行（#75） |
+| **ZCode** | 官方代码工具 | [zcode.z.ai/cn](https://zcode.z.ai/cn) | 地图一行 |
+| **AutoGLM / AutoClaw** | 报告 / 浏览器操作 / 本地客户端 | [autoglm.zhipuai.cn](https://autoglm.zhipuai.cn) | 地图一行 |
+| **BigModel / Z.ai API** | 模型 HTTP API | [bigmodel.cn](https://bigmodel.cn)、[docs.z.ai](https://docs.z.ai) | 地图一行 |
+| **Zread.ai / AMiner / 学习中心 / AI 输入法** | 公司页「原生产品」列出 | [zhipuai.cn/zh](https://www.zhipuai.cn/zh) | 地图一行；独立 URL 以公司页为准 |
+| **CodeGeeX** | 智能编程助手（官方新闻） | [公司新闻](https://www.zhipuai.cn/en/news/20) | 地图一行 |
+| **开源 GLM** | 模型权重 | [github.com/zai-org/GLM-5](https://github.com/zai-org/GLM-5) | 地图一行 |
+| 商业生态 / IR / 招聘 | 非 AI 产品手册 | 公司页 | **非本站** |
+
+官方把「在线体验」写成两个链接（[GLM-5.2 研究页](https://www.zhipuai.cn/zh/research/161)）：**Z.ai = chat.z.ai**，**智谱清言 App/网页版 = chatglm.cn**。
+
+**容易撞名：**
+
+- **清言 ≠ Z.ai 对话。** 两个入口，两套协议主体。没有官方「一个账号打通」。
+- **ChatGLM** 是历史模型 / 商店文案里的名字，不是现在要记的产品 URL。
+- **对话里写代码 ≠ GLM Coding Plan。** 后者是给 Claude Code 等工具的额度，见 #75。
+- **AutoGLM ≠ AutoClaw。** 公司页两者都列。
+
+细节见 [术语表](./zhipu-chat-glossary.md)。
+
+### 快速决策：我该用哪个？
+
+```
+我要做什么？
+├── 在浏览器里对话 / 写作 / 看图看文档 / 做 PPT 或研究报告
+│   ├── 人在国内、要中文产品面 → 智谱清言（chatglm.cn 或官方 App）
+│   └── 人在国际面、页面是 Z.ai → chat.z.ai
+├── 在 Claude Code / Cline 等工具里用 GLM 额度
+│   └── → GLM Coding Plan（本目录不写安装）
+├── 要官方桌面代码工具
+│   └── → ZCode
+├── 要报告 / 网页自动操作 / 本地小龙虾客户端
+│   └── → AutoGLM / AutoClaw
+└── 在自己的程序里调模型
+    └── → BigModel 或 docs.z.ai API
+```
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 选对入口 | 上面的决策树 | 不把 Coding Plan 打开当清言 |
+| 2. 会用对话 | [智谱清言 / Z.ai 教程](./zhipu-chat.md) | 登录、发第一条、知道芯片是什么 |
+| 3. 回查入口 | [速查表](./zhipu-chat-cheatsheet.md) | URL、决策、信息源 |
+| 4. 名字打架 | [术语表](./zhipu-chat-glossary.md) | 清言 / Z.ai / ChatGLM / Coding Plan |
+
+没有独立 cookbook：官方没有可引用的 How-to 文档树。
+
+## 相关页面
+
+- [智谱清言 / Z.ai 教程](./zhipu-chat.md)
+- [速查表](./zhipu-chat-cheatsheet.md)
+- [术语表](./zhipu-chat-glossary.md)
+- [产品总览](../index.md)

--- a/docs/zh/products/zhipu-chat/zhipu-chat-cheatsheet.md
+++ b/docs/zh/products/zhipu-chat/zhipu-chat-cheatsheet.md
@@ -1,0 +1,123 @@
+---
+title: 智谱清言 / Z.ai 速查表
+description: 只查不学。入口、决策和官方链接。额度与价格以登录后的官方页为准。
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# 智谱清言 / Z.ai 速查表
+
+只查不学。数字和档位以你登录后的官方页为准。最后核实：2026-08-19。
+
+## 我该打开哪扇门
+
+| 场景 | 打开 | 不要打开 |
+|------|------|----------|
+| 国内网页对话 | [chatglm.cn](https://chatglm.cn) | Coding Plan 订阅页 |
+| 装官方 App | [chatglm.cn/download](https://chatglm.cn/download) 或 [App Store](https://apps.apple.com/cn/app/id6450893458) | 非官方「清言」apk 站 |
+| 国际网页对话 | [chat.z.ai](https://chat.z.ai) | `docs.z.ai`（那是 API） |
+| 给 Claude Code 等配 GLM | [z.ai/subscribe](https://z.ai/subscribe) 或 [bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding) | 清言会员页 |
+| 调 HTTP API | [docs.z.ai](https://docs.z.ai) 或 [docs.bigmodel.cn](https://docs.bigmodel.cn) | 聊天窗口当 SDK |
+| 看全家族 | [zhipuai.cn/zh](https://www.zhipuai.cn/zh) | 三方导航站 |
+
+术语钩子（一行，详解在 [术语表](./zhipu-chat-glossary.md)）：
+
+| 词 | 一句话 |
+|----|--------|
+| 智谱清言 | 国内对话产品 |
+| Z.ai 对话 | 国际对话产品 |
+| ChatGLM | 历史模型 / 商店文案，不是 URL |
+| GLM Coding Plan | 编码工具额度，不是清言安装 |
+| AutoGLM / AutoClaw | 另一张 Agent / 客户端皮 |
+| ZCode | 官方代码工具 |
+
+## 清言首页芯片（2026-08-19）
+
+来源：[chatglm.cn](https://chatglm.cn)
+
+| 芯片 | 备注 |
+|------|------|
+| Agent | 首页定位句里的 Agent |
+| 研究报告 | 官方入口 |
+| PPT制作 | 官方入口 |
+| 数据分析 | 官方入口 |
+| GLM-5.2 | 页面展示的模型名 |
+| GLM-5.2快速 | 页面展示的模型名 |
+
+下载页还写了对话 / 写作 / 编程 / 图片与文档理解 / 调用工具。付费协议还点名清影生视频、视频通话、云知识库、AI 画图。**不要把这份表理解成「免费用户一定全开」。**
+
+## Z.ai 页面芯片（2026-08-19）
+
+来源：[chat.z.ai](https://chat.z.ai) description + 可见芯片；[glm-4.5 blog](https://z.ai/blog/glm-4.5)
+
+| 芯片 / 说法 | 备注 |
+|-------------|------|
+| Magic Design | 页面芯片 |
+| Full-Stack | 页面芯片 |
+| Write Code | 页面芯片 |
+| artifacts / slides / full-stack | blog 原文，聊天面能力 |
+
+## 账号边界（清言协议）
+
+来源：[付费服务协议](https://chatglm.cn/pay/policy/vipservice)（2026-05-21）
+
+| 问题 | 答案 |
+|------|------|
+| 权益在哪个账号 | 购买时登录的那个 |
+| 能挪到另一个清言账号吗 | 不能（§3.2.2） |
+| 和 BigModel / 开放平台是一份吗 | 不是；可叠加，不退重合部分（§4.4） |
+| 价格写死了吗 | 没有；看服务页（§4.7） |
+| 默认能退款吗 | 不能；重复扣款 / 官方故障走客服（§4.8.1） |
+
+Z.ai 条款：[Terms of Use](https://docs.z.ai/legal-agreement/terms-of-use)。不要用它填清言国内价。
+
+## 高质量信息源
+
+最后核实：2026-08-19。只收亲自打开过的官方页。
+
+### 一手官方
+
+| 来源 | 用途 |
+|------|------|
+| [chatglm.cn](https://chatglm.cn) | 清言产品、首页芯片 |
+| [chatglm.cn/download](https://chatglm.cn/download) | 客户端文案 |
+| [chatglm.cn/pay/policy/vipservice](https://chatglm.cn/pay/policy/vipservice) | 会员 / 积分 / 账号 |
+| [chatglm.cn/agreement](https://chatglm.cn/agreement) | 用户协议 |
+| [chatglm.cn/privacypolicy](https://chatglm.cn/privacypolicy) | 隐私政策 |
+| [chat.z.ai](https://chat.z.ai) | Z.ai 对话 |
+| [z.ai](https://z.ai) | 国际站顶栏 |
+| [z.ai/company](https://z.ai/company) | 公司时间线、Chat / API / Coding Plan |
+| [z.ai/blog/glm-5.2](https://z.ai/blog/glm-5.2) | 聊天入口 vs Coding Plan 入口 |
+| [zhipuai.cn/zh](https://www.zhipuai.cn/zh) | 一级产品家族 |
+| [zhipuai.cn/zh/research/161](https://www.zhipuai.cn/zh/research/161) | 官方「在线体验」两个 URL |
+| [docs.z.ai](https://docs.z.ai) | API 文档 |
+| [docs.bigmodel.cn/cn/guide/start/introduction](https://docs.bigmodel.cn/cn/guide/start/introduction) | 国内开放平台介绍 |
+| [App Store 智谱清言](https://apps.apple.com/cn/app/id6450893458) | 官方 App 介绍与内购列表 |
+
+### 只监控、本目录不展开
+
+| 来源 | 用途 |
+|------|------|
+| [z.ai/subscribe](https://z.ai/subscribe) | GLM Coding Plan（#75） |
+| [bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding) | 国内 Coding Plan |
+| [zcode.z.ai/cn](https://zcode.z.ai/cn) | ZCode |
+| [autoglm.zhipuai.cn](https://autoglm.zhipuai.cn) | AutoGLM / AutoClaw |
+| [github.com/zai-org/GLM-5](https://github.com/zai-org/GLM-5) | 开源权重 |
+
+### 待核实
+
+| 名称 | 为什么存疑 |
+|------|------------|
+| 智谱学习中心 / 智谱 AI 输入法 / Zread.ai / AMiner 的独立产品 URL | 公司页列出名称，本次未抓到可引用的独立文档页 |
+| 清言微信小程序是否仍是一级入口 | 只在三方转载里出现，官方 download 页抓取未给出正文列表 |
+| 清言与 Z.ai 是否共享登录 | 官方未写 |
+
+**访问提示（2026-08-19）：** `chatglm.cn` / `chat.z.ai` 是 SPA，无头抓取经常只剩 title。`www.zhipuai.cn` 在部分网络会解析到私网地址。以阅读器或浏览器为准。
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./zhipu-chat.md)
+- [术语表](./zhipu-chat-glossary.md)

--- a/docs/zh/products/zhipu-chat/zhipu-chat-glossary.md
+++ b/docs/zh/products/zhipu-chat/zhipu-chat-glossary.md
@@ -1,0 +1,66 @@
+---
+title: 智谱清言 / Z.ai 术语表
+description: 不教操作。只解释清言、Z.ai、ChatGLM、Coding Plan 为什么不是同一个东西。
+domain: product
+tags:
+  - coding-agent
+role: glossary
+---
+
+# 智谱清言 / Z.ai 术语表
+
+不教操作。只解释名字为什么打架。选入口看 [学习地图](./index.md)。
+
+## 都带「智谱 / GLM / Z.ai」的东西
+
+| 名字 | 是什么 | 不是什么 |
+|------|--------|----------|
+| **智谱清言** | 国内消费端助手。协议定义：北京智谱华章科技有限公司经营的生成式人工智能产品（[付费协议 §1.1](https://chatglm.cn/pay/policy/vipservice)）。入口 [chatglm.cn](https://chatglm.cn) | 不是 Coding Plan，不是 API 控制台 |
+| **Z.ai 对话** | 国际消费端助手。[chat.z.ai](https://chat.z.ai) title：Advanced AI Chatbot & Agent | 不是 `docs.z.ai` 里的 SDK 教程 |
+| **Z.ai（公司站用法）** | 公司站 [zhipuai.cn](https://www.zhipuai.cn/zh) 把 Z.ai 既当品牌、又当原生产品之一 | 不等于「所有智谱产品都叫 Z.ai」 |
+| **ChatGLM** | 2023 年发布的对话模型 / 清言商店文案里的旧称（[z.ai/company](https://z.ai/company) 时间线；App Store 介绍） | 不是现在要输入的产品 URL |
+| **GLM** | 模型家族名。开放平台介绍：General Language Model（[docs.bigmodel.cn](https://docs.bigmodel.cn/cn/guide/start/introduction)） | 不是某一个 App |
+| **GLM-5.2** | 2026-08-19 清言首页与 Z.ai 页面展示的旗舰模型名；研究页把它同时挂到聊天和 Coding Plan | 不是「聊天里永远只有这一个」 |
+| **GLM Coding Plan** | 给 Claude Code 等编码工具的订阅（[z.ai/subscribe](https://z.ai/subscribe)） | 不是清言网页的安装步骤 |
+| **ZCode** | 官方代码工具（[research/161](https://www.zhipuai.cn/zh/research/161)） | 不是 chat.z.ai 的聊天标签 |
+| **AutoGLM** | 公司页与 [autoglm.zhipuai.cn](https://autoglm.zhipuai.cn) 上的 Agent / 报告助手 | 不是清言里某一个 Mode 的别名（官方把它单列成产品） |
+| **AutoClaw** | 公司页原生产品；营销文案是本地 OpenClaw 客户端 | 不是 AutoGLM 的另一个拼写而已——公司页两者并排 |
+| **CodeGeeX** | 官方新闻里的智能编程助手 | 不是清言 |
+| **BigModel** | 国内开放平台 [bigmodel.cn](https://bigmodel.cn) | 不是聊天会员中心 |
+| **清影** | 付费协议点名的生视频相关权益 | 不是独立于清言的本站教程 |
+
+## 两套主体
+
+| | 清言 | Z.ai |
+|--|------|------|
+| 产品 URL | chatglm.cn | chat.z.ai / z.ai |
+| 协议里的运营方 | 北京智谱华章科技有限公司 | JINGSHENG HENGXING TECHNOLOGY PTE.LTD（[Terms](https://docs.z.ai/legal-agreement/terms-of-use)） |
+| 官方有没有写「同一登录」 | 没有 | 没有 |
+
+所以：**不要**把清言会员、Z.ai 登录、Coding Plan、开放平台 API Key 画成一口池子。清言协议只保证「清言会员」和「开放平台付费」独立且可叠加（§4.4），没说国际站共用。
+
+## 对话里的 Agent 不是仓库 Agent
+
+清言首页把自己写成 Agent：理解目标、调用工具、把回答变成交付结果。Z.ai description 写 Build websites、write code、long-horizon tasks。
+
+这仍是**聊天面**：
+
+- 没有官方「在仓库里跑清言 CLI」的步骤。
+- 官方把仓库 / IDE 编码放到 **GLM Coding Plan** 和 **ZCode**（研究页「Agent」小节）。
+- 对话里生成的页面或代码，不会自动变成你本机的 git commit。
+
+对位关系：清言 / Z.ai 对话 ≈ Claude.ai；Coding Plan / ZCode ≈ 给别的编码工具供电，**不是**本目录的 Claude Code 教程。
+
+## 禁止当事实写
+
+- 「清言和 chat.z.ai 同一个账号」
+- 「免费每天 N 次」（三方站常见，官方协议只说看会员页）
+- 把 App Store 某一天的 ¥ 内购表写成全国统一价
+- 产品名写成「ChatGLM 网页版安装 Coding Plan」
+- 用 `docs.z.ai` 的 API 模型表当清言下拉框
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./zhipu-chat.md)
+- [速查表](./zhipu-chat-cheatsheet.md)

--- a/docs/zh/products/zhipu-chat/zhipu-chat.md
+++ b/docs/zh/products/zhipu-chat/zhipu-chat.md
@@ -1,0 +1,159 @@
+---
+title: 智谱清言 / Z.ai 对话
+description: 写给谁：要在浏览器或官方 App 里用智谱助手的前端工程师。不需要仓库。
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# 智谱清言 / Z.ai 对话
+
+> 本页只根据官方产品页、付费协议、商店页和模型公告画对话面。对位 Claude.ai。
+>
+> 它**不是** GLM Coding Plan，也不是 ZCode。编码套餐见 [学习地图](./index.md) 那一行。
+
+## 目标与非目标
+
+**写给谁：** 前端工程师。你需要浏览器或清言 App。
+
+**目标：** 写清两个官方对话入口实际是什么、能做什么、账号和付费边界在哪。
+
+**非目标：** Coding Plan 安装、API SDK、臆造每日次数 / token 上限 / 现行会员价、模型内部（链 [Learn LLM](/zh/tech/fundamentals/LLM)）。
+
+## 先决条件
+
+- 能打开 [chatglm.cn](https://chatglm.cn) 或 [chat.z.ai](https://chat.z.ai)
+- 国内面准备手机号 / 微信等清言支持的登录方式；国际面按 Z.ai 登录页为准
+- 不需要 Git 仓库、不需要 API Key
+
+## 学习目标
+
+- 能选对「清言」还是「Z.ai」
+- 能发出第一条对话，并认出官方能力芯片
+- 知道会员权益绑在哪个账号上，以及为什么不能拿开放平台额度当清言会员
+
+## 它是什么
+
+一张对话面，两个官方入口。官方「在线体验」原文（[GLM-5.2 研究页](https://www.zhipuai.cn/zh/research/161)）：
+
+| 入口 | 官方写法 | URL |
+|------|----------|-----|
+| 国内 | 智谱清言 App/网页版 | [chatglm.cn](https://chatglm.cn) |
+| 国际 | Z.ai | [chat.z.ai](https://chat.z.ai) |
+
+客户端（只写官方写过的）：
+
+| 客户端 | 依据 |
+|--------|------|
+| 网页 | [chatglm.cn](https://chatglm.cn)、[chat.z.ai](https://chat.z.ai) |
+| 官方 App | [chatglm.cn/download](https://chatglm.cn/download)；App Store [智谱清言](https://apps.apple.com/cn/app/id6450893458) |
+| 浏览器插件 | Chrome Web Store「智谱清言：ChatGLM & AutoGLM」 |
+
+这些页面上**没有**「把清言装成仓库 CLI」的官方步骤。对话里写代码仍是聊天，不是 checkout Agent。
+
+## 智谱清言：打开就能聊
+
+1. 打开 [chatglm.cn](https://chatglm.cn)。
+2. 登录。付费协议把服务范围写成 **chatglm.cn 网站、智谱清言 App**（[付费服务协议](https://chatglm.cn/pay/policy/vipservice) §1.5）。
+3. 在输入框发问题。页脚要求你读 [用户协议](https://chatglm.cn/agreement) 与 [隐私政策](https://chatglm.cn/privacypolicy)。
+
+2026-08-19 首页可见的入口芯片：
+
+| 芯片 | 只说明「官方把这件事放在首页」 |
+|------|--------------------------------|
+| **Agent** | 首页定位就是「能帮你把事办成的 Agent」 |
+| **研究报告** | 官方首页入口 |
+| **PPT制作** | 官方首页入口 |
+| **数据分析** | 官方首页入口 |
+| **GLM-5.2 / GLM-5.2快速** | 页面上的模型名；以你账号里实际能选的为准 |
+
+下载页补充的能力（[chatglm.cn/download](https://chatglm.cn/download)）：对话、写作、编程、理解图片与文档；「可以对话聊天、也可以调用工具执行复杂任务」。
+
+付费协议列出的权益**种类**（§1.6、§4.1，不是额度数字）：
+
+- 各模型相关权益
+- 各类型 Agent 权益
+- 清影生视频
+- 视频通话
+- 更大的云知识库空间
+- 更多 AI 画图功能
+
+**具体次数、积分、是否仍叫 VIP/SVIP，以登录后的会员权益页为准。** 协议允许智谱改权益和价格，并要求你看服务页最新展示。
+
+App Store 官方介绍还按场景写了通用问答、写作、学习、职场、编程、虚拟对话等。那是商店文案，用来理解产品面，不要当成命令清单。
+
+### 浏览器插件
+
+官方插件名：**智谱清言：ChatGLM & AutoGLM**（Chrome Web Store，开发者标识 zhipuextension）。商店原文能力：通用问答侧边栏、页面总结、页面对话、划线解释/总结/翻译、写作助手、勾选总结、站内高级检索。插件政策见 [chatglm.cn/advanced-authpolicy](https://chatglm.cn/advanced-authpolicy)。
+
+## Z.ai：国际对话面
+
+1. 打开 [chat.z.ai](https://chat.z.ai) 或顶栏带 **Chat** 的 [z.ai](https://z.ai)。
+2. 按页面登录。Z.ai 顶栏同时有 **Chat / API / Coding Plan / Contact / Docs**（[z.ai/company](https://z.ai/company)）。**Chat** 才是本页；**Coding Plan** 和 **Docs** 不是清言教程。
+
+官方对自己的定义（页面 description）：
+
+> Meet Z.ai, the AI assistant powered by GLM-5.2. Build websites, write code, handle long-horizon tasks, and get instant answers.
+
+2026-08-19 页面可见芯片：**Magic Design**、**Full-Stack**、**Write Code**。
+
+官方 blog 对聊天面的补充（只抄原文能撑住的）：
+
+- [glm-4.5](https://z.ai/blog/glm-4.5)：在 Z.ai 选模型即可聊；支持 artifacts、presentation slide、full-stack development。
+- [glm-5.2](https://z.ai/blog/glm-5.2)：「Chat with GLM-5.2 on Z.ai」。同一篇把 Coding Plan / ZCode 写成另一条路径。
+
+Z.ai 的法律文本在 [Terms of Use](https://docs.z.ai/legal-agreement/terms-of-use)（签约方 JINGSHENG HENGXING TECHNOLOGY PTE.LTD）。那份条款主要覆盖平台 / API 使用，**不要**用它反推清言国内会员规则。
+
+## 账号与付费（只写协议原文）
+
+清言付费协议（生效 2026-05-21）里，前端工程师最容易踩的几条：
+
+| 规则 | 原文要点 |
+|------|----------|
+| 权益跟账号走 | 多个清言账号时，权益只进**购买时登录的那个**。账号之间充值 / 会员**不能**转移、迁徙、转让、分享（§3.1、§3.2.2） |
+| 和开放平台不是同一份 | 清言会员与智谱其它产品（「包括但不限于智谱 AI 开放平台」）付费**独立不冲突**，重合权益可叠加，**不会**因此退款（§4.4） |
+| 价格看页面 | 收费标准、优惠、付款方式会改；以服务页公示为准（§4.7） |
+| 默认不退 | 付费服务不能退货退款、换货、兑现金；重复扣款或官方技术故障导致无法履约，走客服申诉（§4.5、§4.8.1） |
+| 设备会不一样 | 软件版本、设备、操作系统不同，实际能用的服务可能有差别（§4.6） |
+
+App Store 列出过内购档位（连续包月、月卡、清影智能体等）。**档位和价格会变**，不要把某一天的截图当价目表。查 [App Store 产品页](https://apps.apple.com/cn/app/id6450893458) 或清言会员页。
+
+**不要假设** 清言会员 = Z.ai 登录 = Coding Plan 额度。官方没有这样写。
+
+## 旁边那些面（别混）
+
+| 产品面 | 是什么 | 去哪 |
+|--------|--------|------|
+| **智谱清言 / Z.ai 对话** | 本页 | chatglm.cn / chat.z.ai |
+| **GLM Coding Plan** | 给编码工具的订阅 | [z.ai/subscribe](https://z.ai/subscribe) — 本目录不写安装 |
+| **ZCode** | 官方代码工具 | [zcode.z.ai/cn](https://zcode.z.ai/cn) |
+| **AutoGLM / AutoClaw** | 报告助手 / 本地客户端 | [autoglm.zhipuai.cn](https://autoglm.zhipuai.cn) |
+| **API** | 模型 HTTP 接口 | [docs.z.ai](https://docs.z.ai)、[docs.bigmodel.cn](https://docs.bigmodel.cn) |
+
+## 常见陷阱
+
+- 打开 [z.ai/subscribe](https://z.ai/subscribe) 或 [bigmodel.cn/glm-coding](https://bigmodel.cn/glm-coding)，却以为在配置清言网页。
+- 用 A 账号买会员、用 B 账号登录网页，然后以为「丢了订阅」。协议写明权益不搬家。
+- 把开放平台 / Coding Plan 余额当成清言次数。协议写明两套付费独立。
+- 把对话里生成的 HTML / 脚本当成已经改好了你的 Git 仓库。
+- 把三方博客的「每日 50 次 / 某月 ¥xx」写进自己的笔记当官方规格。
+
+## 官方文档
+
+| 页面 | 用来干什么 |
+|------|------------|
+| [chatglm.cn](https://chatglm.cn) | 清言产品 |
+| [chatglm.cn/download](https://chatglm.cn/download) | App / 客户端入口 |
+| [付费服务协议](https://chatglm.cn/pay/policy/vipservice) | 会员、积分、账号边界 |
+| [chat.z.ai](https://chat.z.ai) | Z.ai 对话 |
+| [z.ai](https://z.ai) | 国际站顶栏（Chat / API / Coding Plan） |
+| [zhipuai.cn/zh](https://www.zhipuai.cn/zh) | 厂商一级产品 |
+| [GLM-5.2 研究页](https://www.zhipuai.cn/zh/research/161) | 官方「在线体验」两个 URL |
+| [docs.z.ai](https://docs.z.ai) | API，不是清言 How-to |
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [速查表](./zhipu-chat-cheatsheet.md)
+- [术语表](./zhipu-chat-glossary.md)


### PR DESCRIPTION
Closes #74

## 范围

只做 **智谱清言 / Z.ai 对话**（对位 Claude.ai）。**不写 GLM Coding Plan 安装主教程**；家族图里 Coding Plan 只一行，链到 #75。

按指令 **未改 `products-gallery.js`**。侧栏挂在 `docs/.vitepress/sidebars/ai-coding.mjs`（三组：地图 / 核心 / 参考）。

## 研究

先 doc-research，维护参考：`.claude/skills/doc-research/references/zhipu-chat.md`。

官方一级入口（2026-08-19）：

| 官方入口 | URL | 本站去向 |
|---|---|---|
| 智谱清言 | https://chatglm.cn | 独立 Tutorial |
| Z.ai 对话 | https://chat.z.ai | 同一 Tutorial（国际面） |
| GLM Coding Plan | https://z.ai/subscribe 、 https://bigmodel.cn/glm-coding | 地图一行 |
| AutoGLM / AutoClaw | https://autoglm.zhipuai.cn | 地图一行 |
| ZCode | https://zcode.z.ai/cn | 地图一行 |
| BigModel / docs.z.ai | API | 地图一行 |
| Zread.ai / AMiner / 学习中心 / AI 输入法 / CodeGeeX / 开源 GLM | 公司页或官方新闻 | 地图一行 |
| 商业生态 / IR | 公司页 | 非本站 |

两套主体：清言 = 北京智谱华章；Z.ai Terms = JINGSHENG HENGXING TECHNOLOGY PTE.LTD。**不写同一登录池**。

## 文件

密度不够五文件同构，**省略 cookbook**（没有官方 How-to 树）。

```
docs/zh/products/zhipu-chat/
docs/products/zhipu-chat/
  index.md
  zhipu-chat.md
  zhipu-chat-cheatsheet.md
  zhipu-chat-glossary.md
```

额度 / 现行价格只链官方会员页与 App Store，禁止抄三方「每日 50 次」。

## 验收

- [x] `references/zhipu-chat.md` 先写形态调研
- [x] 本目录没有同厂其它产品完整教程
- [x] 家族图一级 AI 入口都有去向
- [x] `pnpm docs:build` 通过
- [x] 未改 gallery