### PR TITLE
docs(hunyuan): add Hunyuan handbook for #77

### DIFF
--- a/.claude/skills/doc-research/references/hunyuan.md
+++ b/.claude/skills/doc-research/references/hunyuan.md
@@ -1,0 +1,157 @@
+# 腾讯混元 / Tencent Hy 维护参考
+
+> 通用维护流程见 [`maintenance-workflow.md`](./maintenance-workflow.md)；高质量数据源清单发布在 `docs/zh/products/hunyuan/hunyuan-cheatsheet.md` 的「高质量信息源」章节。文档架构见 [`documentation-architecture.md`](./documentation-architecture.md)。
+
+## 产品形态调研结论（写教程前必须先有这一节）
+
+调研时间：2026-08-19。以下每条都来自一手官方来源，来源标在括号里。
+
+**结论一：本 issue 的产品是「混元 / Hy」模型与开放能力，不是元宝、也不是 CodeBuddy。**
+
+- 官方首页 [hunyuan.tencent.com](https://hunyuan.tencent.com/) / [hy.tencent.com](https://hy.tencent.com/) 一级导航：模型、研究、Co-design、International、试用 Hy；页脚「产品」列出 **WorkBuddy / 元宝 / ima**。
+- 品牌正在从「腾讯混元 / Tencent Hunyuan」迁到「Tencent Hy」。GitHub org [Tencent-Hunyuan](https://github.com/Tencent-Hunyuan) 的官网写的是 `https://hy.tencent.com/`。国际通稿原文：「Tencent Hy, formerly known as Tencent Hunyuan」。
+- 元宝是 C 端助手（[yuanbao.tencent.com](https://yuanbao.tencent.com/)），自称「已接入最新的混元 Hy3 模型」。CodeBuddy 是腾讯云代码助手（[codebuddy.cn](https://www.codebuddy.cn/)）。二者是同厂其它产品，本目录只在家族图占一行。
+
+**结论二：前端工程师要调用混元，当前官方主路径是 TokenHub，不是单独再学一套「混元云 API 产品树」。**
+
+- TokenHub 文档根：[cloud.tencent.com/document/product/1823](https://cloud.tencent.com/document/product/1823)。产品概述原文：「整合腾讯自研的混元大模型能力，并引入优质第三方模型」。
+- Hy3 调用指南：[混元调用指南](https://cloud.tencent.com/document/product/1823/132252)。`hy3` 兼容 OpenAI Chat Completions、OpenAI Responses、Anthropic Messages。端点：`https://tokenhub.tencentmaas.com/v1`。
+- 快速入门：[1823/130058](https://cloud.tencent.com/document/product/1823/130058)。步骤：注册并实名 → 控制台开通 → 模型广场领免费体验包 → 创建 API Key → 调 `chat/completions`。
+- 老产品页 [cloud.tencent.com/product/hunyuan](https://cloud.tencent.com/product/hunyuan) 与文档树 [product/1729](https://cloud.tencent.com/document/product/1729) 仍在，但 2026-07 之后的 Hy3 正文写在 TokenHub（1823）。**本站以 TokenHub + hunyuan.tencent.com 为准**；1729 上的 Hunyuan-T1 / TurboS 当历史规格，不要当当前旗舰。
+- 同站产品页 [cloud.tencent.com/product/tclm](https://cloud.tencent.com/product/tclm) 已列出 Hy3（295B / 21B 激活、192K 入 / 128K 出、`no_think` / `think_low` / `think_high`，更新 2026-07-06）。
+
+**结论三：Hy3 同时是托管 API 模型和开源权重，本站两条线都写，但不写自建机房运维手册。**
+
+- 仓库 [Tencent-Hunyuan/Hy3](https://github.com/Tencent-Hunyuan/Hy3) / Hugging Face [tencent/Hy3](https://huggingface.co/tencent/Hy3)：295B MoE、21B 激活、3.8B MTP、256K 上下文、Apache-2.0。推荐参数 `temperature=0.9`、`top_p=1.0`。推理模式 `reasoning_effort`: `no_think`（默认）/ `low` / `high`。
+- 官方部署：vLLM `vllm serve tencent/Hy3`（`--tool-call-parser hy_v3`）；SGLang `--tool-call-parser hunyuan`。8 卡、推荐 H20-3e。
+- TokenHub 侧 `hy3`：上下文 256k、最大输入 192k、最大输出 128k；能力：深度思考（保留式）、结构化输出、Function Calling、Cache。价格（后付费，元/百万 tokens）：输入 1 / 输出 4 / 缓存命中 0.25（[模型价格](https://cloud.tencent.com/document/product/1823/130055)，2026-08-14）。
+- `hy3-preview` 官方标注 **2026-08-31 下线**。教程默认写 `hy3`。
+
+**结论四：混元还有多模态与专项模型；本站只收官方已给 slug 的表，不拆独立教程。**
+
+官方模型页分类（[hunyuan.tencent.com/model/hy-model](https://hunyuan.tencent.com/model/hy-model)）：语言模型、视觉语言模型、视觉生成模型、语音识别模型。已核到的 Hy 系 slug（TokenHub [模型列表](https://cloud.tencent.com/document/product/1823/130051)）：
+
+| 官方名 | model 参数 | 本站处理 |
+|--------|------------|----------|
+| Hy3 | `hy3` | Tutorial + cheatsheet 主线 |
+| Hy3 preview | `hy3-preview` | 地图/速查一行，标下线日 |
+| Hy-MT2-Pro / Plus / Lite | `hy-mt2-pro` / `hy-mt2-plus` / `hy-mt2-lite` | 速查一行 |
+| Hy-Role-Latest / Hy-Role | `hunyuan-role-latest` / `hy-role` | 速查一行 |
+| HY-Image-V3.0 / Hy-Image-Lite | `hy-image-v3.0` / `hy-image-lite` | 地图一行 |
+| HY-Video-1.5 | `hy-video-1.5` | 地图一行 |
+| HY-3D-3.0 / 3.1 / Express | `hy-3d-3.0` / `hy-3d-3.1` / `hy-3d-express` | 地图一行 |
+| HY-Vision-2.0-Instruct 等 | `hy-vision-2.0-instruct` 等 | 地图一行 |
+| Hy-ASR-3.0-Preview | TokenHub 定价页出现 | 地图一行 |
+
+开源仓（[github.com/Tencent-Hunyuan](https://github.com/Tencent-Hunyuan)）置顶还有 HunyuanVideo、HunyuanImage-3.0、Hunyuan3D-2.1、HunyuanOCR 等。开源权重名与 TokenHub slug **不要混抄**。
+
+**结论五：适合本站「前端工程师」定位，但形态是模型 + API，不是第一方编码 CLI。**
+
+- 有 OpenAI / Anthropic 兼容 HTTP，官方给了 Node.js 示例（[132252](https://cloud.tencent.com/document/product/1823/132252)）。
+- TokenHub 快速入门列出「在 Claude Code / Cursor / OpenClaw / CodeBuddy Code 中调用」。Hy3 专项页：[1823/131903](https://cloud.tencent.com/document/product/1823/131903)。
+- Hy3 README 原文把 frontend design、coding 列为生产力场景；SWE-Bench Verified 在 CodeBuddy / Cline / KiloCode 上方差 ≤ 4%。
+- **没有**第一方 `hunyuan` CLI。编码 agent 产品是 CodeBuddy（#78），办公 agent 是 WorkBuddy。本目录不写它们的教程。
+- 本地跑满血 Hy3 需要 8×H20 级 GPU，对个人前端不现实。教程只给官方启动命令并链仓库，不写「笔记本也能跑」。
+
+**结论六：两套官方页会打架，写作时必须点名以谁为准。**
+
+| 事实 | 以谁为准 | 另一份 |
+|------|----------|--------|
+| 当前旗舰语言模型 | TokenHub 模型列表 + hunyuan.tencent.com 的 Hy3 | product/hunyuan 上的 Hunyuan-T1 / TurboS |
+| API 端点与鉴权 | TokenHub `tokenhub.tencentmaas.com/v1` + Bearer API Key | 1729 老混元 API / 云 API 签名 |
+| 思考档位 | TokenHub：`thinking` + `reasoning_effort`（`hy3` 默认 `low`；带 tools 时 `low` 映射为 `high`） | tclm 产品页：`no_think` / `think_low` / `think_high`；开源 README：`chat_template_kwargs.reasoning_effort` |
+| 价格 | [1823/130055](https://cloud.tencent.com/document/product/1823/130055) | 营销页摘抄；过期立即以该页为准 |
+
+## 基本信息
+
+- 工具名：腾讯混元 / Tencent Hy（旗舰语言模型 Hy3）
+- 官方文档根地址：<https://hunyuan.tencent.com/> ；API：<https://cloud.tencent.com/document/product/1823>
+- 发版节奏：模型按发布日滚动（Hy3 正式版 2026-07-06；Hy3 Preview 约 2026-04 下旬）。不要写死「每 X 天一版」。
+- 当前覆盖：Hy3 正式版 + TokenHub 文档（模型列表 / 混元调用指南 / 快速入门 / 模型价格，复核 2026-08-19）
+
+## 官方一级导航（产品家族）
+
+> 排轴 A/B 之前先填完。规则见 [`family-completeness.md`](./family-completeness.md)。
+
+| 官方一级入口 | 官方 URL | 本站去向 | 不拆页理由（若一行） |
+|--------------|----------|----------|----------------------|
+| Hy / 混元官网（模型） | https://hunyuan.tencent.com/ https://hunyuan.tencent.com/model/hy-model | 独立页 `index` + `hunyuan.md` | |
+| 研究 | https://hunyuan.tencent.com/research https://hy.tencent.com/research/hy3 | 地图一行 | 论文/研究站，不是操作面 |
+| Co-design | https://hunyuan.tencent.com/ 页头「Co-design」 | 地图一行 | 官网一级栏目，公开密度是营销/合作，不拆教程 |
+| International | 官网页头 International | 地图一行 | 语言切换 / 国际入口，不是新产品 |
+| 试用 Hy / Hy AI Studio | https://aistudio.tencent.com/ | Tutorial 一节 | 对话/多模态体验台，步骤薄 |
+| 开源模型（GitHub / HF） | https://github.com/Tencent-Hunyuan https://huggingface.co/tencent/Hy3 | Tutorial 一节 + cheatsheet | |
+| TokenHub（托管推理） | https://cloud.tencent.com/product/tokenhub https://cloud.tencent.com/document/product/1823 | Tutorial + cookbook + cheatsheet | 本站只写 **调混元**；三方模型不展开 |
+| 腾讯混元大模型（老云产品 1729） | https://cloud.tencent.com/product/hunyuan https://cloud.tencent.com/document/product/1729 | 地图一行 | 与 TokenHub 重叠；Hy3 正文已迁 1823 |
+| 元宝 | https://yuanbao.tencent.com/ | 地图一行 → #76 | 同厂 C 端助手，不写正文 |
+| CodeBuddy | https://www.codebuddy.cn/ | 地图一行 → #78 | 同厂编码工具，不写正文 |
+| WorkBuddy | https://www.workbuddy.cn/ https://cloud.tencent.com/product/workbuddy | 地图一行 | 同厂办公 Agent，不写正文 |
+| ima | https://ima.qq.com/ | 地图一行 | 同厂知识管家，不写正文 |
+| 招聘机会 | 官网页脚 | 非本站 | 不是产品 |
+| 人脸识别 / 云服务器 / 短信 / 域名等 | 腾讯云一级 nav | 非本站 | 非 AI 或非混元 |
+
+易撞名：
+
+- **混元 / Hy ≠ 元宝**。混元是模型与开放能力；元宝是消费级助手，只是接入了 Hy3。
+- **Hy3 ≠ Hy AI Studio ≠ TokenHub**。Hy3 是模型；AI Studio 是试用台；TokenHub 是云上模型网关（还卖别人的模型）。
+- **TokenHub ≠ 老「腾讯混元大模型」1729**。调 Hy3 以 TokenHub 为准。
+- **CodeBuddy / WorkBuddy 不是混元 CLI**。混元没有第一方编码 CLI。
+- **开源权重名（HunyuanImage-3.0）≠ TokenHub slug（`hy-image-v3.0`）**。
+- **`hy3-preview` ≠ `hy3`**。Preview 已标下线日。
+
+## 文档文件结构（Diataxis）
+
+```
+docs/zh/products/hunyuan/
+├── index.md                 # 🗺️ 学习地图 + 家族图
+├── hunyuan.md               # 📘 Tutorial — 试用、TokenHub 第一次调用、开源权重入口
+├── hunyuan-cookbook.md      # 🔧 How-to — Node 调用、思考档、工具调用、接到 Claude Code
+├── hunyuan-cheatsheet.md    # 📐 Reference — slug / 端点 / 价格 / 数据源
+└── hunyuan-glossary.md      # 📖 Explanation — 撞名、双文档树、思考档位两套词
+
+docs/products/hunyuan/       # 英文同构
+```
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 + 速查 | 家族图、决策树、本目录收/不收 | 操作步骤；元宝/CodeBuddy 教程 |
+| `hunyuan.md` | Tutorial | 试用 Studio、开通 TokenHub、第一次 `hy3` 调用、开源入口 | 完整参数表；自建 8 卡集群运维 |
+| `hunyuan-cookbook.md` | How-to | 流式、思考、Function Calling、接到 Claude Code | TokenHub 上的 DeepSeek/Kimi 选型 |
+| `hunyuan-cheatsheet.md` | Reference | slug、价格、端点、协议、信息源 | 概念散文 |
+| `hunyuan-glossary.md` | Explanation | 是什么 / 不是什么 / 两套官方页谁赢 | 参数清单 |
+
+轴 A：先地图，再 Tutorial（先能调通），再 How-to，Reference / Explanation 殿后。
+轴 B：TokenHub 调 Hy3 是前端读者主线；开源权重部署相关度中、排 Tutorial 后段；元宝/CodeBuddy 只占地图。
+
+## 监控页面
+
+- 官网 / 模型：<https://hunyuan.tencent.com/> <https://hunyuan.tencent.com/model/hy-model>
+- Hy3 研究帖：<https://hy.tencent.com/research/hy3>
+- TokenHub 文档根：<https://cloud.tencent.com/document/product/1823>
+- 模型列表：<https://cloud.tencent.com/document/product/1823/130051>
+- 混元调用指南：<https://cloud.tencent.com/document/product/1823/132252>
+- 快速入门：<https://cloud.tencent.com/document/product/1823/130058>
+- 模型价格：<https://cloud.tencent.com/document/product/1823/130055>
+- Claude Code × Hy3：<https://cloud.tencent.com/document/product/1823/131903>
+- 开源：<https://github.com/Tencent-Hunyuan/Hy3> <https://huggingface.co/tencent/Hy3>
+- 试用：<https://aistudio.tencent.com/>
+- 控制台：<https://console.cloud.tencent.com/tokenhub>
+- 老产品树（对照用，不要当主源）：<https://cloud.tencent.com/document/product/1729>
+
+## Git 提交 scope
+
+```
+docs(hunyuan): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+1. **官网是 SPA**。`curl` / 普通抓取经常只拿到导航壳；正文用阅读器或浏览器渲染。`hunyuan.tencent.com` 与 `hy.tencent.com` 是同一站两域名。
+2. **禁止把 TokenHub 写成「混元专用网关」**。它明确聚合第三方模型。本目录只示范 `hy3`。
+3. **禁止把 1729 的 Hunyuan-T1 / TurboS / hunyuan-lite 写成当前默认模型**。当前旗舰 slug 是 `hy3`。
+4. **思考参数有三套词**：TokenHub `thinking` / `reasoning_effort`；产品页 `no_think` / `think_low` / `think_high`；开源 `chat_template_kwargs.reasoning_effort`。教程里并列引用，禁止猜哪套覆盖哪套。
+5. **带 `tools` 时 TokenHub 会把 `reasoning_effort=low` 映射成 `high`**（[132252](https://cloud.tencent.com/document/product/1823/132252) 原文）。不要写成「low 在 toolcall 下仍是 low」。
+6. **开源 parser 名字不一致**：vLLM `hy_v3`，SGLang `hunyuan`。按官方 README 抄，不要统一成一个。
+7. **免费额度只写「控制台 + 新人免费体验包为准」**。营销页有「100 万 tokens」，不要把它写成所有模型的固定配额。
+8. **不写元宝 / CodeBuddy / WorkBuddy / ima 的操作步骤**；不写人脸识别、云主机、短信等非 AI 腾讯云。
+9. **不写模型内部机制**（MoE 路由、MTP 训练）。规格数字可以抄官方表，原理链 [Learn LLM](https://llm.zenheart.site/chapters/)。

--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -12,5 +12,6 @@
 | Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
 | Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
 | Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| Hunyuan / Hy | [`hunyuan.md`](./hunyuan.md) | `docs/zh/products/hunyuan/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/docs/.vitepress/sidebars/ai-coding.mjs
+++ b/docs/.vitepress/sidebars/ai-coding.mjs
@@ -192,6 +192,27 @@ export const enAiCodingItems = [
                                     },
                                  ]
                               },
+                              {
+                                 text: 'Hunyuan', link: '/products/hunyuan/', items: [
+                                    { text: '🗺️ Learning Map', link: '/products/hunyuan/' },
+                                    {
+                                       text: 'Core',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Hunyuan Tutorial', link: '/products/hunyuan/hunyuan' },
+                                          { text: 'Cookbook', link: '/products/hunyuan/hunyuan-cookbook' },
+                                       ]
+                                    },
+                                    {
+                                       text: 'Reference',
+                                       collapsed: false,
+                                       items: [
+                                          { text: 'Cheatsheet', link: '/products/hunyuan/hunyuan-cheatsheet' },
+                                          { text: 'Glossary', link: '/products/hunyuan/hunyuan-glossary' },
+                                       ]
+                                    },
+                                 ]
+                              },
                               { text: 'Pi Agent', link: '/products/ai-coding/pi-agent' },
                               { text: 'Other Tools', link: '/products/ai-coding/othertools' },
 ]
@@ -378,6 +399,27 @@ export const zhAiCodingItems = [
                                        items: [
                                           { text: '速查表', link: '/zh/products/ai-coding/grok/grok-cheatsheet' },
                                           { text: '术语表', link: '/zh/products/ai-coding/grok/grok-glossary' },
+                                       ]
+                                    },
+                                 ]
+                              },
+                              {
+                                 text: '混元', link: '/zh/products/hunyuan/', items: [
+                                    { text: '🗺️ 学习地图', link: '/zh/products/hunyuan/' },
+                                    {
+                                       text: '核心',
+                                       collapsed: false,
+                                       items: [
+                                          { text: '混元教程', link: '/zh/products/hunyuan/hunyuan' },
+                                          { text: 'Cookbook', link: '/zh/products/hunyuan/hunyuan-cookbook' },
+                                       ]
+                                    },
+                                    {
+                                       text: '速查与参考',
+                                       collapsed: false,
+                                       items: [
+                                          { text: '速查表', link: '/zh/products/hunyuan/hunyuan-cheatsheet' },
+                                          { text: '术语表', link: '/zh/products/hunyuan/hunyuan-glossary' },
                                        ]
                                     },
                                  ]

--- a/docs/products/hunyuan/hunyuan-cheatsheet.md
+++ b/docs/products/hunyuan/hunyuan-cheatsheet.md
@@ -1,0 +1,119 @@
+---
+title: Tencent Hunyuan cheatsheet
+description: "Lookup only. Slugs, endpoints, and prices follow the live TokenHub pages. Rechecked 2026-08-19."
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: cheatsheet
+---
+
+# Tencent Hunyuan cheatsheet
+
+Lookup only. Slugs and prices move. Follow the official links.
+
+## Decisions
+
+| Job | Pick |
+|-----|------|
+| Language model from your app | TokenHub `hy3` |
+| Browser try-out | [AI Studio](https://aistudio.tencent.com/) |
+| Translation | `hy-mt2-pro` / `plus` / `lite` |
+| Role-play | `hy-role` / `hunyuan-role-latest` |
+| Image | `hy-image-v3.0` |
+| 3D | `hy-3d-3.1` |
+| Self-host | [tencent/Hy3](https://huggingface.co/tencent/Hy3), not TokenHub |
+| Chat app | Yuanbao, not this table |
+| Coding IDE | CodeBuddy, not this table |
+
+## Endpoint and auth
+
+| Item | Value | Source |
+|------|-------|--------|
+| Base URL | `https://tokenhub.tencentmaas.com/v1` | [Quick start](https://cloud.tencent.com/document/product/1823/130058) |
+| Chat Completions | `POST /v1/chat/completions` | same + [132252](https://cloud.tencent.com/document/product/1823/132252) |
+| Auth | `Authorization: Bearer <TokenHub API Key>` | same |
+| Protocols | OpenAI Chat Completions, OpenAI Responses, Anthropic Messages | [132252](https://cloud.tencent.com/document/product/1823/132252) |
+| Console | https://console.cloud.tencent.com/tokenhub | TokenHub product page |
+
+Local open-weight default: `http://127.0.0.1:8000/v1`, `api_key` may be `EMPTY` (Hy3 README).
+
+## Hy-family `model` values
+
+Source: [model list](https://cloud.tencent.com/document/product/1823/130051) (rechecked 2026-08-19). Hy / Hunyuan rows only.
+
+| Name | `model` | Context | Max in / out | Official capabilities |
+|------|---------|---------|--------------|------------------------|
+| Hy3 | `hy3` | 256k | 192k / 128k | retained thinking, structured output, function calling, cache |
+| Hy3 preview | `hy3-preview` | 256k | 192k / 128k | interleaved thinking; **retires 2026-08-31** |
+| Hy-MT2-Pro | `hy-mt2-pro` | 8k | 4k / 4k | translation flagship |
+| Hy-MT2-Plus | `hy-mt2-plus` | 8k | 4k / 4k | translation |
+| Hy-MT2-Lite | `hy-mt2-lite` | 8k | 4k / 4k | light translation |
+| Hy-Role-Latest | `hunyuan-role-latest` | 32k | 28k / 4k | role-play |
+| Hy-Role | `hy-role` | 32k | 28k / 4k | role-play |
+| HY-Image-V3.0 | `hy-image-v3.0` | — | — | T2I, I2I |
+| Hy-Image-Lite | `hy-image-lite` | — | — | T2I |
+| HY-Video-1.5 | `hy-video-1.5` | — | — | T2V, I2V |
+| HY-3D-3.0 | `hy-3d-3.0` | — | — | T23D, I23D |
+| HY-3D-3.1 | `hy-3d-3.1` | — | — | T23D, I23D |
+| HY-3D-Express | `hy-3d-express` | — | — | fast 3D |
+| HY-Vision-2.0-Instruct | `hy-vision-2.0-instruct` | 44k | 24k / 16k | image-to-text |
+| HY-Vision-1.5-Thinking | `hunyuan-t1-vision-20250916` | 40k | 16k / 24k | vision thinking |
+| HY-Vision-Video | `hunyuan-turbos-vision-video-20250728` | 32k | 24k / 8k | video understanding |
+
+Concurrency and task types stay on the model-list page.
+
+## Prices (pay-as-you-go, CNY / million tokens)
+
+Source: [pricing](https://cloud.tencent.com/document/product/1823/130055), “last updated 2026-08-14 21:58:00”. Bills win.
+
+| Model | Input | Output | Cache hit |
+|-------|-------|--------|-----------|
+| Hy3 | 1 | 4 | 0.25 |
+| Hy3 preview (input &lt; 16k) | 1.2 | 4 | 0.4 |
+| Hy3 preview (16k–32k) | 1.6 | 6.4 | 0.6 |
+| Hy3 preview (32k+) | 2 | 8 | 0.8 |
+| Hy-MT2-Pro / Plus | 0.5 | 2 | — |
+| Hy-MT2-Lite | 0.3 | 1.2 | — |
+| Hy-Role / Latest | 2.4 | 9.6 | — |
+| Hy-Image-3.0 | 10 (20,000 tokens/image → about 0.2 CNY/image) | | |
+
+Free tier: claim it in Model Square. **The console is the source of truth.**
+
+## Thinking fields
+
+| Surface | Field | Values | Source |
+|---------|-------|--------|--------|
+| TokenHub | `thinking` | `{ "type": "enabled" }` | [132252](https://cloud.tencent.com/document/product/1823/132252) |
+| TokenHub | `reasoning_effort` | default `low` on `hy3`; `high` allowed; `low`→`high` when `tools` present | same |
+| tclm product page | copy | `no_think` / `think_low` / `think_high` | [tclm](https://cloud.tencent.com/product/tclm) |
+| Open README | `chat_template_kwargs.reasoning_effort` | `no_think` (default) / `low` / `high` | [Hy3 README](https://github.com/Tencent-Hunyuan/Hy3) |
+
+Recommended sampling (README): `temperature=0.9`, `top_p=1.0`. TokenHub’s basic sample also uses `temperature: 0.9`.
+
+## Glossary index
+
+One line each. Definitions: [glossary](./hunyuan-glossary.md).
+
+| Term | Hook |
+|------|------|
+| [Hy / Hunyuan](./hunyuan-glossary.md#hy--hunyuan) | Model family, not an app |
+| [Hy3](./hunyuan-glossary.md#hy3) | Current flagship LM |
+| [TokenHub](./hunyuan-glossary.md#tokenhub) | Multi-vendor gateway |
+| [1729](./hunyuan-glossary.md#two-cloud-doc-trees) | Older Hunyuan API tree |
+| [Yuanbao](./hunyuan-glossary.md#sibling-products-are-not-hunyuan) | Consumer assistant |
+| [CodeBuddy](./hunyuan-glossary.md#sibling-products-are-not-hunyuan) | Coding product |
+
+## High-quality sources
+
+- **[Hunyuan site](https://hunyuan.tencent.com/)** — first-level model/research nav. Use a browser (SPA). Last checked: 2026-08-19
+- **[TokenHub docs](https://cloud.tencent.com/document/product/1823)** — enablement, calls, billing. Last checked: 2026-08-19
+- **[Model list](https://cloud.tencent.com/document/product/1823/130051)** — slug SSOT. Last checked: 2026-08-19
+- **[Hy call guide](https://cloud.tencent.com/document/product/1823/132252)** — `hy3` request samples. Last checked: 2026-08-19
+- **[Pricing](https://cloud.tencent.com/document/product/1823/130055)** — pay-as-you-go table. Last checked: 2026-08-19
+- **[Quick start](https://cloud.tencent.com/document/product/1823/130058)** — keys and first call. Last checked: 2026-08-19
+- **[Claude Code × Hy3](https://cloud.tencent.com/document/product/1823/131903)** — official wiring. Last checked: 2026-08-19
+- **[Hy3 GitHub](https://github.com/Tencent-Hunyuan/Hy3)** / **[HF tencent/Hy3](https://huggingface.co/tencent/Hy3)** — open specs and serve commands. Last checked: 2026-08-19
+- **[org Tencent-Hunyuan](https://github.com/Tencent-Hunyuan)** — other modalities. Last checked: 2026-08-19
+- **[Hy AI Studio](https://aistudio.tencent.com/)** — playground. Last checked: 2026-08-19
+- **Unverified:** standalone Co-design landing URL (header item exists; scrape only returned the SPA shell).

--- a/docs/products/hunyuan/hunyuan-cookbook.md
+++ b/docs/products/hunyuan/hunyuan-cookbook.md
@@ -1,0 +1,153 @@
+---
+title: Tencent Hunyuan cookbook
+description: "Recipes that exist on the TokenHub Hy call guide or the Hy3 README. Third-party model shopping is out of scope."
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: cookbook
+---
+
+# Tencent Hunyuan cookbook
+
+One problem per section. Enablement is in the [tutorial](./hunyuan.md). Tables are in the [cheatsheet](./hunyuan-cheatsheet.md).
+
+## Streaming
+
+Source: [Hy call guide · streaming](https://cloud.tencent.com/document/product/1823/132252). Set `stream: true`. To receive `usage` on the last chunk, add `stream_options: { include_usage: true }`.
+
+```ts
+import OpenAI from 'openai'
+
+const client = new OpenAI({
+  apiKey: process.env.TOKENHUB_API_KEY,
+  baseURL: 'https://tokenhub.tencentmaas.com/v1',
+})
+
+const stream = await client.chat.completions.create({
+  model: 'hy3',
+  messages: [{ role: 'user', content: 'Hello' }],
+  stream: true,
+  stream_options: { include_usage: true },
+})
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content ?? '')
+  if (chunk.usage) console.log('\nusage:', chunk.usage)
+}
+```
+
+## Turn thinking on
+
+TokenHub documents two knobs on [132252](https://cloud.tencent.com/document/product/1823/132252):
+
+1. `thinking: { type: "enabled" }` — read `message.reasoning_content`.
+2. `reasoning_effort` — `hy3` / `hy3-preview` **default to `low`**. You may set `high`.
+
+Official Node sample puts `thinking` at the top level:
+
+```ts
+const response = await client.chat.completions.create({
+  model: 'hy3',
+  messages: [
+    { role: 'user', content: 'A has 5 apples, gives 2 to B, then buys 3. How many remain?' },
+  ],
+  thinking: { type: 'enabled' },
+})
+
+const msg = response.choices[0].message
+if (msg.reasoning_content) console.log('reasoning:', msg.reasoning_content)
+console.log('answer:', msg.content)
+```
+
+**Tool-call exception (official wording):** on Hy3 GA, sending `tools` enables adaptive thinking. If you still send `reasoning_effort: "low"`, the API **maps `low` to `high`**. Do not reconcile invoices against the value you typed.
+
+Open-weight serving uses `extra_body.chat_template_kwargs.reasoning_effort` (`no_think` / `low` / `high`). That is not the same JSON as TokenHub. See the [glossary](./hunyuan-glossary.md).
+
+## Function calling
+
+The call guide’s Function Calling section uses OpenAI-style `tools`. Keep the protocol fields; swap the function body for your backend.
+
+```ts
+const response = await client.chat.completions.create({
+  model: 'hy3',
+  messages: [{ role: 'user', content: 'What is the weather in Beijing today?' }],
+  tools: [
+    {
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        description: 'Look up weather by city',
+        parameters: {
+          type: 'object',
+          properties: {
+            city: { type: 'string', description: 'City name' },
+          },
+          required: ['city'],
+        },
+      },
+    },
+  ],
+})
+```
+
+Copy request/response field names from [132252](https://cloud.tencent.com/document/product/1823/132252). This page does not invent a second schema.
+
+## Structured output
+
+The same call guide lists structured output as a `hy3` capability. How JSON Schema is attached is defined there and in TokenHub’s API protocol page. Do not guess field names from another vendor’s `response_format` tutorial.
+
+## Claude Code
+
+Official page: [Call from Claude Code (Hy3)](https://cloud.tencent.com/document/product/1823/131903). Quick start also links Cursor, OpenClaw, Cline, Kilo Code, Roo Code, and CodeBuddy Code.
+
+Remember three facts:
+
+1. The base URL is TokenHub’s OpenAI or Anthropic-compatible host, not `api.anthropic.com`.
+2. The model id is `hy3`, not `hunyuan`.
+3. The key is a TokenHub API key. CodeBuddy install steps belong in #78.
+
+Do not fork a `settings.json` onto this site; 131903 will move.
+
+## Serve open Hy3 (only if you have the GPUs)
+
+Source: [Hy3 README](https://github.com/Tencent-Hunyuan/Hy3). Official suggestion: 8 GPUs, H20-3e class.
+
+vLLM (parser name `hy_v3`):
+
+```bash
+export VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm
+vllm serve tencent/Hy3 \
+  --tensor-parallel-size 8 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 2 \
+  --tool-call-parser hy_v3 \
+  --reasoning-parser hy_v3 \
+  --enable-auto-tool-choice \
+  --port 8000 \
+  --served-model-name hy3
+```
+
+SGLang (parser name `hunyuan`):
+
+```bash
+python3 -m sglang.launch_server \
+  --model tencent/Hy3 \
+  --tp-size 8 \
+  --tool-call-parser hunyuan \
+  --reasoning-parser hunyuan \
+  --speculative-num-steps 2 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 3 \
+  --speculative-algorithm EAGLE \
+  --port 8000 \
+  --served-model-name hy3
+```
+
+Do not mix parser names. Recommended sampling from the README: `temperature=0.9`, `top_p=1.0`.
+
+## Recipes that do not belong here
+
+- Choosing DeepSeek / Kimi / GLM on TokenHub.
+- Yuanbao model switcher or CodeBuddy plugins.
+- Treating 1729-era `hunyuan-turbo` / `Hunyuan-T1` as the current default.

--- a/docs/products/hunyuan/hunyuan-glossary.md
+++ b/docs/products/hunyuan/hunyuan-glossary.md
@@ -1,0 +1,85 @@
+---
+title: Tencent Hunyuan glossary
+description: "No how-to. Separate Hy, TokenHub, Yuanbao, and CodeBuddy, then the two cloud doc trees and three thinking vocabularies."
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: glossary
+---
+
+# Tencent Hunyuan glossary
+
+No procedures. If you only need a door, use the [learning map](./index.md).
+
+## Hy / Hunyuan
+
+**What it is:** Tencent’s current brand for the self-developed model family. [hunyuan.tencent.com](https://hunyuan.tencent.com/) and [hy.tencent.com](https://hy.tencent.com/) are the same site. International copy has said “Tencent Hy, formerly known as Tencent Hunyuan”.
+
+**What it is not:** Yuanbao the app, a TokenHub account, or an executable.
+
+Repos, papers, and the older cloud product still say Hunyuan. Both names must map to an official page. Do not invent a third product name like “Hunyuan 3.0” — the current flagship LM is **Hy3**.
+
+Internals (why MoE, what MTP is) belong in [Learn LLM](https://llm.zenheart.site/chapters/).
+
+## Hy3
+
+**What it is:** Flagship language model shipped 2026-07-06. TokenHub slug `hy3`. Open weights at [Tencent-Hunyuan/Hy3](https://github.com/Tencent-Hunyuan/Hy3): 295B total, 21B active, 256K context, Apache-2.0.
+
+Hosted capabilities ([model list](https://cloud.tencent.com/document/product/1823/130051)): retained thinking, structured output, function calling, cache. The product page adds Coding / long-context / Agent.
+
+**What it is not:**
+
+- Not `hy3-preview` (official retire date 2026-08-31).
+- Not the image / video / 3D models.
+- Not a button inside CodeBuddy.
+
+## TokenHub
+
+**What it is:** Tencent Cloud’s “LLM service platform”, product tree **1823**. Official overview: one door that **bundles Hunyuan and third-party models**. Calling Hy is one line of business.
+
+**Why the name matters:** In 2026 the Hy3 call guide, prices, keys, and Claude Code wiring all live on this tree. Calling it “the Hunyuan console” hides the multi-vendor catalog and collides with tree 1729.
+
+Auth is a TokenHub API key, not a random CAM SecretId/SecretKey.
+
+## Two cloud doc trees
+
+| Tree | ID | How to use it now |
+|------|-----|-------------------|
+| TokenHub | 1823 | **Primary source here.** Hy3, prices, OpenAI-compatible endpoint |
+| Tencent Hunyuan LLM | 1729 | Still online. Still shows older Hunyuan-T1 / TurboS specs |
+
+[cloud.tencent.com/product/hunyuan](https://cloud.tencent.com/product/hunyuan) still scrapes as the older lineup; [product/tclm](https://cloud.tencent.com/product/tclm) already features Hy3. When marketing pages disagree, **TokenHub docs + hunyuan.tencent.com win**, and the conflict is named in the prose.
+
+## Why thinking has three vocabularies
+
+Not three products — three official pages, three JSON shapes:
+
+| Source | How it is spelled |
+|--------|-------------------|
+| TokenHub call guide | `thinking: { type: "enabled" }`; `reasoning_effort` (default `low` on `hy3`) |
+| tclm product page | `no_think` / `think_low` / `think_high` |
+| Hy3 open README | `extra_body.chat_template_kwargs.reasoning_effort = no_think \| low \| high` (default `no_think`) |
+
+This site does not guess that TokenHub `low` equals a particular open-weight enum. Copy the fields from the page you are actually calling. With `tools` present, TokenHub maps `low` to `high` (call guide).
+
+## Sibling products are not Hunyuan
+
+| Name | Official positioning | Entry | This site |
+|------|----------------------|-------|-----------|
+| Yuanbao | “Tencent’s all-in-one AI assistant… already using the latest Hunyuan Hy3 model” | [yuanbao.tencent.com](https://yuanbao.tencent.com/) | #76 |
+| CodeBuddy | Tencent Cloud coding assistant (IDE / CLI) | [codebuddy.cn](https://www.codebuddy.cn/) | #78 |
+| WorkBuddy | Office agent workbench | [workbuddy.cn](https://www.workbuddy.cn/) | Map row |
+| ima | “AI knowledge steward based on a knowledge base” | [ima.qq.com](https://ima.qq.com/) | Map row |
+
+They **consume** Hunyuan (or other models). They are not “Hunyuan open capabilities”. The Hy3 README names CodeBuddy / Cline / KiloCode as evaluation scaffolds. That does not make Hunyuan equal to CodeBuddy.
+
+## Open-source names vs API slugs
+
+The [Tencent-Hunyuan](https://github.com/Tencent-Hunyuan) org still uses Hunyuan* repo names (HunyuanVideo, HunyuanImage-3.0, Hunyuan3D-2.1). TokenHub call parameters prefer `hy-*` / `hy3`.
+
+Reconcile against the page you are reading. Do not treat similar names as the same `model` field.
+
+## Internals this handbook will not teach
+
+MoE routing, MTP speculative decoding, quantization training, RL post-training: the README has sections; they are model internals. Use [LLM fundamentals](../../tech/fundamentals/LLM.md). This handbook only keeps official **spec numbers and serve commands**.

--- a/docs/products/hunyuan/hunyuan.md
+++ b/docs/products/hunyuan/hunyuan.md
@@ -1,0 +1,145 @@
+---
+title: Tencent Hunyuan tutorial
+description: "Pick the right door, then complete one hy3 call on TokenHub. Open weights have official serve commands; this page only gives the entry."
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: tutorial
+---
+
+# Tencent Hunyuan tutorial
+
+> Path: identify the product → optional playground → first TokenHub call → find the open checkpoint. Parameters live in the [cheatsheet](./hunyuan-cheatsheet.md). Recipes live in the [cookbook](./hunyuan-cookbook.md). Names live in the [glossary](./hunyuan-glossary.md).
+>
+> Model internals (MoE, MTP, attention) are out of scope. See [LLM fundamentals](../../tech/fundamentals/LLM.md) and [Learn LLM](https://llm.zenheart.site/chapters/).
+
+## 1. Confirm the door
+
+| What you think you opened | What it actually is | Next |
+|---------------------------|---------------------|------|
+| “Tencent’s AI” in a browser | Usually [Yuanbao](https://yuanbao.tencent.com/) | Leave. Issue #76 |
+| IDE completion / repo agent | [CodeBuddy](https://www.codebuddy.cn/) | Leave. Issue #78 |
+| Your service needs `chat/completions` | **TokenHub + `hy3`** | Keep reading |
+| Download weights and serve | [Tencent-Hunyuan/Hy3](https://github.com/Tencent-Hunyuan/Hy3) | Jump to [Open weights](#open-weights) |
+
+The official site is [hunyuan.tencent.com](https://hunyuan.tencent.com/) (same site: [hy.tencent.com](https://hy.tencent.com/)). Marketing has moved from Hunyuan to **Hy**; APIs and repos still use both names.
+
+## 2. Optional playground
+
+**Hy AI Studio**: [aistudio.tencent.com](https://aistudio.tencent.com/). The site header “试用 Hy” / “Try Hy” lands here. Use it to hear the model, not as a production endpoint.
+
+## 3. TokenHub: first `hy3` call in 15 minutes
+
+Sources: [Quick start](https://cloud.tencent.com/document/product/1823/130058), [Hy call guide](https://cloud.tencent.com/document/product/1823/132252).
+
+### 3.1 Enable the service
+
+1. [Register for Tencent Cloud](https://cloud.tencent.com/register) and finish real-name verification (quick start “准备工作”).
+2. Open the [TokenHub console](https://console.cloud.tencent.com/tokenhub) and enable the product.
+3. In **Model Square**, claim the new-user free pack. Quotas follow the console and the official free-pack page — do not treat the marketing “1 million tokens” line as a fixed quota for every model.
+4. **API Key management** → pick a region → **Create API Key**. Scope “all” or include `hy3`. Copy the key immediately.
+
+TokenHub is not a Hunyuan-only gateway. It also lists DeepSeek / Kimi / GLM. This tutorial only sets `model` to `hy3`.
+
+### 3.2 One TypeScript call
+
+Endpoint: `https://tokenhub.tencentmaas.com/v1`. Auth: `Authorization: Bearer <API Key>`. `hy3` speaks OpenAI Chat Completions (plus Responses and Anthropic Messages per the call guide).
+
+Official Node sample, `model` set to `hy3`, `temperature: 0.9` as in the call guide:
+
+```ts
+import OpenAI from 'openai'
+
+const client = new OpenAI({
+  apiKey: process.env.TOKENHUB_API_KEY,
+  baseURL: 'https://tokenhub.tencentmaas.com/v1',
+})
+
+const response = await client.chat.completions.create({
+  model: 'hy3',
+  messages: [{ role: 'user', content: 'Hello. Briefly introduce yourself.' }],
+  temperature: 0.9,
+})
+
+console.log(response.choices[0].message.content)
+```
+
+curl from [132252](https://cloud.tencent.com/document/product/1823/132252):
+
+```bash
+curl -X POST 'https://tokenhub.tencentmaas.com/v1/chat/completions' \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${TOKENHUB_API_KEY}" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "Hello. Briefly introduce yourself."}],
+    "stream": false,
+    "temperature": 0.9
+  }'
+```
+
+A good response has `model: "hy3"` and text in `choices[0].message.content`. Do not commit the key.
+
+### 3.3 Hosted specs
+
+Sources: [model list](https://cloud.tencent.com/document/product/1823/130051), [pricing](https://cloud.tencent.com/document/product/1823/130055).
+
+| Field | Official value |
+|-------|----------------|
+| `model` | `hy3` |
+| Context | 256k |
+| Max in / out | 192k / 128k |
+| Capabilities | retained thinking, structured output, function calling, cache |
+| Pay-as-you-go | input 1 / output 4 / cache hit 0.25 **CNY per million tokens** |
+
+`hy3-preview` is similar and is marked **retired on 2026-08-31**. Do not start new work on the preview slug.
+
+Thinking, streaming, and tools: [cookbook](./hunyuan-cookbook.md).
+
+## 4. Point an existing coding agent at Hy3
+
+TokenHub quick start lists Claude Code, Cursor, OpenClaw, CodeBuddy Code, Cline, Kilo Code, Roo Code. The Hy3-specific Claude Code page is [1823/131903](https://cloud.tencent.com/document/product/1823/131903).
+
+This page does not re-teach those IDEs. Point the compatible base URL at `https://tokenhub.tencentmaas.com/v1`, set the model to `hy3`, and use a TokenHub key. How to install CodeBuddy is #78.
+
+## 5. Open weights
+
+Flagship open model: **Hy3** — [GitHub](https://github.com/Tencent-Hunyuan/Hy3), [Hugging Face `tencent/Hy3`](https://huggingface.co/tencent/Hy3). Apache-2.0. Contact from the README: `hunyuan_opensource@tencent.com`.
+
+Official numbers: 295B MoE, 21B active, 3.8B MTP, 256K context, 192 experts top-8. README: full serve wants **8 GPUs**, H20-3e or larger memory. This is not an `ollama run` laptop path.
+
+After the server is up (README Quickstart):
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "Hello! Can you briefly introduce yourself?"}],
+    temperature=0.9,
+    top_p=1.0,
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+)
+print(response.choices[0].message.content)
+```
+
+Copy launch flags from the README. Parser names differ on purpose:
+
+- vLLM: `--tool-call-parser hy_v3`, `--reasoning-parser hy_v3`
+- SGLang: `--tool-call-parser hunyuan`, `--reasoning-parser hunyuan`
+
+The same org also publishes HunyuanVideo, HunyuanImage-3.0, Hunyuan3D-2.1, HunyuanOCR. Pick the repo for the modality. Do not assume every checkpoint answers to the `hy3` slug.
+
+## 6. Common failures
+
+| Symptom | Check first |
+|---------|-------------|
+| 401 | Missing key, or a CAM SecretId instead of a TokenHub API key |
+| Unknown model | `hunyuan` / `Hy3` / retiring `hy3-preview` |
+| Thinking field ignored | TokenHub uses `thinking` / `reasoning_effort`; local README uses `chat_template_kwargs` |
+| Looking for a CLI | There is no first-party Hunyuan CLI. The terminal agent is CodeBuddy |
+
+Next: [cookbook](./hunyuan-cookbook.md) or [cheatsheet](./hunyuan-cheatsheet.md).

--- a/docs/products/hunyuan/index.md
+++ b/docs/products/hunyuan/index.md
@@ -1,0 +1,135 @@
+---
+title: Tencent Hunyuan learning map
+description: "Hunyuan (Tencent Hy) is Tencent's model and open-capability line. It is not Yuanbao and not CodeBuddy. This directory covers models, TokenHub, and open weights only."
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: map
+---
+
+# Tencent Hunyuan learning map
+
+> **Hunyuan / Tencent Hy** is Tencent's self-developed model family and the channels that open those models to developers. The research site is [hunyuan.tencent.com](https://hunyuan.tencent.com/). Hosted inference goes through [TokenHub](https://cloud.tencent.com/document/product/1823).
+>
+> This directory covers **models and open capabilities only**. Yuanbao, CodeBuddy, WorkBuddy, and ima are sibling products. They get one row on the family map.
+
+## Product landscape
+
+Several Tencent doors share the words Hunyuan or Hy. They are **not** one product with four skins.
+
+```
+Tencent AI (Hunyuan-related official surfaces)
+├── Hunyuan / Hy — models, research, open weights (this handbook)
+│   ├── Hy models (Hy3, Hy-MT2, image / video / 3D / vision / ASR)
+│   ├── Research (Hy3 note, Hyra, …)
+│   ├── Co-design / International (site chrome, not a call surface)
+│   ├── Try Hy (Hy AI Studio)
+│   └── Open weights (GitHub Tencent-Hunyuan / Hugging Face tencent/Hy3)
+├── TokenHub — cloud model gateway (serves Hy and third-party models)
+├── Tencent Hunyuan LLM (cloud product 1729, older API tree)
+├── Yuanbao — consumer assistant (runs Hy3)     → issue #76
+├── CodeBuddy — coding IDE / CLI                → issue #78
+├── WorkBuddy — office agent
+└── ima — knowledge steward
+```
+
+| Surface | What it is | Official URL | This site |
+|---------|------------|--------------|-----------|
+| **Hy models / Hunyuan site** | Model and research home | [hunyuan.tencent.com](https://hunyuan.tencent.com/) | This page + [tutorial](./hunyuan.md) |
+| **TokenHub** | Unified LLM API (Hy + third parties) | [Product](https://cloud.tencent.com/product/tokenhub) / [docs 1823](https://cloud.tencent.com/document/product/1823) | [Tutorial](./hunyuan.md) / [Cookbook](./hunyuan-cookbook.md) / [Cheatsheet](./hunyuan-cheatsheet.md) |
+| Try Hy (AI Studio) | Browser playground | [aistudio.tencent.com](https://aistudio.tencent.com/) | One tutorial section |
+| Open weights | Apache-2.0 checkpoints | [Tencent-Hunyuan](https://github.com/Tencent-Hunyuan) / [tencent/Hy3](https://huggingface.co/tencent/Hy3) | Tutorial section + cheatsheet |
+| Research | Tech notes | [research](https://hunyuan.tencent.com/research) / [Hy3](https://hy.tencent.com/research/hy3) | Map row |
+| Co-design / International | First-level site nav | [hunyuan.tencent.com](https://hunyuan.tencent.com/) header | Map row; not a new product |
+| Hunyuan cloud product (1729) | Older dedicated API tree | [product/hunyuan](https://cloud.tencent.com/product/hunyuan) / [docs 1729](https://cloud.tencent.com/document/product/1729) | Map row. Hy3 prose lives on TokenHub |
+| Yuanbao | All-in-one assistant that already uses Hy3 | [yuanbao.tencent.com](https://yuanbao.tencent.com/) | Map row → #76 |
+| CodeBuddy | Tencent Cloud coding assistant | [codebuddy.cn](https://www.codebuddy.cn/) | Map row → #78 |
+| WorkBuddy | Office agent workbench | [workbuddy.cn](https://www.workbuddy.cn/) / [cloud product](https://cloud.tencent.com/product/workbuddy) | Map row |
+| ima | Knowledge-base steward | [ima.qq.com](https://ima.qq.com/) | Map row |
+| Jobs / face ID / CVM / SMS | Non-topic nav items | — | **Out of scope** |
+
+**Name collisions** (full write-up in the [glossary](./hunyuan-glossary.md)):
+
+- **Hunyuan / Hy ≠ Yuanbao.** The model family is not the consumer chat app.
+- **Hy3 ≠ TokenHub ≠ AI Studio.** Model, gateway, playground.
+- **There is no first-party `hunyuan` CLI.** The coding agent product is CodeBuddy.
+- **Open-source repo names ≠ TokenHub `model` slugs.**
+
+### Quick decision
+
+```
+What do I want?
+├── Try Hy3 / translation / multimodal in a browser
+│   └── → Hy AI Studio (aistudio.tencent.com)
+├── Call Hunyuan from my own front end / Node service
+│   └── → TokenHub, model = hy3 (this handbook)
+├── Point Claude Code / Cursor at Hy3
+│   └── → TokenHub “connect AI tools”; Hy3 walkthrough is official 1823/131903
+│       └── CodeBuddy itself is #78, not this directory
+├── Serve open weights
+│   └── → github.com/Tencent-Hunyuan/Hy3 (official: 8-GPU class)
+├── Chat / search / write, no code
+│   └── → Yuanbao (#76)
+├── IDE completion / repo agent
+│   └── → CodeBuddy (#78)
+└── CVM / COS / SMS
+    └── → Out of scope
+```
+
+Sources: [hunyuan.tencent.com](https://hunyuan.tencent.com/), [TokenHub docs](https://cloud.tencent.com/document/product/1823), [Hy call guide](https://cloud.tencent.com/document/product/1823/132252).
+
+## When this handbook is worth it
+
+**Read it when**
+
+- You want an OpenAI-compatible domestic model from TypeScript, and the official door is TokenHub `hy3`.
+- You already use Claude Code / Cursor and want Hy3 on the same harness (official connect pages exist).
+- You need to compare hosted `hy3` with the open checkpoint.
+
+**Skip it when**
+
+- You want Yuanbao the chat app → #76.
+- You want CodeBuddy the coding product → #78.
+- You want MoE / MTP / attention internals → [LLM fundamentals](../../tech/fundamentals/LLM.md) and [Learn LLM](https://llm.zenheart.site/chapters/).
+
+## Learning path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Pick a door | This map | Stop mixing Yuanbao / TokenHub / Hy3 |
+| 2. First call | [Tutorial](./hunyuan.md) | A `hy3` completion in 15 minutes |
+| 3. Wire it in | [Cookbook](./hunyuan-cookbook.md) | Streaming, thinking, tools, Claude Code |
+| 4. Look up | [Cheatsheet](./hunyuan-cheatsheet.md) | Slugs, prices, endpoints |
+| 5. Names | [Glossary](./hunyuan-glossary.md) | Which official tree wins |
+
+## Model snapshot (Hy-family slugs only)
+
+Canonical table: [TokenHub model list](https://cloud.tencent.com/document/product/1823/130051). Prices: [pricing](https://cloud.tencent.com/document/product/1823/130055) (2026-08-14).
+
+| Official name | `model` | Window (in / out) | Official one-liner |
+|---------------|---------|-------------------|--------------------|
+| Hy3 | `hy3` | 192k / 128k (256k context) | Real-world Coding / long-context / Agent |
+| Hy3 preview | `hy3-preview` | same | **Retires 2026-08-31** |
+| Hy-MT2-Pro / Plus / Lite | `hy-mt2-*` | 4k / 4k | Translation |
+| Hy-Role / Latest | `hy-role` / `hunyuan-role-latest` | 28k / 4k | Role-play |
+| HY-Image-V3.0 | `hy-image-v3.0` | — | T2I / I2I |
+| HY-3D-3.1 | `hy-3d-3.1` | — | T23D / I23D |
+
+Hosted Hy3: **1 / 4 / 0.25** CNY per million tokens (input / output / cache hit). Open weights are a separate path: [tutorial](./hunyuan.md#open-weights).
+
+## Out of scope
+
+- Full Yuanbao / CodeBuddy / WorkBuddy / ima tutorials.
+- Picking DeepSeek / Kimi / GLM on TokenHub.
+- Non-AI Tencent Cloud (CVM, COS, SMS, domains).
+- Model internals.
+
+## Related
+
+- [Tutorial](./hunyuan.md)
+- [Cookbook](./hunyuan-cookbook.md)
+- [Cheatsheet](./hunyuan-cheatsheet.md)
+- [Glossary](./hunyuan-glossary.md)
+- [LLM fundamentals](../../tech/fundamentals/LLM.md)
+- [All products](../ai-coding/)

--- a/docs/zh/products/hunyuan/hunyuan-cheatsheet.md
+++ b/docs/zh/products/hunyuan/hunyuan-cheatsheet.md
@@ -1,0 +1,119 @@
+---
+title: 腾讯混元速查表
+description: "只查不学。slug、端点、价格以 TokenHub 当页为准。本页复核日 2026-08-19。"
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: cheatsheet
+---
+
+# 腾讯混元速查表
+
+只查不学。价格和 slug 会变，以链出去的官方页为准。
+
+## 决策
+
+| 场景 | 选 |
+|------|----|
+| 自己的服务调语言模型 | TokenHub `hy3` |
+| 网页先试用 | [AI Studio](https://aistudio.tencent.com/) |
+| 翻译 | `hy-mt2-pro` / `plus` / `lite` |
+| 角色扮演 | `hy-role` / `hunyuan-role-latest` |
+| 生图 | `hy-image-v3.0` |
+| 生 3D | `hy-3d-3.1` |
+| 自建推理 | [tencent/Hy3](https://huggingface.co/tencent/Hy3)，不是 TokenHub |
+| 聊天 App | 元宝，不是本表 |
+| 编码 IDE | CodeBuddy，不是本表 |
+
+## 端点与鉴权
+
+| 项 | 值 | 来源 |
+|----|----|------|
+| Base URL | `https://tokenhub.tencentmaas.com/v1` | [快速入门](https://cloud.tencent.com/document/product/1823/130058) |
+| Chat Completions | `POST /v1/chat/completions` | 同上 + [132252](https://cloud.tencent.com/document/product/1823/132252) |
+| 鉴权 | `Authorization: Bearer <TokenHub API Key>` | 同上 |
+| 协议 | OpenAI Chat Completions、OpenAI Responses、Anthropic Messages | [132252](https://cloud.tencent.com/document/product/1823/132252) |
+| 控制台 | https://console.cloud.tencent.com/tokenhub | TokenHub 产品页 |
+
+本地开源 serve 默认是 `http://127.0.0.1:8000/v1`，`api_key` 可用 `EMPTY`（Hy3 README）。
+
+## 混元系 `model` 参数
+
+来源：[模型列表](https://cloud.tencent.com/document/product/1823/130051)（复核 2026-08-19）。只抄混元 / Hy 行。
+
+| 名称 | `model` | 窗口 | 最大入 / 出 | 能力（官方列） |
+|------|---------|------|-------------|----------------|
+| Hy3 | `hy3` | 256k | 192k / 128k | 深度思考（保留式）、结构化输出、Function Calling、Cache |
+| Hy3 preview | `hy3-preview` | 256k | 192k / 128k | 交错式思考；**2026-08-31 下线** |
+| Hy-MT2-Pro | `hy-mt2-pro` | 8k | 4k / 4k | 翻译旗舰 |
+| Hy-MT2-Plus | `hy-mt2-plus` | 8k | 4k / 4k | 翻译 |
+| Hy-MT2-Lite | `hy-mt2-lite` | 8k | 4k / 4k | 翻译轻量 |
+| Hy-Role-Latest | `hunyuan-role-latest` | 32k | 28k / 4k | 角色扮演 |
+| Hy-Role | `hy-role` | 32k | 28k / 4k | 角色扮演 |
+| HY-Image-V3.0 | `hy-image-v3.0` | — | — | 文生图、图生图 |
+| Hy-Image-Lite | `hy-image-lite` | — | — | 文生图 |
+| HY-Video-1.5 | `hy-video-1.5` | — | — | 文生视频、图生视频 |
+| HY-3D-3.0 | `hy-3d-3.0` | — | — | 文生 3D、图生 3D |
+| HY-3D-3.1 | `hy-3d-3.1` | — | — | 文生 3D、图生 3D |
+| HY-3D-Express | `hy-3d-express` | — | — | 极速 3D |
+| HY-Vision-2.0-Instruct | `hy-vision-2.0-instruct` | 44k | 24k / 16k | 图生文 |
+| HY-Vision-1.5-Thinking | `hunyuan-t1-vision-20250916` | 40k | 16k / 24k | 视觉深度思考 |
+| HY-Vision-Video | `hunyuan-turbos-vision-video-20250728` | 32k | 24k / 8k | 视频理解 |
+
+视觉 / 3D 的并发与任务类型以模型列表当页为准。
+
+## 价格（后付费，元/百万 tokens）
+
+来源：[模型价格](https://cloud.tencent.com/document/product/1823/130055)，页面「最近更新时间：2026-08-14 21:58:00」。最终以账单为准。
+
+| 模型 | 输入 | 输出 | 缓存命中 |
+|------|------|------|----------|
+| Hy3 | 1 | 4 | 0.25 |
+| Hy3 preview（输入 &lt; 16k） | 1.2 | 4 | 0.4 |
+| Hy3 preview（16k–32k） | 1.6 | 6.4 | 0.6 |
+| Hy3 preview（32k+） | 2 | 8 | 0.8 |
+| Hy-MT2-Pro / Plus | 0.5 | 2 | — |
+| Hy-MT2-Lite | 0.3 | 1.2 | — |
+| Hy-Role / Latest | 2.4 | 9.6 | — |
+| Hy-Image-3.0 | 10（且 20,000 tokens/张 → 约 0.2 元/张） | | |
+
+免费体验：快速入门要求在模型广场领取，**额度以控制台为准**。
+
+## 思考相关字段
+
+| 面 | 字段 | 取值 | 来源 |
+|----|------|------|------|
+| TokenHub | `thinking` | `{ "type": "enabled" }` | [132252](https://cloud.tencent.com/document/product/1823/132252) |
+| TokenHub | `reasoning_effort` | `hy3` 默认 `low`；可 `high`。带 `tools` 时 `low`→`high` | 同上 |
+| 云产品页 tclm | 文案 | `no_think` / `think_low` / `think_high` | [tclm](https://cloud.tencent.com/product/tclm) |
+| 开源 README | `chat_template_kwargs.reasoning_effort` | `no_think`（默认）/ `low` / `high` | [Hy3 README](https://github.com/Tencent-Hunyuan/Hy3) |
+
+推荐采样（开源 README）：`temperature=0.9`，`top_p=1.0`。TokenHub 基础对话示例也用了 `temperature: 0.9`。
+
+## 术语索引
+
+一行一个，解释在 [术语表](./hunyuan-glossary.md)。
+
+| 词 | 钩子 |
+|----|------|
+| [Hy / 混元](./hunyuan-glossary.md#hy--混元) | 模型家族，不是 App |
+| [Hy3](./hunyuan-glossary.md#hy3) | 当前旗舰语言模型 |
+| [TokenHub](./hunyuan-glossary.md#tokenhub) | 云上网关，卖多家模型 |
+| [1729](./hunyuan-glossary.md#两套云文档) | 老混元 API 树 |
+| [元宝](./hunyuan-glossary.md#同厂产品不是混元) | C 端助手 |
+| [CodeBuddy](./hunyuan-glossary.md#同厂产品不是混元) | 编码工具 |
+
+## 高质量信息源
+
+- **[混元官网](https://hunyuan.tencent.com/)** — 模型与研究一级导航。建议访问方式：浏览器（SPA）。最后核实：2026-08-19
+- **[TokenHub 文档根](https://cloud.tencent.com/document/product/1823)** — 开通、调用、计费。最后核实：2026-08-19
+- **[模型列表](https://cloud.tencent.com/document/product/1823/130051)** — slug 真源。最后核实：2026-08-19
+- **[混元调用指南](https://cloud.tencent.com/document/product/1823/132252)** — `hy3` 请求示例。最后核实：2026-08-19
+- **[模型价格](https://cloud.tencent.com/document/product/1823/130055)** — 后付费表。最后核实：2026-08-19
+- **[快速入门](https://cloud.tencent.com/document/product/1823/130058)** — Key 与第一调用。最后核实：2026-08-19
+- **[Claude Code × Hy3](https://cloud.tencent.com/document/product/1823/131903)** — 官方接入。最后核实：2026-08-19
+- **[Hy3 GitHub](https://github.com/Tencent-Hunyuan/Hy3)** / **[HF tencent/Hy3](https://huggingface.co/tencent/Hy3)** — 开源规格与部署。最后核实：2026-08-19
+- **[org Tencent-Hunyuan](https://github.com/Tencent-Hunyuan)** — 其它开源模态。最后核实：2026-08-19
+- **[Hy AI Studio](https://aistudio.tencent.com/)** — 试用。最后核实：2026-08-19
+- **待核实**：Co-design 栏目的独立落地 URL（官网页头有入口，公开页抓取只拿到 SPA 壳）。

--- a/docs/zh/products/hunyuan/hunyuan-cookbook.md
+++ b/docs/zh/products/hunyuan/hunyuan-cookbook.md
@@ -1,0 +1,153 @@
+---
+title: 腾讯混元 Cookbook
+description: "只写能在 TokenHub 混元调用指南或 Hy3 README 里找到原文的配方。第三方模型选型不在这里。"
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: cookbook
+---
+
+# 腾讯混元 Cookbook
+
+每节一个问题。基础开通见 [教程](./hunyuan.md)。参数表见 [速查](./hunyuan-cheatsheet.md)。
+
+## 流式输出
+
+来源：[混元调用指南 · 流式请求](https://cloud.tencent.com/document/product/1823/132252)。`stream: true`；要在最后一个 chunk 拿 `usage`，加 `stream_options: { include_usage: true }`。
+
+```ts
+import OpenAI from 'openai'
+
+const client = new OpenAI({
+  apiKey: process.env.TOKENHUB_API_KEY,
+  baseURL: 'https://tokenhub.tencentmaas.com/v1',
+})
+
+const stream = await client.chat.completions.create({
+  model: 'hy3',
+  messages: [{ role: 'user', content: '你好' }],
+  stream: true,
+  stream_options: { include_usage: true },
+})
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content ?? '')
+  if (chunk.usage) console.log('\nusage:', chunk.usage)
+}
+```
+
+## 打开深度思考
+
+TokenHub 给了两套旋钮，都写在 [132252](https://cloud.tencent.com/document/product/1823/132252)：
+
+1. `thinking: { type: "enabled" }`，响应里用 `message.reasoning_content` 看思考过程。
+2. `reasoning_effort`：`hy3` / `hy3-preview` **默认 `low`**。可设 `high`。
+
+Node 官方示例把 `thinking` 放在请求顶层：
+
+```ts
+const response = await client.chat.completions.create({
+  model: 'hy3',
+  messages: [
+    { role: 'user', content: '小明有5个苹果，给了小红2个，又买了3个，最后还剩几个？' },
+  ],
+  thinking: { type: 'enabled' },
+})
+
+const msg = response.choices[0].message
+if (msg.reasoning_content) console.log('思考过程:', msg.reasoning_content)
+console.log('最终回答:', msg.content)
+```
+
+**toolcall 特例（官方原文）**：Hy3 正式版在携带 `tools` 时具备 adaptive thinking。若此时把 `reasoning_effort` 设为 `low`，API **会把 `low` 映射为 `high`**。不要按「我设了 low」去对账单。
+
+开源权重那条线用的是 `extra_body.chat_template_kwargs.reasoning_effort`（`no_think` / `low` / `high`），和 TokenHub 字段不是同一份 JSON。见 [术语表](./hunyuan-glossary.md)。
+
+## Function Calling
+
+调用指南「工具调用（Function Calling）」节要求走 OpenAI 风格的 `tools`。下面只保留官方结构，函数体换成前端常见的「查天气」占位，**工具名与参数以你自己的后端为准**；协议字段不要改。
+
+```ts
+const response = await client.chat.completions.create({
+  model: 'hy3',
+  messages: [{ role: 'user', content: '北京今天天气怎么样？' }],
+  tools: [
+    {
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        description: '查询城市天气',
+        parameters: {
+          type: 'object',
+          properties: {
+            city: { type: 'string', description: '城市名' },
+          },
+          required: ['city'],
+        },
+      },
+    },
+  ],
+})
+```
+
+具体 request / response 字段以 [132252](https://cloud.tencent.com/document/product/1823/132252) 当页示例为准，本页不二次发明。
+
+## 结构化输出
+
+同一篇调用指南把「结构化输出」列为 `hy3` 能力。JSON Schema 怎么塞进请求，以该页和 TokenHub「API 协议说明」为准。不要从别的厂商的 `response_format` 教程里猜字段名。
+
+## 把 Hy3 接到 Claude Code
+
+官方专项页：[在 Claude Code 中调用（Hy3 示例）](https://cloud.tencent.com/document/product/1823/131903)。快速入门还链了 Cursor、OpenClaw、Cline、Kilo Code、Roo Code、CodeBuddy Code。
+
+本站只记三件事：
+
+1. Base URL 是 TokenHub 的 OpenAI 或 Anthropic 兼容口，不是 `api.anthropic.com`。
+2. 模型 ID 写 `hy3`，不要写 `hunyuan`。
+3. Key 是 TokenHub API Key。CodeBuddy 自己怎么装，见 #78，不要混进这份配方。
+
+逐步点击以 131903 为准——TokenHub 文档会改路径，不要在本站再抄一份会过期的 `settings.json`。
+
+## 本机 serve 开源 Hy3（有卡再做）
+
+来源：[Hy3 README](https://github.com/Tencent-Hunyuan/Hy3)。官方建议 8 卡、H20-3e 级。
+
+vLLM（parser 名是 `hy_v3`）：
+
+```bash
+export VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm
+vllm serve tencent/Hy3 \
+  --tensor-parallel-size 8 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 2 \
+  --tool-call-parser hy_v3 \
+  --reasoning-parser hy_v3 \
+  --enable-auto-tool-choice \
+  --port 8000 \
+  --served-model-name hy3
+```
+
+SGLang（parser 名是 `hunyuan`）：
+
+```bash
+python3 -m sglang.launch_server \
+  --model tencent/Hy3 \
+  --tp-size 8 \
+  --tool-call-parser hunyuan \
+  --reasoning-parser hunyuan \
+  --speculative-num-steps 2 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 3 \
+  --speculative-algorithm EAGLE \
+  --port 8000 \
+  --served-model-name hy3
+```
+
+两套命令不要混用 parser 名。推荐采样：`temperature=0.9`，`top_p=1.0`。
+
+## 不要写进本页的配方
+
+- TokenHub 上选 DeepSeek / Kimi / GLM（不是混元）。
+- 元宝里切模型、CodeBuddy 装插件。
+- 把 1729 老文档里的 `hunyuan-turbo` / `Hunyuan-T1` 当当前默认。

--- a/docs/zh/products/hunyuan/hunyuan-glossary.md
+++ b/docs/zh/products/hunyuan/hunyuan-glossary.md
@@ -1,0 +1,85 @@
+---
+title: 腾讯混元术语表
+description: "不教操作。先分清 Hy、TokenHub、元宝、CodeBuddy，再处理两套云文档和三套思考字段。"
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: glossary
+---
+
+# 腾讯混元术语表
+
+不教操作，只解释「为什么会撞名」。选门看 [学习地图](./index.md)。
+
+## Hy / 混元
+
+**是什么**：腾讯自研大模型家族的现行品牌。官网 [hunyuan.tencent.com](https://hunyuan.tencent.com/) 与 [hy.tencent.com](https://hy.tencent.com/) 是同一站。国际通稿写过「Tencent Hy, formerly known as Tencent Hunyuan」。
+
+**不是什么**：不是元宝 App，不是 TokenHub 账号，不是一个可执行文件。
+
+仓库、论文、老云产品仍大量使用 Hunyuan。写文档时两种叫法都要能对上官方页，不要发明第三种「混元 3.0」当产品名——当前旗舰语言模型官方名是 **Hy3**。
+
+机制（为什么是 MoE、MTP 是什么）见 [Learn LLM](https://llm.zenheart.site/chapters/)，本页不展开。
+
+## Hy3
+
+**是什么**：2026-07-06 正式发布的旗舰语言模型。TokenHub slug `hy3`。开源权重 [Tencent-Hunyuan/Hy3](https://github.com/Tencent-Hunyuan/Hy3)：295B 总参数、21B 激活、256K 上下文、Apache-2.0。
+
+托管侧能力（[模型列表](https://cloud.tencent.com/document/product/1823/130051)）：深度思考（保留式）、结构化输出、Function Calling、Cache。产品页补充了 Coding / 长文 / Agent。
+
+**不是什么**：
+
+- 不是 `hy3-preview`。Preview 官方标注 2026-08-31 下线。
+- 不是「混元生图 / 生视频 / 生 3D」那些模态模型。
+- 不是 CodeBuddy 里的某一个按钮。
+
+## TokenHub
+
+**是什么**：腾讯云「大模型服务平台」。文档树产品 ID **1823**。官方概述：统一入口，**整合混元并引入第三方模型**。调混元只是它的一条线。
+
+**为什么单独成词**：2026 年 Hy3 的调用指南、价格、Key、Claude Code 接入都写在这棵树上。把它理解成「混元控制台」会漏掉「它还卖别人的模型」，也会和 1729 老树打架。
+
+鉴权是 TokenHub 自己的 API Key，不是随便一个腾讯云 SecretId/SecretKey。
+
+## 两套云文档
+
+| 树 | ID | 现在怎么用 |
+|----|-----|------------|
+| TokenHub | 1823 | **本站主源**。Hy3、价格、OpenAI 兼容口 |
+| 腾讯混元大模型 | 1729 | 仍在线。页面上还能看到 Hunyuan-T1 / TurboS 等更早规格 |
+
+[cloud.tencent.com/product/hunyuan](https://cloud.tencent.com/product/hunyuan) 抓下来仍偏老规格；同主题的 [product/tclm](https://cloud.tencent.com/product/tclm) 已切到 Hy3。两份营销页不一致时，**以 TokenHub 文档 + hunyuan.tencent.com 为准**，并在正文点名冲突。
+
+## 思考档位为什么有三套词
+
+不是三个产品，是三份官方页用了不同 JSON：
+
+| 出处 | 怎么写 |
+|------|--------|
+| TokenHub 调用指南 | `thinking: { type: "enabled" }`；`reasoning_effort`（`hy3` 默认 `low`） |
+| tclm 产品页 | `no_think` / `think_low` / `think_high` |
+| Hy3 开源 README | `extra_body.chat_template_kwargs.reasoning_effort = no_think \| low \| high`（默认 `no_think`） |
+
+本站不猜「TokenHub 的 low 等于开源的哪一档」。照你正在打的那份文档抄字段。带 `tools` 时 TokenHub 会把 `low` 映射成 `high`（调用指南原文）。
+
+## 同厂产品不是混元
+
+| 名字 | 官方一句话 / 定位 | 入口 | 本站 |
+|------|-------------------|------|------|
+| 元宝 | 「腾讯推出的全能 AI 助手，已接入最新的混元 Hy3 模型」 | [yuanbao.tencent.com](https://yuanbao.tencent.com/) | #76 |
+| CodeBuddy | 腾讯云代码助手（IDE / CLI） | [codebuddy.cn](https://www.codebuddy.cn/) | #78 |
+| WorkBuddy | 办公 Agent 工作台 | [workbuddy.cn](https://www.workbuddy.cn/) | 地图一行 |
+| ima | 「以知识库为基础的 AI 知识管家」 | [ima.qq.com](https://ima.qq.com/) | 地图一行 |
+
+它们**消费**混元（或其它模型），本身不是「混元开放能力」。Hy3 README 提到在 CodeBuddy / Cline / KiloCode 上评测，那是脚手架名字，不能反过来说混元 = CodeBuddy。
+
+## 开源名 vs API slug
+
+GitHub org [Tencent-Hunyuan](https://github.com/Tencent-Hunyuan) 的仓库名偏 Hunyuan*（HunyuanVideo、HunyuanImage-3.0、Hunyuan3D-2.1）。TokenHub 的调用参数偏 `hy-*` / `hy3`。
+
+对账时以各页原文为准，禁止「看名字像就当成同一个 model 字段」。
+
+## 本站不写的机制
+
+MoE 路由、MTP 推测解码、量化训练、RL 后训练流程：官方 README 有章节，但属于模型内部。需要原理时去 [LLM 基础](../../tech/fundamentals/LLM.md)。本目录只保留官方给出的**规格数字和启动命令**。

--- a/docs/zh/products/hunyuan/hunyuan.md
+++ b/docs/zh/products/hunyuan/hunyuan.md
@@ -1,0 +1,147 @@
+---
+title: 腾讯混元教程
+description: "先分清门，再在 TokenHub 上用 hy3 打出第一句。开源权重另有官方部署命令，本页只给入口。"
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: tutorial
+---
+
+# 腾讯混元教程
+
+> 本页带你走完「认产品 → 网页试用 → TokenHub 第一次调用 → 找到开源权重」。参数与价格见 [速查表](./hunyuan-cheatsheet.md)，场景配方见 [Cookbook](./hunyuan-cookbook.md)，撞名见 [术语表](./hunyuan-glossary.md)。
+>
+> 模型内部（MoE、MTP、注意力）不在这里讲，见 [LLM 基础](../../tech/fundamentals/LLM.md) 和 [Learn LLM](https://llm.zenheart.site/chapters/)。
+
+## 1. 先确认你进对了门
+
+| 你以为自己在用 | 实际是 | 下一步 |
+|----------------|--------|--------|
+| 「腾讯那个 AI」网页聊天 | 多半是 [元宝](https://yuanbao.tencent.com/) | 离开本页，见 #76 |
+| IDE 里补全 / 改仓库 | [CodeBuddy](https://www.codebuddy.cn/) | 离开本页，见 #78 |
+| 自己的服务要 `chat/completions` | **TokenHub + `hy3`** | 继续往下 |
+| 下载权重自己 serve | [Tencent-Hunyuan/Hy3](https://github.com/Tencent-Hunyuan/Hy3) | 跳到 [开源权重](#开源权重) |
+
+混元官网是 [hunyuan.tencent.com](https://hunyuan.tencent.com/)（同站 [hy.tencent.com](https://hy.tencent.com/)）。品牌文案已从 Hunyuan 迁到 **Hy**；API 和仓库里两套名字都还在。
+
+## 2. 网页试用（可选）
+
+官方试用台是 **Hy AI Studio**：[aistudio.tencent.com](https://aistudio.tencent.com/)。官网页头「试用 Hy」也进这里。适合确认模型口吻，不适合当生产端点。
+
+生产调用不要抄 Studio 的页面 URL，走下一节的 TokenHub。
+
+## 3. TokenHub：15 分钟第一次 `hy3`
+
+事实源：[快速入门](https://cloud.tencent.com/document/product/1823/130058)、[混元调用指南](https://cloud.tencent.com/document/product/1823/132252)。
+
+### 3.1 开通
+
+1. [注册腾讯云](https://cloud.tencent.com/register) 并完成实名（快速入门「准备工作」原文）。
+2. 登录 [TokenHub 控制台](https://console.cloud.tencent.com/tokenhub)，按界面开通。
+3. 在**模型广场**右上角领「新用户福利免费体验」。额度与有效期以控制台和 [新人免费体验包](https://cloud.tencent.com/document/product/1823) 文档为准，不要把营销页的「100 万 tokens」当成所有模型的固定配额。
+4. 打开 **API Key 管理** → 选地域 → **创建 API Key**。范围选「全选」或勾上 `hy3`。创建后立刻复制，页面不会反复明文展示。
+
+TokenHub 不是混元专用网关。它还提供 DeepSeek / Kimi / GLM 等。本教程只把 `model` 设成 `hy3`。
+
+### 3.2 调一次（TypeScript）
+
+端点：`https://tokenhub.tencentmaas.com/v1`。鉴权：`Authorization: Bearer <API Key>`。`hy3` 兼容 OpenAI Chat Completions（以及 Responses、Anthropic Messages，见调用指南）。
+
+官方 Node 示例把 `model` 换成 `hy3`，并带上调用指南推荐的 `temperature: 0.9`：
+
+```ts
+import OpenAI from 'openai'
+
+const client = new OpenAI({
+  apiKey: process.env.TOKENHUB_API_KEY,
+  baseURL: 'https://tokenhub.tencentmaas.com/v1',
+})
+
+const response = await client.chat.completions.create({
+  model: 'hy3',
+  messages: [{ role: 'user', content: '你好，请简单介绍一下你自己。' }],
+  temperature: 0.9,
+})
+
+console.log(response.choices[0].message.content)
+```
+
+curl 对照（[132252](https://cloud.tencent.com/document/product/1823/132252)）：
+
+```bash
+curl -X POST 'https://tokenhub.tencentmaas.com/v1/chat/completions' \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${TOKENHUB_API_KEY}" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "你好，请简单介绍一下你自己。"}],
+    "stream": false,
+    "temperature": 0.9
+  }'
+```
+
+成功时响应里的 `model` 是 `hy3`，`choices[0].message.content` 是正文。不要把示例里的 `YOUR_API_KEY` 提交进仓库。
+
+### 3.3 规格（托管）
+
+来源：[模型列表](https://cloud.tencent.com/document/product/1823/130051)、[模型价格](https://cloud.tencent.com/document/product/1823/130055)。
+
+| 项 | 官方值 |
+|----|--------|
+| `model` | `hy3` |
+| 上下文窗口 | 256k |
+| 最大输入 / 输出 | 192k / 128k |
+| 能力 | 深度思考（保留式）、结构化输出、Function Calling、Cache |
+| 后付费 | 输入 1 / 输出 4 / 缓存命中 0.25 **元/百万 tokens** |
+
+`hy3-preview` 能力相近，但官方写明 **2026-08-31 下线**。新代码不要再用 preview slug。
+
+思考档、流式、工具调用见 [Cookbook](./hunyuan-cookbook.md)。
+
+## 4. 接到现成 coding agent
+
+TokenHub 快速入门「通过 AI 工具调用模型」列出 Claude Code、Cursor、OpenClaw、CodeBuddy Code、Cline、Kilo Code、Roo Code 等。Hy3 在 Claude Code 里的官方步骤：[1823/131903](https://cloud.tencent.com/document/product/1823/131903)。
+
+本页不复制那些 IDE 的安装过程。要点只有一句：把兼容端点指到 `https://tokenhub.tencentmaas.com/v1`，模型填 `hy3`，Key 用 TokenHub 的。CodeBuddy 本身怎么用，去 #78。
+
+## 5. 开源权重
+
+旗舰开源模型是 **Hy3**：[GitHub](https://github.com/Tencent-Hunyuan/Hy3)、[Hugging Face `tencent/Hy3`](https://huggingface.co/tencent/Hy3)。Apache-2.0。联系邮箱（README 原文）：`hunyuan_opensource@tencent.com`。
+
+官方规格（不要改数字）：295B MoE、21B 激活、3.8B MTP、256K 上下文、192 experts top-8。README 原文：满血 serve 建议 **8 卡**，推荐 H20-3e 或显存更大的 GPU。这不是「笔记本 `ollama run`」那条路。
+
+本地先起服务，再打 OpenAI 兼容口（README Quickstart）：
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "Hello! Can you briefly introduce yourself?"}],
+    temperature=0.9,
+    top_p=1.0,
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+)
+print(response.choices[0].message.content)
+```
+
+启动命令以仓库 README 为准。两套 parser **不要抄混**：
+
+- vLLM：`--tool-call-parser hy_v3`、`--reasoning-parser hy_v3`
+- SGLang：`--tool-call-parser hunyuan`、`--reasoning-parser hunyuan`
+
+同 org 还有 HunyuanVideo、HunyuanImage-3.0、Hunyuan3D-2.1、HunyuanOCR 等。下载哪个仓，看你要的模态，不要假设都能用 `hy3` 这个 slug 调用。
+
+## 6. 常见失败
+
+| 现象 | 先查 |
+|------|------|
+| 401 | Key 没带、带了腾讯云 CAM 密钥而不是 TokenHub API Key |
+| 模型不存在 | `model` 写成了 `hunyuan` / `Hy3` / `hy3-preview`（后者临近下线） |
+| 思考字段对不上 | TokenHub 用 `thinking` / `reasoning_effort`；本地 README 用 `chat_template_kwargs`。见 [术语表](./hunyuan-glossary.md) |
+| 想找 CLI | 混元没有第一方 CLI。终端 Agent 是 CodeBuddy |
+
+下一步：[Cookbook](./hunyuan-cookbook.md) 或 [速查表](./hunyuan-cheatsheet.md)。

--- a/docs/zh/products/hunyuan/index.md
+++ b/docs/zh/products/hunyuan/index.md
@@ -1,0 +1,135 @@
+---
+title: 腾讯混元学习地图
+description: "混元（Tencent Hy）是腾讯的模型与开放能力，不是元宝，也不是 CodeBuddy。本目录只教怎么认模型、怎么在 TokenHub 上调 Hy3、怎么找到开源权重。"
+domain: product
+tags:
+  - hunyuan
+  - llm-api
+role: map
+---
+
+# 腾讯混元学习地图
+
+> **混元 / Tencent Hy** 是腾讯自研的大模型家族，以及把这些模型开放给开发者的通道。官网定义自己是「全链路自研」的模型与研究站（[hunyuan.tencent.com](https://hunyuan.tencent.com/)）。云上调用走 [TokenHub](https://cloud.tencent.com/document/product/1823)。
+>
+> 本目录**只写模型与开放能力**。元宝、CodeBuddy、WorkBuddy、ima 是同厂其它产品，只在下面家族图占一行。
+
+## 产品全景
+
+好几个腾讯入口都带「混元」或「Hy」。它们**不是**同一个产品的四张皮。
+
+```
+腾讯 AI（与混元相关的官方一级）
+├── 混元 / Hy — 模型、研究、开源（本目录主线）
+│   ├── Hy 模型（Hy3、Hy-MT2、生图 / 生视频 / 生 3D / 视觉理解 / ASR）
+│   ├── 研究（Hy3 技术帖、Hyra 等）
+│   ├── Co-design / International（官网栏目，不是独立调用面）
+│   ├── 试用 Hy（Hy AI Studio）
+│   └── 开源权重（GitHub Tencent-Hunyuan / Hugging Face tencent/Hy3）
+├── TokenHub — 云上模型网关（调混元，也卖第三方模型）
+├── 腾讯混元大模型（云产品 1729，老 API 树）
+├── 元宝 — C 端助手（接入了 Hy3）          → issue #76
+├── CodeBuddy — 编码 IDE / CLI               → issue #78
+├── WorkBuddy — 办公 Agent
+└── ima — 知识管家
+```
+
+| 入口 | 是什么 | 官方 URL | 本站去向 |
+|------|--------|----------|----------|
+| **Hy 模型 / 混元官网** | 模型与研究主站 | [hunyuan.tencent.com](https://hunyuan.tencent.com/) | 本页 + [教程](./hunyuan.md) |
+| **TokenHub** | 统一大模型 API（混元 + 第三方） | [产品页](https://cloud.tencent.com/product/tokenhub) / [文档 1823](https://cloud.tencent.com/document/product/1823) | [教程](./hunyuan.md) / [Cookbook](./hunyuan-cookbook.md) / [速查](./hunyuan-cheatsheet.md) |
+| 试用 Hy（AI Studio） | 网页里试用对话 / 多模态 | [aistudio.tencent.com](https://aistudio.tencent.com/) | 教程一节，不拆页 |
+| 开源权重 | Hy3 等 Apache-2.0 权重与部署脚本 | [Tencent-Hunyuan](https://github.com/Tencent-Hunyuan) / [tencent/Hy3](https://huggingface.co/tencent/Hy3) | 教程一节 + 速查 |
+| 研究 | 技术帖与论文 | [research](https://hunyuan.tencent.com/research) / [Hy3 帖](https://hy.tencent.com/research/hy3) | 地图一行 |
+| Co-design / International | 官网一级栏目 | [hunyuan.tencent.com](https://hunyuan.tencent.com/) 页头 | 地图一行；不是新产品 |
+| 腾讯混元大模型（1729） | 更早的云 API 产品树 | [product/hunyuan](https://cloud.tencent.com/product/hunyuan) / [文档 1729](https://cloud.tencent.com/document/product/1729) | 地图一行。Hy3 正文以 TokenHub 为准 |
+| 元宝 | 全能 AI 助手，已接入 Hy3 | [yuanbao.tencent.com](https://yuanbao.tencent.com/) | 地图一行，正文见 #76 |
+| CodeBuddy | 腾讯云代码助手 | [codebuddy.cn](https://www.codebuddy.cn/) | 地图一行，正文见 #78 |
+| WorkBuddy | 办公 Agent 工作台 | [workbuddy.cn](https://www.workbuddy.cn/) / [云产品页](https://cloud.tencent.com/product/workbuddy) | 地图一行，不写教程 |
+| ima | 以知识库为基础的 AI 知识管家 | [ima.qq.com](https://ima.qq.com/) | 地图一行，不写教程 |
+| 招聘 / 人脸识别 / 云主机 / 短信 | 官网或腾讯云一级 nav 里的非本主题项 | — | **非本站** |
+
+**容易撞名的几条**（展开见 [术语表](./hunyuan-glossary.md)）：
+
+- **混元 / Hy ≠ 元宝**。混元是模型；元宝是 C 端助手。
+- **Hy3 ≠ TokenHub ≠ AI Studio**。模型、网关、试用台是三件事。
+- **没有官方 `hunyuan` CLI**。终端里写代码的是 CodeBuddy，不是本目录。
+- **开源仓库名 ≠ TokenHub 的 `model` 参数**。例如权重 `HunyuanImage-3.0` 对 API slug `hy-image-v3.0`。
+
+### 快速决策：我该走哪扇门？
+
+```
+我要做什么？
+├── 在网页里先试试 Hy3 / 翻译 / 多模态
+│   └── → Hy AI Studio（aistudio.tencent.com）或官网「试用 Hy」
+├── 在自己的前端 / Node 服务里调混元
+│   └── → TokenHub，model = hy3（本目录主线）
+├── 把 Hy3 接到 Claude Code / Cursor 等现成 coding agent
+│   └── → TokenHub「接入 AI 工具」；Hy3 示例见官方 1823/131903
+│       └── 不要在本目录找 CodeBuddy 教程（那是 #78）
+├── 本机 / 自建集群跑开源权重
+│   └── → github.com/Tencent-Hunyuan/Hy3（官方写的是 8 卡级 GPU）
+├── 只要聊天、搜索、写文档，不写代码
+│   └── → 元宝（#76），不是本目录
+├── 要 IDE 补全 / 仓库 Agent
+│   └── → CodeBuddy（#78），不是混元 CLI
+└── 云主机 / 对象存储 / 短信
+    └── → 非本站。不要在混元文档里找
+```
+
+来源：[hunyuan.tencent.com](https://hunyuan.tencent.com/)、[TokenHub 文档](https://cloud.tencent.com/document/product/1823)、[混元调用指南](https://cloud.tencent.com/document/product/1823/132252)。
+
+## 什么时候值得看这套文档
+
+**值得看**
+
+- 你要在 TypeScript / Node 里用 OpenAI 兼容 SDK 调一个国内模型，官方推荐入口是 TokenHub，slug 是 `hy3`。
+- 你已经在用 Claude Code / Cursor，想换成或兼用 Hy3（官方有接入页）。
+- 你要对照开源权重和托管 API，而不是再装一个腾讯编码 IDE。
+
+**先别看**
+
+- 你要的是元宝那种聊天 App —— 去 #76。
+- 你要的是 CodeBuddy 的补全和仓库 Agent —— 去 #78。
+- 你想搞懂 MoE / MTP / 注意力为什么这样设计 —— 去 [LLM 基础](../../tech/fundamentals/LLM.md) 和 [Learn LLM](https://llm.zenheart.site/chapters/)。本目录不写模型内部。
+
+## 学习路径
+
+| 阶段 | 读 | 目标 |
+|------|----|------|
+| 1. 认门 | 本页家族图 | 不再把元宝 / TokenHub / Hy3 当成同一个东西 |
+| 2. 调通 | [教程](./hunyuan.md) | 15 分钟内用 TokenHub 打出第一句 `hy3` |
+| 3. 接到工作流 | [Cookbook](./hunyuan-cookbook.md) | 流式、思考档、Function Calling、Claude Code |
+| 4. 查参数 | [速查表](./hunyuan-cheatsheet.md) | slug、价格、端点、数据源 |
+| 5. 分清名字 | [术语表](./hunyuan-glossary.md) | 两套官方页谁说了算 |
+
+## 模型速查（只列官方已给 slug 的混元系）
+
+完整表以 [TokenHub 模型列表](https://cloud.tencent.com/document/product/1823/130051) 为准。价格只抄 [模型价格](https://cloud.tencent.com/document/product/1823/130055)（2026-08-14）。
+
+| 官方名 | `model` | 窗口（入 / 出） | 一句话（官方） |
+|--------|---------|-----------------|----------------|
+| Hy3 | `hy3` | 192k / 128k（窗口 256k） | 「基于真实业务场景打磨……强化 Coding、长文、推理和 Agent」 |
+| Hy3 preview | `hy3-preview` | 同上 | 官方标注 **2026-08-31 下线**，不要当默认 |
+| Hy-MT2-Pro / Plus / Lite | `hy-mt2-pro` 等 | 4k / 4k | 翻译专项 |
+| Hy-Role / Latest | `hy-role` / `hunyuan-role-latest` | 28k / 4k | 角色扮演 |
+| HY-Image-V3.0 | `hy-image-v3.0` | — | 文生图 / 图生图 |
+| HY-3D-3.1 | `hy-3d-3.1` | — | 文生 3D / 图生 3D |
+
+Hy3 托管价：输入 **1** / 输出 **4** / 缓存命中 **0.25** 元/百万 tokens。开源权重是另一条线，见 [教程 · 开源](./hunyuan.md#开源权重)。
+
+## 本目录不写什么
+
+- 元宝、CodeBuddy、WorkBuddy、ima 的完整教程。
+- TokenHub 上的 DeepSeek / Kimi / GLM 选型（那是网关能力，不是混元）。
+- 腾讯云非 AI 产品（CVM、COS、短信、域名）。
+- 模型内部训练与推理机制。
+
+## 相关页面
+
+- [教程](./hunyuan.md) — 试用、第一次 API、开源入口
+- [Cookbook](./hunyuan-cookbook.md)
+- [速查表](./hunyuan-cheatsheet.md)
+- [术语表](./hunyuan-glossary.md)
+- [LLM 基础](../../tech/fundamentals/LLM.md)
+- [产品总览](../ai-coding/)


### PR DESCRIPTION
Closes #77

## What

First Tencent Hunyuan / Hy handbook: **models and open capabilities only**. ZH + EN, Diataxis after official Retrieve — not a cloned Claude/Grok five-file set of coding-agent docs.

```
docs/zh/products/hunyuan/     # map, tutorial, cookbook, cheatsheet, glossary
docs/products/hunyuan/        # same shape
.claude/skills/doc-research/references/hunyuan.md
```

Nav: `docs/.vitepress/sidebars/ai-coding.mjs` only (map / core / reference). **Did not touch `products-gallery.js`** (explicit worktree constraint).

## Retrieve (2026-08-19)

Official doors opened: [hunyuan.tencent.com](https://hunyuan.tencent.com/), [hy.tencent.com](https://hy.tencent.com/), [model/hy-model](https://hunyuan.tencent.com/model/hy-model), [research/hy3](https://hy.tencent.com/research/hy3), [AI Studio](https://aistudio.tencent.com/), [TokenHub](https://cloud.tencent.com/product/tokenhub) + [docs 1823](https://cloud.tencent.com/document/product/1823), [product/hunyuan](https://cloud.tencent.com/product/hunyuan) / [1729](https://cloud.tencent.com/document/product/1729), [tclm](https://cloud.tencent.com/product/tclm), [Tencent-Hunyuan/Hy3](https://github.com/Tencent-Hunyuan/Hy3), [huggingface.co/tencent/Hy3](https://huggingface.co/tencent/Hy3).

| Official first-level AI door | This site |
|---|---|
| Hy models / Hunyuan site | Independent tutorial |
| TokenHub (hosted `hy3`) | Tutorial + cookbook + cheatsheet |
| Try Hy / AI Studio | Tutorial section |
| Open weights | Tutorial section + cheatsheet |
| Research / Co-design / International | Map row |
| Hunyuan cloud product 1729 | Map row; Hy3 prose follows TokenHub |
| Yuanbao | Map row → #76 |
| CodeBuddy | Map row → #78 |
| WorkBuddy / ima | Map row + official URL |
| Jobs / CVM / SMS / face ID | Marked out of scope |

## Fit for frontend engineers

Hunyuan is a **model + OpenAI/Anthropic-compatible API**, not a first-party coding CLI. The official Node samples and TokenHub “connect Claude Code / Cursor” pages are the useful surface. Local full Hy3 wants 8×H20-class GPUs — tutorial gives official serve commands only. IDE/repo work is CodeBuddy — one line, no tutorial here. Model internals link to Learn LLM.

## Guardrails honored

- No Yuanbao / CodeBuddy / WorkBuddy / ima tutorials.
- No non-AI Tencent Cloud.
- TokenHub is documented as a **multi-vendor gateway**; examples stay on `hy3`.
- Two official trees (1823 vs 1729) and three thinking vocabularies are named side by side. TokenHub + hunyuan.tencent.com win for current Hy3.
- `hy3-preview` is marked **retires 2026-08-31**.
- No invented CLI flags or “usually / should be” facts.

## Checks

- [x] `references/hunyuan.md` product-shape research before the tutorial
- [x] Family map has a destination for every official first-level AI door we could open
- [x] No sibling-product tutorials in this directory
- [x] `pnpm docs:build` passed
- [x] Auditor-style pass: no `should be` / `usually` facts; collision table present