### PR TITLE
docs(kimi): add Kimi chat/agent handbook (ZH+EN)

### DIFF
--- a/.claude/skills/doc-research/references/kimi.md
+++ b/.claude/skills/doc-research/references/kimi.md
@@ -1,0 +1,139 @@
+# Kimi 维护参考
+
+> 通用维护流程见 [`maintenance-workflow.md`](./maintenance-workflow.md)。读者可见的数据源写在 `docs/zh/products/kimi/kimi-cheatsheet.md` 的「高质量信息源」。架构见 [`documentation-architecture.md`](./documentation-architecture.md)。
+
+## 产品形态调研结论（写教程前必须先有这一节）
+
+调研时间：2026-08-19。每条都来自一手官方页，来源标在括号里。
+
+**结论一：本 issue 的产品是 kimi.com 上的对话 / Agent 工作台，不是 Kimi Code。**
+
+- [kimi.com/zh-cn/products](https://www.kimi.com/zh-cn/products/) 把「Kimi」写成「一站式 AI 工作台。从深度研究、幻灯片到表格、文档与网站，Kimi 内置强大的 Agent 能力」。
+- 英文产品 nav 原文：「Kimi — All-in-one agentic AI workspace」。
+- 帮助中心 [Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview) 把对话侧 Agent 入口写成网页 `https://www.kimi.com/agent`，手机/平板是 Kimi App 里切 **K3** 或 **K3 集群 / K3 Swarm**。
+- 本目录**禁止**把 Kimi Code CLI 安装写成主教程。Kimi Code 只在家族图占一行，链到 `/zh/products/kimi-code/`（#71）。
+
+**结论二：官方产品页一级入口是 5 个，首页 / 帮助中心还露出对话侧形态。**
+
+产品页一级（[zh-cn/products](https://www.kimi.com/zh-cn/products/)）：
+
+| 一级入口 | 官方一句话 |
+|----------|------------|
+| **Kimi** | 一站式 AI 工作台 |
+| **Kimi Work** | 搭载 Agent Swarm 与预接专业数据源的 AI 桌面端 |
+| **Kimi Code** | 面向开发者的 AI 编程助手；CLI 与插件 |
+| **Kimi WebBridge** | 专为 AI Agent 打造的浏览器插件 |
+| **Kimi Platform** | 官方 API 开放平台 |
+
+首页侧栏（[kimi.com](https://www.kimi.com/)）另有：Plugins、Scheduled Tasks、Slides、Swarm、Deep Research、Docs、Websites、Sheets、Design，以及 **Kimi Work / Kimi Code / Kimi Claw**。帮助中心把 Agent Mode、Kimi Claw、Kimi Business、Kimi API 单独成类。
+
+**结论三：Claw / Swarm / Goal 是 kimi.com 对话侧形态，不是 Kimi Code。**
+
+- **Kimi Agent**：自主助手，K3 驱动，20+ 工具；入口 `kimi.com/agent`（[Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview)）。
+- **Agent Swarm**：最多 300 个子 Agent 并行；入口 `kimi.com/agent-swarm`；会员 Moderato 及以上（[Agent Swarm](https://www.kimi.com/zh-hans/help/agent/agent-swarm)）。
+- **Kimi Claw**：一键把 OpenClaw 部署到云端；入口 `kimi.com/bot`；Allegretto 及以上（[Claw overview](https://www.kimi.com/en/help/kimi-claw/overview)）。
+- **Goal**：会员表有 Goal Mode（Allegretto 起）；项目对话可「use plugins, Skills, and Goal」（[Projects](https://www.kimi.com/help/features/project)）。**不要**把 Kimi Code 的 `/goal` 写成 kimi.com 聊天命令。
+
+**结论四：两套官方套餐名并存，禁止自行对齐。**
+
+- [会员概览](https://www.kimi.com/help/membership/membership-overview)：**Moderato $19 / Allegretto $39 / Allegro $99 / Vivace $199**。聊天里 **K2.6 对所有用户免费且不消耗额度**。会员功能共用额度池。
+- [Projects](https://www.kimi.com/help/features/project) 与 [Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks) 用 **Free / Go / Pro / Max / Ultra**，数字也不完全等于会员概览那张表。
+- 教程必须并列引用、写清以哪份为准。禁止把 Moderato 写成 Go。
+
+**结论五：适合本站「前端工程师选产品面」定位；编码仓库工作链走 Kimi Code。**
+
+- 浏览器即可用，对位 Claude.ai / Grok 聊天。
+- 对话里能出网站 / PPT / 表格 / 深度研究，仍是工作台，不是对着 checkout 改文件的 CLI。
+- 真要终端 / IDE 改仓库 → 家族图一行链 Kimi Code，本目录不写安装。
+
+**禁止当事实写：**
+
+- Kimi Code 安装命令当本目录主路径（`curl …install.sh`、`npm i -g @moonshot-ai/kimi-code`、`kimi --version`）。
+- 把 `/goal`、`kimi -p` 写成 kimi.com 输入框命令。
+- 臆造人民币价、自行映射 Moderato↔Go。
+- 把 Kimi Work Projects 和 kimi.com Projects 写成同一份数据（官方原文：not connected and don't share data）。
+- 模型内部机制（PARL 训练细节只链官方，本站不展开）→ [Learn LLM](/zh/tech/fundamentals/LLM)。
+
+## 基本信息
+
+- 工具名：Kimi（kimi.com 对话与 Agent）
+- 厂商：月之暗面 Moonshot AI
+- 官方产品页：<https://www.kimi.com/zh-cn/products/>
+- 产品本体：<https://www.kimi.com/>
+- 帮助中心：<https://www.kimi.com/zh-hans/help> / <https://www.kimi.com/help>
+- 公司站：<https://www.moonshot.cn/>
+- 发版节奏：帮助中心 Agent 时间线到 2026-07 K3；会员与功能页会改数字
+- 当前覆盖：2026-08-19 打开的官方页（见监控页面）
+
+## 官方一级导航（产品家族）
+
+| 官方一级入口 | 官方 URL | 本站去向 | 不拆页理由（若一行） |
+|--------------|----------|----------|----------------------|
+| Kimi 工作台 / 对话 | https://www.kimi.com/ | 独立页 `kimi.md` | |
+| Kimi Agent | https://www.kimi.com/agent | 独立页 `kimi.md` | 与对话同一产品面 |
+| Agent Swarm | https://www.kimi.com/agent-swarm | Tutorial + Cookbook | 对话侧模式，官方有完整帮助 |
+| Kimi Claw | https://www.kimi.com/bot | Tutorial + Cookbook | 对话侧云端 OpenClaw；帮助中心 15 篇，本 issue 不单独立 Code 式教程 |
+| Goal | 会员表 + Projects 页 | 地图一行 + Tutorial 一节 | 官方没有独立 Goal 产品页；聊天侧只写 Projects / 会员原文 |
+| Slides / Docs / Sheets / Deep Research / Websites / Design | 首页侧栏 | 地图一行 | 工作台能力，不是另一厂产品 |
+| Plugins / Scheduled Tasks / Skills / Projects / Memory | 帮助中心 Features | Tutorial / Cookbook / Cheatsheet | 横切能力 |
+| **Kimi Code** | 产品页「Kimi Code」 | **地图一行** → `/zh/products/kimi-code/` | #71；本目录不写安装 |
+| Kimi Work | https://www.kimi.com/products/kimi-work | 地图一行 | 桌面知识工作 Agent；另产品 |
+| Kimi WebBridge | 产品页「Kimi WebBridge」 | 地图一行 | 浏览器插件；另产品 |
+| Kimi Platform / API | https://platform.moonshot.cn/ | 地图一行 | HTTP API；另产品 |
+| Kimi Business | 帮助中心 Kimi Business | 地图一行 | 企业方案 |
+| 研究 / Doodle / 加入我们 | https://www.moonshot.cn/ | 非本站 | 公司站，不是 AI 产品入口 |
+
+易撞名：Kimi ≠ Kimi Code ≠ Kimi Work ≠ Kimi Claw；Agent ≠ Agent Swarm ≠ Claw 群聊；Goal（工作台）≠ Kimi Code `/goal`；kimi.com Projects ≠ Kimi Work Projects；OpenClaw ≠ Kimi Claw。
+
+## 文档文件结构（Diataxis）
+
+本目录只收 **kimi.com 对话与 Agent**。5 文件，不单独立 Claw / Work / Code 教程。
+
+```
+docs/zh/products/kimi/
+├── index.md              # 学习地图 + 家族表
+├── kimi.md               # Tutorial：打开 kimi.com，对话 / Agent / Swarm / Claw
+├── kimi-cookbook.md      # How-to：场景配方
+├── kimi-cheatsheet.md    # Reference：入口、额度表、信息源
+└── kimi-glossary.md      # Explanation：撞名与「不是什么」
+
+docs/products/kimi/       # 英文同构
+```
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 | 家族表、决策树 | 操作步骤、Code 安装 |
+| `kimi.md` | Tutorial | 入口、对话、Agent、Swarm、Claw、会员口径 | Code CLI、API 调用 |
+| `kimi-cookbook.md` | How-to | 可跳读配方 | 基础「打开网站」 |
+| `kimi-cheatsheet.md` | Reference | 入口、套餐原文表、信息源 | 概念散文 |
+| `kimi-glossary.md` | Explanation | 是什么 / 不是什么 | 参数清单 |
+
+跨页：`index` → `kimi` → `kimi-cookbook` → `kimi-cheatsheet` → `kimi-glossary`。
+
+## 监控页面
+
+- 产品家族：<https://www.kimi.com/zh-cn/products/>
+- 产品本体：<https://www.kimi.com/>
+- 帮助中心：<https://www.kimi.com/zh-hans/help>、<https://www.kimi.com/help>
+- Agent：<https://www.kimi.com/zh-cn/help/agent/agent-overview>
+- Agent Swarm：<https://www.kimi.com/zh-hans/help/agent/agent-swarm>
+- 会员：<https://www.kimi.com/zh-hans/help/membership/membership-overview>
+- Claw：<https://www.kimi.com/en/help/kimi-claw/overview>、<https://www.kimi.com/help/kimi-claw/group-chat>
+- Features：Projects / Skills / Plugins / Scheduled Tasks / Memory
+- 公司站：<https://www.moonshot.cn/>
+- API：<https://platform.moonshot.cn/>、<https://platform.kimi.com/>
+
+## Git 提交 scope
+
+```
+docs(kimi): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+1. **`www.kimi.com` 对部分抓取器会解析到 198.18.x（SSRF 拦截）**。用 web-reader / 浏览器，不要假设 `web_fetch` 能通。
+2. **帮助中心 slug 不稳定**：猜路径常落到站内搜索空结果。先打开分类页抄侧栏 slug。
+3. **中英帮助路径**：`/zh-cn/help`、`/zh-hans/help`、`/help` 三套并存；canonical 有时跳 `kimi.ai`。链官方时优先用打开成功的那条。
+4. **套餐名两套**：会员页乐理名 + 美元；Projects / Scheduled Tasks 用 Free/Go/Pro/Max/Ultra。更新额度时两张表都要核。
+5. **Kimi Code 命令不要漏进本目录**。复核时搜 `install.sh`、`@moonshot-ai/kimi-code`、`kimi --version`、`/login`。
+6. **导航**：本 issue 执行时用户明确禁止改 gallery / sidebar。页能打开即可。

--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -12,5 +12,6 @@
 | Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
 | Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
 | Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| Kimi | [`kimi.md`](./kimi.md) | `docs/zh/products/kimi/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/docs/products/kimi/index.md
+++ b/docs/products/kimi/index.md
@@ -1,0 +1,109 @@
+---
+title: Kimi learning map
+description: Moonshot ships several surfaces named Kimi. This directory covers kimi.com chat and Agent only. Kimi Code is one family-table row.
+domain: product
+tags:
+  - chat
+role: map
+---
+
+# Kimi learning map
+
+> **Kimi** is Moonshot AI's all-in-one workspace. Official product-page copy ([kimi.com/zh-cn/products](https://www.kimi.com/zh-cn/products/)):
+> a one-stop AI workspace with built-in Agent capabilities for deep research, slides, sheets, documents, and websites.
+>
+> English product nav: "**Kimi** — All-in-one agentic AI workspace."
+>
+> This directory is the Claude.ai / Grok Chat analog. It is **not** Kimi Code. The terminal / IDE coding agent is [Kimi Code](/products/kimi-code/).
+
+## Product family
+
+Every official first-class AI entry must appear here. Thin official density stays a single row.
+
+| Official first-class entry | Official URL | This site |
+|----------------------------|--------------|-----------|
+| **Kimi** (workspace / chat) | [kimi.com](https://www.kimi.com/), [zh-cn/products](https://www.kimi.com/zh-cn/products/) | Standalone [kimi.md](./kimi.md) |
+| **Kimi Agent** | [kimi.com/agent](https://www.kimi.com/agent), [Agent overview](https://www.kimi.com/help/agent/agent-overview) | Same tutorial |
+| **Agent Swarm** | [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm), [Agent Swarm](https://www.kimi.com/help/agent/agent-swarm) | Tutorial + [Cookbook](./kimi-cookbook.md) |
+| **Kimi Claw** | [kimi.com/bot](https://www.kimi.com/bot), [Claw overview](https://www.kimi.com/en/help/kimi-claw/overview) | Tutorial + Cookbook (cloud OpenClaw on the chat side) |
+| **Goal** | Membership "Goal Mode"; project chats can use Goal ([Projects](https://www.kimi.com/help/features/project)) | One map row + a tutorial section. **Not** Kimi Code `/goal` |
+| Slides / Docs / Sheets / Deep Research / Websites / Design | Home sidebar ([kimi.com](https://www.kimi.com/)) | One row: workspace capabilities, no extra pages |
+| Plugins / Scheduled Tasks / Skills / Projects / Memory | [Help → Features](https://www.kimi.com/help/features) | Tutorial / Cookbook / [cheatsheet](./kimi-cheatsheet.md) |
+| **Kimi Code** | Products page "Kimi Code" | **One row:** [Kimi Code](/products/kimi-code/) (issue #71; no install here) |
+| **Kimi Work** | [kimi.com/products/kimi-work](https://www.kimi.com/products/kimi-work) | One row: Mac/Windows desktop knowledge-work agent |
+| **Kimi WebBridge** | Products page "Kimi WebBridge" | One row: browser extension for agents |
+| **Kimi Platform / API** | [platform.moonshot.cn](https://platform.moonshot.cn/) | One row: HTTP API |
+| **Kimi Business** | [Help Center](https://www.kimi.com/help) "Kimi Business" | One row: enterprise |
+| Research / doodles / careers | [moonshot.cn](https://www.moonshot.cn/) | Out of scope |
+
+```
+Moonshot / Kimi family
+├── Kimi (kimi.com workspace) ← this directory
+│   ├── Chat (official: K2.6 is free in Chat and does not consume credits)
+│   ├── Agent (kimi.com/agent; App → K3)
+│   ├── Agent Swarm (kimi.com/agent-swarm; App → K3 Swarm)
+│   ├── Goal / Projects / Skills / Plugins / scheduled tasks / memory
+│   └── Kimi Claw (kimi.com/bot; cloud OpenClaw)
+├── Kimi Code — terminal and IDE coding agent → /products/kimi-code/
+├── Kimi Work — desktop local agent
+├── Kimi WebBridge — browser extension
+├── Kimi Platform — model API
+└── Kimi Business — enterprise
+```
+
+**Name collisions:**
+
+- **Kimi ≠ Kimi Code ≠ Kimi Work ≠ Kimi Claw**.
+- **Agent ≠ Agent Swarm ≠ Claw group chat**.
+- **Goal (workspace) ≠ Kimi Code `/goal`**.
+- **kimi.com Projects ≠ Kimi Work Projects** — official: not connected and don't share data ([Projects](https://www.kimi.com/help/features/project)).
+
+### Decision tree
+
+```
+What do you need?
+├── Browser Q&A / docs / slides / sheets / deep research / site preview
+│   └── → [Kimi chat and Agent](./kimi.md)
+│       ├── Everyday Q&A → kimi.com (official: K2.6 is free, no credit burn)
+│       ├── End-to-end site / Office / report → kimi.com/agent, or App → K3
+│       ├── Large parallel collection / long writing → kimi.com/agent-swarm, or K3 Swarm
+│       ├── Same files across many turns → sidebar Projects
+│       ├── Same job every day → sidebar Scheduled Tasks
+│       └── 24/7 cloud assistant on Feishu / WeCom → kimi.com/bot (Claw)
+├── Edit a real repo / tests / PRs
+│   └── → [Kimi Code](/products/kimi-code/) (install is not in this directory)
+├── Local files / desktop cron
+│   └── → Kimi Work (kimi.com/products/kimi-work)
+├── Agent clicks the browser like a person
+│   └── → Kimi WebBridge, or WebBridge inside Kimi Work
+└── Call models from your own software
+    └── → Kimi Platform (platform.moonshot.cn)
+```
+
+Sources: [products](https://www.kimi.com/zh-cn/products/), [kimi.com](https://www.kimi.com/), [Agent overview](https://www.kimi.com/help/agent/agent-overview), [Claw overview](https://www.kimi.com/en/help/kimi-claw/overview), [Kimi Work overview](https://www.kimi.com/help/kimi-work/overview), [moonshot.cn](https://www.moonshot.cn/).
+
+## Learning path
+
+| Stage | Read | Outcome |
+|-------|------|---------|
+| 1. Pick the door | This family table | Do not walk into Code / Work by accident |
+| 2. First session | [Tutorial](./kimi.md) | Web chat + first Agent run |
+| 3. Recipes | [Cookbook](./kimi-cookbook.md) | Swarm / Claw / projects / schedules |
+| 4. Look up | [Cheatsheet](./kimi-cheatsheet.md) | Official entries and tables only |
+| 5. Names | [Glossary](./kimi-glossary.md) | Collisions and non-goals |
+
+## Out of scope here
+
+- Kimi Code CLI / VS Code install, slash commands, `AGENTS.md`.
+- Kimi Work desktop install steps.
+- API `base_url` / `MOONSHOT_API_KEY` samples (Platform).
+- Model internals. See [Learn LLM](/tech/fundamentals/LLM).
+
+## Related pages
+
+- [Kimi chat and Agent](./kimi.md)
+- [Cookbook](./kimi-cookbook.md)
+- [Cheatsheet](./kimi-cheatsheet.md)
+- [Glossary](./kimi-glossary.md)
+- [Kimi Code](/products/kimi-code/)
+- [Products index](../index.md)

--- a/docs/products/kimi/kimi-cheatsheet.md
+++ b/docs/products/kimi/kimi-cheatsheet.md
@@ -1,0 +1,157 @@
+---
+title: Kimi chat and Agent cheatsheet
+description: Look up only. Entries, slashes, and quotas are copied from official pages that opened. Two plan-name systems stay unmerged.
+domain: product
+tags:
+  - chat
+role: cheatsheet
+---
+
+# Kimi chat and Agent cheatsheet
+
+Look up only. Numbers belong to the linked official page. Last verified: 2026-08-19.
+
+This table has **no** Kimi Code CLI. Coding commands: [Kimi Code](/products/kimi-code/).
+
+## Official entries
+
+| Surface | Entry |
+|---------|-------|
+| Workspace / chat | [kimi.com](https://www.kimi.com/) |
+| Product family | [kimi.com/zh-cn/products](https://www.kimi.com/zh-cn/products/) |
+| Agent | [kimi.com/agent](https://www.kimi.com/agent) |
+| Agent Swarm | [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm) |
+| Kimi Claw | [kimi.com/bot](https://www.kimi.com/bot) |
+| Kimi Work (other product) | [kimi.com/products/kimi-work](https://www.kimi.com/products/kimi-work) |
+| Kimi Code (other product) | [Kimi Code](/products/kimi-code/) |
+| API (other product) | [platform.moonshot.cn](https://platform.moonshot.cn/) |
+| Help Center | [help](https://www.kimi.com/help), [zh-hans/help](https://www.kimi.com/zh-hans/help) |
+| Company / app | [moonshot.cn](https://www.moonshot.cn/) |
+
+Home sidebar from [kimi.com](https://www.kimi.com/): Plugins, Scheduled Tasks, Slides, Swarm, Deep Research, Docs, Websites, Sheets, Design; Kimi Work, Kimi Code, Kimi Claw. New chat: **⌘K**.
+
+App model switch ([Agent overview](https://www.kimi.com/help/agent/agent-overview)): **K3** or **K3 Swarm**.
+
+## Commands / entries that appear on chat help
+
+These are help-center strings, **not** the Kimi Code TUI.
+
+| Input or control | What it does | Source |
+|------------------|--------------|--------|
+| `/` | Invoke Skills / plugins | Skills, Plugins, Scheduled Tasks |
+| `+` | Plugins / upload / new project | Plugins, Projects |
+| `/skill-creator` | Create a Skill in dialogue | [Skills](https://www.kimi.com/help/features/what-are-skills) |
+| `/stop` | Force-stop a Claw in group chat | [group-chat](https://www.kimi.com/help/kimi-claw/group-chat) |
+| Create scheduled task | Sidebar scheduler | [Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks) |
+| Create (Claw) | One-click cloud OpenClaw | [Claw overview](https://www.kimi.com/en/help/kimi-claw/overview) |
+| Link existing OpenClaw | Attach a self-hosted instance | Same |
+| Start Group Chat | Claw group | group-chat |
+| Settings → Personalization → Memory Space | Memory UI | [Memory](https://www.kimi.com/help/features/memory-space) |
+| Settings → Chat channels | Claw channels | Claw overview |
+
+Official skill name examples: `docx`, `deep-research`, `sop-writer`, `event-etf-study`.
+
+## Membership overview (music names + USD)
+
+Source: [membership-overview](https://www.kimi.com/help/membership/membership-overview). Chat **K2.6 is free and does not consume credits**. Membership features share one pool.
+
+Table 1:
+
+| Feature | Moderato $19/mo | Allegretto $39/mo | Allegro $99/mo | Vivace $199/mo |
+|---------|-----------------|-------------------|----------------|----------------|
+| Agent credits* | 60 | 150 | 360 | 720 |
+| Agent concurrent tasks | 2 | 2 | 4 | 4 |
+| Agent speed priority | 4× | 4× | 4× | 4× |
+| Professional database | 2,000 calls | 5,000 | 12,000 | 24,000 |
+| Kimi Code | Available | Available | Available | Available |
+
+\* Official footnote: approximate, typical-task token conversion, for reference only.
+
+Table 2 (same page, chat/Agent rows):
+
+| Feature | Moderato | Allegretto | Allegro | Vivace |
+|---------|----------|------------|---------|--------|
+| K3 extra-long chat (up to 1M tokens) | — | — | ✅ | ✅ |
+| Scheduled tasks | 10 | 15 | 20 | 25 |
+| Widget tasks | 10 | 15 | 20 | 25 |
+| Projects | 20 | 20 | 100 | 100 |
+| Project storage | 20GB | 20GB | 50GB | 50GB |
+| Plugins | 15+ types | 15+ | 15+ | 15+ |
+| Agent Swarm | ✅ | ✅ | ✅ | ✅ |
+| Swarm concurrent subtasks | 2 | 4 | 8 | 8 |
+| Goal Mode | — | ✅ | ✅ | ✅ |
+| Kimi Claw (Web, Android, PC) | — | ✅ | ✅ | ✅ |
+| Group chat with Claw | — | 10 | 10 | 10 |
+
+Annual billing: official "save up to **$480/year**". Kimi Code also has a **5-hour / weekly** rate limit.
+
+## The other official tier names
+
+[Projects](https://www.kimi.com/help/features/project) and [Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks) use **Free / Go / Pro / Max / Ultra**. Official pages do **not** equate those rows to Moderato…. Do not invent a mapping.
+
+Projects:
+
+| | Free | Go | Pro | Max | Ultra |
+|--|------|----|-----|-----|-------|
+| Projects | 2 | 20 | 20 | 100 | 100 |
+| Project storage | 500MB | 20GB | 20GB | 50GB | 50GB |
+
+Scheduled Tasks (**active at once**; create count unlimited):
+
+| | Free | Go | Pro | Max | Ultra |
+|--|------|----|-----|-----|-------|
+| Scheduled tasks | 2 | 6 | 15 | 20 | 25 |
+
+Project files: ≤ **100 MB** each, up to **50**.
+
+Default schedule expiry: Daily +7 days; Weekly +1 month; Monthly +3 months.
+
+## Other sourced numbers
+
+| Number | Source |
+|--------|--------|
+| Agent 20+ tools | Agent overview |
+| Swarm ≤300 sub-agents, >4000 tool calls, ~4.5× | Agent Swarm |
+| Deep Research 10,000+ words | Agent overview |
+| Sheets up to 1,000-row Excel | Agent overview |
+| ClawHub 5,000+ skills | Agent overview / Claw intro |
+| K3: 2.8T params, 1M tokens, native vision | Agent overview (2026-07-16) |
+| One-click Claw: Allegretto+; default K2.6 | Claw overview |
+| Plugins: K3 / K3 Swarm / Deep Research / Websites / PPT; not Claw or Plus | Plugins |
+
+## High-quality sources
+
+Last verified: 2026-08-19. Official pages opened for this handbook only.
+
+### First-party
+
+| Source | Use |
+|--------|-----|
+| [kimi.com](https://www.kimi.com/) | Workspace |
+| [zh-cn/products](https://www.kimi.com/zh-cn/products/) | First-class products |
+| [help](https://www.kimi.com/help) | EN help index |
+| [zh-hans/help](https://www.kimi.com/zh-hans/help) | ZH help index |
+| [Agent overview](https://www.kimi.com/help/agent/agent-overview) | Agent steps |
+| [Agent Swarm](https://www.kimi.com/help/agent/agent-swarm) | Swarm |
+| [Membership overview](https://www.kimi.com/help/membership/membership-overview) | Plans and pool |
+| [Claw overview](https://www.kimi.com/en/help/kimi-claw/overview) | Deploy |
+| [Claw group chat](https://www.kimi.com/help/kimi-claw/group-chat) | Conductor / `/stop` |
+| [Projects](https://www.kimi.com/help/features/project) | Projects |
+| [Skills](https://www.kimi.com/help/features/what-are-skills) | Skills |
+| [Plugins](https://www.kimi.com/help/features/plugins) | Plugins |
+| [Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks) | Scheduler |
+| [Memory](https://www.kimi.com/help/features/memory-space) | Memory |
+| [Kimi Work overview](https://www.kimi.com/help/kimi-work/overview) | Desktop (not expanded here) |
+| [moonshot.cn](https://www.moonshot.cn/) | Company / app |
+| [platform.moonshot.cn](https://platform.moonshot.cn/) | API |
+
+### Fetch notes
+
+`www.kimi.com` sometimes resolves to 198.18.x for automated clients. Guessed help slugs land on an empty search page. Open the category page, then copy the slug.
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./kimi.md)
+- [Cookbook](./kimi-cookbook.md)
+- [Glossary](./kimi-glossary.md)

--- a/docs/products/kimi/kimi-cookbook.md
+++ b/docs/products/kimi/kimi-cookbook.md
@@ -1,0 +1,128 @@
+---
+title: Kimi chat and Agent cookbook
+description: "You can already open kimi.com. One recipe per job: goal, official entry, steps, pitfall."
+domain: product
+tags:
+  - chat
+role: cookbook
+---
+
+# Kimi chat and Agent cookbook
+
+You can already open [kimi.com](https://www.kimi.com/). One recipe per job. Kimi Code install is not here — see [Kimi Code](/products/kimi-code/).
+
+## 1. Get a downloadable Agent deliverable
+
+**Goal:** a site, deck, sheet, or report — not a chat paragraph.
+
+**Entry:** [kimi.com/agent](https://www.kimi.com/agent); app model switch → **K3** ([Agent overview](https://www.kimi.com/help/agent/agent-overview)).
+
+1. Use a task-shaped prompt (official style: build voting-site code).
+2. Let planning / tools / delivery finish.
+3. Download the project or Office file, or open the deploy link.
+
+**Pitfall:** this Agent does not edit a git checkout on disk.
+
+## 2. Use Swarm for large collection
+
+**Goal:** hundreds of sources, multi-perspective review, or a very long document.
+
+**Entry:** [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm); app → **K3 Swarm** ([Agent Swarm](https://www.kimi.com/help/agent/agent-swarm)).
+
+Official examples you can adapt:
+
+- collect 200+ Paul Graham essays
+- top 3 creators in 100 YouTube niches
+- a 100-page literature review from 40 PDFs
+
+**Pitfall:** Moderato and above only; burns more credits than standard Agent; **[Beta]** may be limited.
+
+## 3. Create a Project for long-running work
+
+**Goal:** the same style guide / PDF set across many turns.
+
+**Entry:** **+** next to Projects, or **+ New project** ([Projects](https://www.kimi.com/help/features/project)).
+
+1. Name 1–50 characters; optional instructions (official example: "You are a senior product manager. Reply in Chinese and output in Markdown.").
+2. Upload files: ≤ 100 MB each, up to 50.
+3. Start a separate in-project chat per distinct output.
+4. Project chats can use plugins, Skills, and Goal, and can switch models.
+
+**Pitfall:** delete is permanent. Kimi Work Projects **do not** share this data.
+
+## 4. Schedule a daily job
+
+**Goal:** a briefing that runs without you clicking.
+
+**Entry:** sidebar **Create scheduled task**, or natural language in chat ([Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks)).
+
+Official copy-paste prompt:
+
+> Every day at 9:00, summarize the latest market news as 3 key points plus 1 risk note, in Chinese, within 200 words.
+
+1. Dry-run in a normal chat or use "Run once now".
+2. If it depends on a Skill, install and test the Skill first.
+3. Tasks created on kimi.com run in the cloud; the client need not stay open.
+
+**Pitfall:** default expiry Daily +7 days, Weekly +1 month, Monthly +3 months. Local Kimi Work tasks do not backfill while the app is closed. Over the active cap, new tasks save as inactive.
+
+## 5. Pin an output format with a Skill
+
+**Goal:** weekly reports / SOPs / research structure without re-explaining.
+
+**Entry:** [What are Skills?](https://www.kimi.com/help/features/what-are-skills)
+
+1. Browse official / recommended skills; click **+**.
+2. Type `/` to invoke, or let Kimi trigger.
+3. Missing skill: upload a document, or `/skill-creator`.
+
+Official names: `docx`, `deep-research`; recommended `sop-writer`, `event-etf-study`.
+
+**Pitfall:** skills load only when relevant. Creating a skill consumes credits (Creating skills FAQ).
+
+## 6. Attach plugins to Agent
+
+**Goal:** company registry / GitHub / Notion instead of search-only.
+
+**Entry:** sidebar **Plugins**, or **+** / `/` ([Plugins](https://www.kimi.com/help/features/plugins)).
+
+1. Switch the model to **K3** or **K3 Swarm** (Deep Research / Websites / PPT also work).
+2. Sign in, install, complete OAuth if asked.
+3. You can invoke multiple plugins at once.
+
+**Pitfall:** not supported in Claw or Kimi Plus chats. Signed-out users cannot install. Catalog varies by region and enterprise. Some plugins bill membership credits.
+
+## 7. One-click deploy a Claw
+
+**Goal:** a 24/7 cloud assistant on Feishu / WeCom without buying a server.
+
+**Entry:** [kimi.com/bot](https://www.kimi.com/bot) ([Claw overview](https://www.kimi.com/en/help/kimi-claw/overview)).
+
+1. Confirm **Allegretto or higher**.
+2. **Create** Kimi Claw and wait.
+3. **Settings → Chat channels**.
+
+Existing OpenClaw: **Link existing OpenClaw**, install the Kimi plugin on that host.
+
+**Pitfall:** default model is **K2.6**, billed to membership credits. Switching to K3 edits OpenClaw config, not a web slash command.
+
+## 8. Start a Claw group chat
+
+**Goal:** several Claws under Kimi Conductor.
+
+**Entry:** Claw sidebar **+** → **Start Group Chat** ([group-chat](https://www.kimi.com/help/kimi-claw/group-chat)).
+
+1. Required **Group Name** and **Group Goal**.
+2. Select linked Claws, Create.
+3. Set group rules in natural language.
+4. Preview files in **Workspace**.
+5. A Claw that will not stop: send **`/stop`** in the main chat.
+
+**Pitfall:** group chat is Allegretto+, 10 groups on the membership table. If @-mention is silent, check the Claw's private chat first. Third-party OpenClaw version bounds are on the group-chat help page.
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./kimi.md)
+- [Cheatsheet](./kimi-cheatsheet.md)
+- [Glossary](./kimi-glossary.md)

--- a/docs/products/kimi/kimi-glossary.md
+++ b/docs/products/kimi/kimi-glossary.md
@@ -1,0 +1,91 @@
+---
+title: Kimi chat and Agent glossary
+description: No how-to. Split the things that share the words Kimi, Agent, Goal, and Project.
+domain: product
+tags:
+  - chat
+role: glossary
+---
+
+# Kimi chat and Agent glossary
+
+No how-to. What the official pages mean — and what they are not. Product choice: [learning map](./index.md). Internals: [Learn LLM](/tech/fundamentals/LLM).
+
+## Things named Kimi
+
+| Name | What it is | Where |
+|------|------------|-------|
+| **Kimi** | All-in-one agentic AI workspace | [kimi.com](https://www.kimi.com/) |
+| **Kimi Agent** | End-to-end autonomous assistant, K3 + 20+ tools | [kimi.com/agent](https://www.kimi.com/agent) |
+| **Agent Swarm** | Up to 300 sub-agents in parallel | [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm) |
+| **Kimi Claw** | One-click cloud OpenClaw, optional chat channels | [kimi.com/bot](https://www.kimi.com/bot) |
+| **Kimi Code** | Terminal and IDE coding agent | [Kimi Code](/products/kimi-code/) |
+| **Kimi Work** | Mac/Windows desktop knowledge-work agent (Work / Chat modes) | [products/kimi-work](https://www.kimi.com/products/kimi-work) |
+| **Kimi WebBridge** | Browser extension for agents | Products page |
+| **Kimi Platform** | Official model API | [platform.moonshot.cn](https://platform.moonshot.cn/) |
+| **Kimi Business** | Enterprise | Help Center |
+| **Kimi Plus** | Named on the plugins page as a chat surface without plugins yet | [Plugins](https://www.kimi.com/help/features/plugins) |
+| **K2.6 / K3 / K3 Swarm** | Model / mode switch in the workspace | Model switch above the input |
+| **Moonshot AI** | The company | [moonshot.cn](https://www.moonshot.cn/) |
+
+## Three Agent scheduling surfaces
+
+| | Single Agent | Agent Swarm | Claw group chat |
+|--|--------------|-------------|-----------------|
+| **What** | One assistant plans and calls tools | One orchestrator, up to 300 sub-agents | Several Claws + Kimi Conductor |
+| **Entry** | `kimi.com/agent` or App **K3** | `kimi.com/agent-swarm` or **K3 Swarm** | `kimi.com/bot` → Start Group Chat |
+| **Official emphasis** | 20+ tools, Office / site deliverables | Scale out, no hand-written workflow | Cross-person, device, permission boundary |
+| **Not** | Not Kimi Code | Not "300 Claws" | Not another name for Swarm |
+
+**OpenClaw ≠ Kimi Claw.** OpenClaw is the assistant you can self-host. Kimi Claw is Moonshot's deploy-or-link surface. A group chat can also invite someone else's OpenClaw as a Worker.
+
+**OK Computer** is the 2025-09-26 Agent-mode name on the official timeline. Current help leads with Kimi Agent / K3.
+
+## Goal collisions
+
+| Phrase | Where official | Not |
+|--------|----------------|-----|
+| Goal / Goal Mode | Membership table (Allegretto+); project chats can use Goal | Not a free global toggle |
+| Kimi Work Goal Mode | Work help | Not the same page as web chat |
+| Kimi Code `/goal` | Code CLI | **Not** a kimi.com chat command |
+
+There is no first-class "Goal product" URL. The family table keeps one row.
+
+## Two Projects
+
+Official ([Projects](https://www.kimi.com/help/features/project)): the Kimi Work desktop app also has "Projects"; they are **not connected and don't share data**.
+
+| | kimi.com Projects | Kimi Work Projects |
+|--|-------------------|--------------------|
+| **Job** | Persistent web workspace | Desktop task space |
+| **This directory** | Tutorial / Cookbook | Map row only |
+
+## Credits, memory, Skills, plugins
+
+**Credit pool:** membership features share one token-metered pool. Chat K2.6 is free. Kimi Code has a separate 5-hour / weekly rate limit. "Agent credits 60" is an official *approximate* typical-task conversion, not "60 chat turns".
+
+**Two plan-name systems:** membership page Moderato / Allegretto / Allegro / Vivace (USD). Projects / Scheduled Tasks pages Free / Go / Pro / Max / Ultra. Cite each page. Do not merge.
+
+**Memory:** cross-chat preferences. Official: not used for training; no unauthorized private data by default. Project context injects global main memory; project instructions stay inside that project.
+
+**Skills:** on-demand knowledge packages. Official / recommended / open-source / custom. Type `/`.
+
+**Plugins:** third-party connectors. K3 / K3 Swarm and some scenarios; not Claw or Plus chats. Not the Kimi Code plugin config.
+
+**Scheduled tasks:** cloud on kimi.com; optional local on Kimi Work (app must be open).
+
+## Do not write as fact
+
+- "Kimi is Kimi Code"
+- "Typing `/goal` on the web equals CLI Goal"
+- "Moderato is Go"
+- "Claw group chat = Agent Swarm"
+- Code install scripts as this directory's quickstart
+- CNY prices (this research did not treat a separate CN price page as SSOT)
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Tutorial](./kimi.md)
+- [Cookbook](./kimi-cookbook.md)
+- [Cheatsheet](./kimi-cheatsheet.md)

--- a/docs/products/kimi/kimi.md
+++ b/docs/products/kimi/kimi.md
@@ -1,0 +1,200 @@
+---
+title: Kimi chat and Agent
+description: "Audience: frontend engineers picking a Moonshot surface. You need a browser or the Kimi app, not a repo checkout."
+domain: product
+tags:
+  - chat
+role: tutorial
+---
+
+# Kimi chat and Agent
+
+> **Kimi** is Moonshot AI's all-in-one workspace. Official product copy ([zh-cn/products](https://www.kimi.com/zh-cn/products/)):
+> built-in Agent capabilities for deep research, slides, sheets, documents, and websites.
+>
+> **Kimi Agent** official definition ([Agent overview](https://www.kimi.com/help/agent/agent-overview)):
+> "Kimi Agent is an autonomous AI assistant that handles complex tasks end-to-end. Powered by Kimi K3, it uses 20+ tools to build websites, generate documents, analyze data, and more."
+>
+> This page maps kimi.com, the products page, and the help center. It is **not** Kimi Code — that is [Kimi Code](/products/kimi-code/).
+
+## Goals and non-goals
+
+**Audience:** frontend engineers choosing a Kimi surface. Browser or Kimi app. No checkout.
+
+**Goals:** open kimi.com, tell Chat / Agent / Swarm / Claw apart, finish one Agent task, know which official table holds credits.
+
+**Non-goals:** Kimi Code install; invented CNY prices; treating Moderato as Go; model internals. Mechanisms: [Learn LLM](/tech/fundamentals/LLM).
+
+## What it is
+
+One workspace, several official clients:
+
+| Client | Official entry |
+|--------|----------------|
+| Web | [kimi.com](https://www.kimi.com/) |
+| Agent | [kimi.com/agent](https://www.kimi.com/agent) |
+| Agent Swarm | [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm) |
+| Kimi Claw | [kimi.com/bot](https://www.kimi.com/bot) |
+| App | [moonshot.cn](https://www.moonshot.cn/) footer "Scan to download Kimi App" |
+
+Home sidebar labels copied from [kimi.com](https://www.kimi.com/): **Plugins, Scheduled Tasks, Slides, Swarm, Deep Research, Docs, Websites, Sheets, Design**, plus **Kimi Work / Kimi Code / Kimi Claw**. New chat shortcut on the homepage: **⌘K**.
+
+Agent capabilities ([Agent overview](https://www.kimi.com/help/agent/agent-overview)):
+
+| Capability | Official description |
+|------------|----------------------|
+| Websites | Generate and deploy responsive web apps |
+| Docs | Word, PDF, Markdown |
+| Sheets | Excel / CSV; official text: up to 1,000-row Excel |
+| Slides | Automated PPT |
+| Deep Research | 10,000+ word reports |
+| Agent Swarm | Up to 300 sub-agents; 4,000+ tool calls |
+| Kimi Claw | Cloud automation; help center cites 5,000+ ClawHub skills |
+
+How it works (same page): task planning → tool invocation (20+ tools) → autonomous execution → error handling → deliverables.
+
+## First session: chat
+
+1. Open [kimi.com](https://www.kimi.com/) and sign in. Signed-out sidebar: "Log in to sync chat history".
+2. Type in the box. Homepage: "Ask anything, or task an agent..."
+3. Chat credits: official membership page — "In Chat, K2.6 is free for all users and does not consume credits" ([membership overview](https://www.kimi.com/help/membership/membership-overview)).
+
+For durable context, create a **Project** instead of re-uploading the same files. Next section.
+
+## First Agent task
+
+Official entries ([Agent overview](https://www.kimi.com/help/agent/agent-overview)):
+
+- **Web:** [https://www.kimi.com/agent](https://www.kimi.com/agent)
+- **Mobile / tablet:** Kimi app → model switch → **K3** or **K3 Swarm**
+
+Official steps:
+
+1. Describe the task clearly. Official examples include creating voting-site code and analyzing a market.
+2. Watch planning, tools, visited URLs, intermediate code.
+3. Download or share: code project, folder, analysis, Word / PDF / PPT.
+
+Official use cases: website development, multimedia content, document comparison / translation, data analysis, slides, format conversion.
+
+## Agent Swarm
+
+Official definition ([Agent Swarm](https://www.kimi.com/help/agent/agent-swarm) / [zh-hans](https://www.kimi.com/zh-hans/help/agent/agent-swarm)): scale-out architecture, up to **300** sub-agents, no preset roles or hand-built workflows. Official claims: about **4.5×** faster than a single Agent; more than **4,000** tool calls per task. Currently powered by **Kimi K3 (K3 Swarm)**.
+
+**Entries:**
+
+- Web: <https://www.kimi.com/agent-swarm>
+- Mobile: Kimi app model switch → **K3 Swarm**
+
+**Access:** **Moderato, Allegretto, Allegro, and Vivace**. Official: these tasks consume noticeably more credits than standard Agent. **[Beta]** means early, limited rollout.
+
+Official steps: describe the task → watch sub-agents → take deliverables → later turns auto-route between chat and Agent.
+
+Good for: large retrieval, batch download, 100+ documents, long writing, complex coding, Office automation. Bad for one-shot chit-chat.
+
+## Kimi Claw
+
+Official positioning ([Claw overview](https://www.kimi.com/en/help/kimi-claw/overview)): talk to **OpenClaw** inside Kimi. OpenClaw is "an AI assistant with a distinct personality and long-term memory."
+
+**One-click cloud deploy:**
+
+1. Sign in at [kimi.com/bot](https://www.kimi.com/bot)
+2. Click **Create** Kimi Claw
+3. Wait for automatic setup (official: usually a few minutes)
+4. Set a nickname; **Settings → Chat channels** for WeChat / Feishu / WeCom and others
+
+Official limits: one-click deploy is **Allegretto and higher**. Default model **Kimi K2.6**, billed against **membership credits**, with Kimi Web Search configured. Can deploy to Feishu, WeCom, Weibo, and other platforms.
+
+**Link an existing OpenClaw:** **Link existing OpenClaw**, then install the Kimi plugin on the machine that already runs OpenClaw.
+
+**Claw group chat** ([group-chat](https://www.kimi.com/help/kimi-claw/group-chat)): sidebar **+** → **Start Group Chat**, required Group Name and Group Goal, pick linked Claws. Kimi assigns a **Conductor**. Send `/stop` in the main chat to force-interrupt. Set group rules in plain language. Allegretto+; membership table lists 10 group chats.
+
+Switching Claw's default model to K3 is documented on the Claw overview as edits to `/root/.openclaw/openclaw.json` (or your real install path). That is **OpenClaw config**, not a kimi.com chat command. Copy the official snippet, and back up first.
+
+## Projects, memory, Skills, plugins, scheduled tasks
+
+Cross-cutting Features: [help/features](https://www.kimi.com/help/features).
+
+### Projects
+
+[Projects](https://www.kimi.com/help/features/project): keep files, chats, and instructions together. Sidebar **+** next to Projects, or **+ New project**. Name: 1–50 characters.
+
+- Project chats can use **project files, project instructions, plugins, Skills, and Goal**, and can switch models.
+- Each file ≤ **100 MB**, up to **50** files; read on demand, not fully preloaded every turn.
+- Deleting a project **permanently** removes its chats, files, and instructions.
+- Injected context: system prompt + global main memory + project instructions + on-demand files.
+- **Kimi Work Projects are not connected and do not share data.**
+
+### Memory
+
+[Memory space](https://www.kimi.com/help/features/memory-space): preferences across chats. Official: will not memorize unauthorized private information (health, passwords, addresses) unless you ask. Manage at **Settings → Personalization → Memory Space**. Say "Remember… / Forget… / What do you currently remember about me?". Official: not used for training; can be turned off or cleared.
+
+### Skills
+
+[What are Skills?](https://www.kimi.com/help/features/what-are-skills): reusable knowledge packages. Type **`/`** or let Kimi trigger them. **`/skill-creator`** builds one in dialogue. Official examples: `docx`, `deep-research`; recommended: `sop-writer`, `event-etf-study`.
+
+### Plugins
+
+[Plugins](https://www.kimi.com/help/features/plugins): connect external tools. Available when the model is **K3** or **K3 Swarm**, and in Deep Research, Websites, and PPT. **Not yet supported in Kimi Claw or Kimi Plus conversations.** Entries: sidebar **Plugins**, input **+**, or **`/`**. Some need OAuth. Signed-out users cannot install. Some plugins consume membership credits on actual calls.
+
+### Scheduled tasks
+
+[Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks): available in **Kimi** and **Kimi Work**. Sidebar "Create scheduled task", or describe the schedule in chat. Cadence: daily / weekly / monthly / one-time. Cloud tasks do not need a client open. **Local** Kimi Work tasks require the desktop app; missed triggers while closed are not backfilled. After a run you can switch models in the result chat and type `/` for plugins and Skills.
+
+Official template: At [time], do [task], output as [format], and follow [constraints].
+
+## Goal
+
+Where Goal appears officially:
+
+- Membership table **Goal Mode**: — on Moderato; ✅ on **Allegretto / Allegro / Vivace** ([membership overview](https://www.kimi.com/help/membership/membership-overview)).
+- Project chats "use plugins, Skills, and Goal" ([Projects](https://www.kimi.com/help/features/project)).
+
+There is no standalone kimi.com Goal product page. Kimi Work has its own Goal Mode ([Work overview](https://www.kimi.com/help/kimi-work/overview)). Kimi Code `/goal` is CLI — **do not** type it as a kimi.com command.
+
+## Membership and credits
+
+[Membership overview](https://www.kimi.com/help/membership/membership-overview) (opened 2026-08-19):
+
+- Four tiers: **Moderato $19/mo, Allegretto $39/mo, Allegro $99/mo, Vivace $199/mo**.
+- **One credit pool** for membership features (website deploy, Deep Research, Slides, Kimi Code, Kimi Work, Kimi Claw, K3, K3 Swarm), metered by tokens.
+- In Chat, **K2.6 is free and does not consume credits**.
+- Credits reset each billing cycle. Annual billing: official "save up to **$480/year**".
+- Kimi Code also has a **5-hour / weekly** rate limit that does not affect other features.
+
+The same page's second table covers Agent concurrency, K3 extra-long chat (Allegro / Vivace, up to 1M tokens), scheduled tasks, projects, Swarm subtasks, Goal, Claw, and Claw group chats. Full numbers: [cheatsheet](./kimi-cheatsheet.md).
+
+**Two official plan-name systems:** Projects / Scheduled Tasks pages use **Free / Go / Pro / Max / Ultra**, and the numbers are not identical to the membership overview. This page **does not invent a mapping**. Prices and membership benefits: membership overview. Project / schedule caps: the feature page; if they disagree, keep both citations.
+
+This page does **not** invent CNY prices. Use the membership / usage UI on your account.
+
+## Common pitfalls
+
+- Treating a generated site as a patched local git checkout. Use [Kimi Code](/products/kimi-code/) for the repo.
+- Opening Swarm or one-click Claw on a plan that the membership table does not unlock (Swarm: Moderato+; one-click Claw: Allegretto+).
+- Assuming Kimi Work desktop projects sync with kimi.com Projects.
+- Typing Kimi Code `/goal` into the web box.
+- Merging Moderato and Go into one unofficial table.
+- Looking for web plugins inside Claw / Kimi Plus chats — officially unsupported.
+- Expecting local Kimi Work schedules to backfill while the app is closed.
+
+## Official docs
+
+| Page | Use it for |
+|------|------------|
+| [kimi.com](https://www.kimi.com/) | The product |
+| [zh-cn/products](https://www.kimi.com/zh-cn/products/) | First-class family |
+| [Agent overview](https://www.kimi.com/help/agent/agent-overview) | Agent entry and steps |
+| [Agent Swarm](https://www.kimi.com/help/agent/agent-swarm) | Swarm entry and limits |
+| [Membership overview](https://www.kimi.com/help/membership/membership-overview) | Plans and credit pool |
+| [Claw overview](https://www.kimi.com/en/help/kimi-claw/overview) | One-click / link existing OpenClaw |
+| [Claw group chat](https://www.kimi.com/help/kimi-claw/group-chat) | Conductor, threads, `/stop` |
+| [Help Center](https://www.kimi.com/help) | Category index |
+| [moonshot.cn](https://www.moonshot.cn/) | Company site, app download |
+
+## Related pages
+
+- [Learning map](./index.md)
+- [Cookbook](./kimi-cookbook.md)
+- [Cheatsheet](./kimi-cheatsheet.md)
+- [Glossary](./kimi-glossary.md)
+- [Kimi Code](/products/kimi-code/)

--- a/docs/zh/products/kimi/index.md
+++ b/docs/zh/products/kimi/index.md
@@ -1,0 +1,109 @@
+---
+title: Kimi 学习地图
+description: 月之暗面有多张都叫 Kimi 的产品面。本目录只写 kimi.com 对话与 Agent。Kimi Code 只在家族表占一行。
+domain: product
+tags:
+  - chat
+role: map
+---
+
+# Kimi 学习地图
+
+> **Kimi** 是月之暗面（Moonshot AI）的一站式 AI 工作台。官方产品页原文（[kimi.com/zh-cn/products](https://www.kimi.com/zh-cn/products/)）：
+> 「一站式 AI 工作台。从深度研究、幻灯片到表格、文档与网站，Kimi 内置强大的 Agent 能力，轻松应对复杂任务。」
+>
+> 英文产品 nav：「**Kimi** — All-in-one agentic AI workspace。」
+>
+> 本目录对位 Claude.ai / Grok 聊天。它**不是** Kimi Code。仓库里的终端 / IDE 编程助手见 [Kimi Code](/zh/products/kimi-code/)。
+
+## 产品家族
+
+下表对账官方一级入口。缺项是 P0。官方密度不够独立教程的，只占一行。
+
+| 官方一级入口 | 官方 URL | 本站去向 |
+|--------------|----------|----------|
+| **Kimi**（一站式工作台 / 对话） | [kimi.com](https://www.kimi.com/)、[zh-cn/products](https://www.kimi.com/zh-cn/products/) | 独立页 [kimi.md](./kimi.md) |
+| **Kimi Agent** | [kimi.com/agent](https://www.kimi.com/agent)、[Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview) | 同上 Tutorial |
+| **Agent Swarm** | [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm)、[Agent Swarm](https://www.kimi.com/zh-hans/help/agent/agent-swarm) | Tutorial + [Cookbook](./kimi-cookbook.md) |
+| **Kimi Claw** | [kimi.com/bot](https://www.kimi.com/bot)、[Claw overview](https://www.kimi.com/en/help/kimi-claw/overview) | Tutorial + Cookbook（对话侧云端 OpenClaw） |
+| **Goal** | 会员表「目标模式」；项目对话可 use Goal（[Projects](https://www.kimi.com/help/features/project)） | 地图一行 + Tutorial 一节。**不是** Kimi Code `/goal` |
+| Slides / Docs / Sheets / Deep Research / Websites / Design | 首页侧栏（[kimi.com](https://www.kimi.com/)） | 地图一行：工作台能力，不拆页 |
+| Plugins / Scheduled Tasks / Skills / Projects / Memory | [帮助中心 Features](https://www.kimi.com/help/features) | Tutorial / Cookbook / [速查](./kimi-cheatsheet.md) |
+| **Kimi Code** | 产品页「Kimi Code」 | **一行**：[Kimi Code](/zh/products/kimi-code/)（#71，本目录不写安装） |
+| **Kimi Work** | [kimi.com/products/kimi-work](https://www.kimi.com/products/kimi-work) | 地图一行：Mac/Windows 桌面知识工作 Agent |
+| **Kimi WebBridge** | 产品页「Kimi WebBridge」 | 地图一行：给 Agent 用的浏览器插件 |
+| **Kimi Platform / API** | [platform.moonshot.cn](https://platform.moonshot.cn/) | 地图一行：HTTP API |
+| **Kimi Business** | [帮助中心](https://www.kimi.com/help)「Kimi Business」 | 地图一行：企业方案 |
+| 研究 / Doodle / 加入我们 | [moonshot.cn](https://www.moonshot.cn/) | 非本站 |
+
+```
+月之暗面 / Kimi 家族
+├── Kimi（kimi.com 工作台）← 本目录主路径
+│   ├── 对话（聊天里 K2.6 免费、不耗会员额度）
+│   ├── Agent（kimi.com/agent；App 切 K3）
+│   ├── Agent Swarm（kimi.com/agent-swarm；App 切 K3 Swarm）
+│   ├── Goal / Projects / Skills / Plugins / 定时任务 / 记忆
+│   └── Kimi Claw（kimi.com/bot；云端 OpenClaw）
+├── Kimi Code — 终端与 IDE 编程助手 → /zh/products/kimi-code/
+├── Kimi Work — 桌面端本地 Agent
+├── Kimi WebBridge — 浏览器插件
+├── Kimi Platform — 模型 API
+└── Kimi Business — 企业方案
+```
+
+**容易撞名：**
+
+- **Kimi ≠ Kimi Code ≠ Kimi Work ≠ Kimi Claw**。四个入口，四份数据与权限。
+- **Agent ≠ Agent Swarm ≠ Claw 群聊**。单 Agent、并行子 Agent、多只 Claw 被 Conductor 调度，不是同一个开关。
+- **Goal（工作台）≠ Kimi Code `/goal`**。后者是 CLI 斜杠命令，本目录不教。
+- **kimi.com Projects ≠ Kimi Work Projects**。官方原文：the two are not connected and don't share data（[Projects](https://www.kimi.com/help/features/project)）。
+
+### 快速决策：我该用哪个？
+
+```
+我要做什么？
+├── 浏览器里问问题 / 写文档 / 出 PPT / 出表 / 深度研究 / 建站预览
+│   └── → [Kimi 对话与 Agent](./kimi.md)
+│       ├── 普通问答 → 打开 kimi.com，聊天（官方：K2.6 免费且不耗额度）
+│       ├── 端到端出网站 / Office / 报告 → kimi.com/agent，或 App 切 K3
+│       ├── 大规模并行搜集 / 长文 → kimi.com/agent-swarm，或 App 切 K3 Swarm
+│       ├── 同一批文件反复用 → 侧栏 Projects
+│       ├── 每天固定跑一遍 → 侧栏 Scheduled Tasks
+│       └── 24/7 云端助手、接到飞书/企微 → kimi.com/bot（Claw）
+├── 对着真实仓库改代码 / 跑测试 / 提 PR
+│   └── → [Kimi Code](/zh/products/kimi-code/)（本目录不写安装）
+├── 在自己电脑上操作本地文件 / 桌面定时任务
+│   └── → Kimi Work（kimi.com/products/kimi-work）
+├── 让 Agent 像人一样点浏览器
+│   └── → Kimi WebBridge（产品页）或 Kimi Work 内置 WebBridge
+└── 在自己的程序里调模型
+    └── → Kimi Platform（platform.moonshot.cn）
+```
+
+来源：[products](https://www.kimi.com/zh-cn/products/)、[kimi.com](https://www.kimi.com/)、[Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview)、[Claw overview](https://www.kimi.com/en/help/kimi-claw/overview)、[Kimi Work overview](https://www.kimi.com/help/kimi-work/overview)、[moonshot.cn](https://www.moonshot.cn/)。
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 分清门 | 本页家族表 | 不要走进 Kimi Code / Work |
+| 2. 打开能用 | [Kimi 教程](./kimi.md) | 网页对话 + 第一次 Agent |
+| 3. 按场景做 | [Cookbook](./kimi-cookbook.md) | Swarm / Claw / 项目 / 定时任务 |
+| 4. 回查入口与额度 | [速查表](./kimi-cheatsheet.md) | 只抄官方表 |
+| 5. 名字拧清 | [术语表](./kimi-glossary.md) | 撞名与「不是什么」 |
+
+## 本目录不写什么
+
+- Kimi Code CLI / VS Code 安装、斜杠命令、`AGENTS.md`。
+- Kimi Work 桌面安装步骤。
+- API `base_url` / `MOONSHOT_API_KEY` 示例（那是 Platform）。
+- 模型内部训练细节。机制见 [Learn LLM](/zh/tech/fundamentals/LLM)。
+
+## 相关页面
+
+- [Kimi 对话与 Agent](./kimi.md)
+- [实战 Cookbook](./kimi-cookbook.md)
+- [速查表](./kimi-cheatsheet.md)
+- [术语表](./kimi-glossary.md)
+- [Kimi Code](/zh/products/kimi-code/)
+- [产品总览](../index.md)

--- a/docs/zh/products/kimi/kimi-cheatsheet.md
+++ b/docs/zh/products/kimi/kimi-cheatsheet.md
@@ -1,0 +1,157 @@
+---
+title: Kimi 对话与 Agent 速查表
+description: 只查不学。入口、斜杠、额度只抄能打开的官方页。两套套餐名不合并。
+domain: product
+tags:
+  - chat
+role: cheatsheet
+---
+
+# Kimi 对话与 Agent 速查表
+
+只查不学。数字以链出的官方页为准。最后核实：2026-08-19。
+
+本表**不含** Kimi Code CLI。编码命令见 [Kimi Code](/zh/products/kimi-code/)。
+
+## 官方入口
+
+| 面 | 入口 |
+|----|------|
+| 工作台 / 对话 | [kimi.com](https://www.kimi.com/) |
+| 产品家族 | [kimi.com/zh-cn/products](https://www.kimi.com/zh-cn/products/) |
+| Agent | [kimi.com/agent](https://www.kimi.com/agent) |
+| Agent Swarm | [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm) |
+| Kimi Claw | [kimi.com/bot](https://www.kimi.com/bot) |
+| Kimi Work（另产品） | [kimi.com/products/kimi-work](https://www.kimi.com/products/kimi-work) |
+| Kimi Code（另产品） | [Kimi Code](/zh/products/kimi-code/) |
+| API（另产品） | [platform.moonshot.cn](https://platform.moonshot.cn/) |
+| 帮助中心 | [zh-hans/help](https://www.kimi.com/zh-hans/help)、[help](https://www.kimi.com/help) |
+| 公司站 / App | [moonshot.cn](https://www.moonshot.cn/) |
+
+首页侧栏原文：[kimi.com](https://www.kimi.com/) — Plugins、Scheduled Tasks、Slides、Swarm、Deep Research、Docs、Websites、Sheets、Design；Kimi Work、Kimi Code、Kimi Claw。新对话：**⌘K**。
+
+App 切模型（[Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview)）：**K3** 或 **K3 集群 / K3 Swarm**。
+
+## 网页里能抄的命令 / 入口
+
+这些出现在官方帮助，**不是** Kimi Code TUI。
+
+| 输入或按钮 | 作用 | 来源 |
+|------------|------|------|
+| `/` | 调 Skills / 插件 | Skills、Plugins、Scheduled Tasks |
+| `+` | 插件 / 上传 / 新项目 | Plugins、Projects |
+| `/skill-creator` | 对话创建 Skill | [Skills](https://www.kimi.com/help/features/what-are-skills) |
+| `/stop` | Claw 群聊强制打断 | [group-chat](https://www.kimi.com/help/kimi-claw/group-chat) |
+| Create scheduled task | 侧栏建定时任务 | [Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks) |
+| Create（Claw） | 一键云端 OpenClaw | [Claw overview](https://www.kimi.com/en/help/kimi-claw/overview) |
+| Link existing OpenClaw | 接入自建实例 | 同上 |
+| Start Group Chat | Claw 群聊 | group-chat |
+| Settings → Personalization → Memory Space | 管理记忆 | [Memory](https://www.kimi.com/help/features/memory-space) |
+| Settings → Chat channels | Claw 渠道 | Claw overview |
+
+官方技能名例子：`docx`、`deep-research`、`sop-writer`、`event-etf-study`。
+
+## 会员概览（乐理名 + 美元）
+
+来源：[membership-overview](https://www.kimi.com/zh-hans/help/membership/membership-overview)。聊天 **K2.6 免费、不耗额度**。会员功能共用水池。
+
+第一张表：
+
+| 功能 | Moderato $19/月 | Allegretto $39/月 | Allegro $99/月 | Vivace $199/月 |
+|------|-----------------|-------------------|----------------|----------------|
+| Agent 额度* | 60 | 150 | 360 | 720 |
+| Agent 并发任务数 | 2 | 2 | 4 | 4 |
+| Agent 速度优先级 | 4× | 4× | 4× | 4× |
+| 专业数据库 | 2,000 次 | 5,000 次 | 12,000 次 | 24,000 次 |
+| Kimi Code | 可调用 | 可调用 | 可调用 | 可调用 |
+
+\* 官方脚注：按典型任务 token 估算的近似值，仅供参考。
+
+第二张表（同页，摘与对话 / Agent 相关的行）：
+
+| 功能 | Moderato | Allegretto | Allegro | Vivace |
+|------|----------|------------|---------|--------|
+| K3 超长对话（最高 100 万 tokens） | — | — | ✅ | ✅ |
+| 定时任务 | 10 | 15 | 20 | 25 |
+| 小组件任务 | 10 | 15 | 20 | 25 |
+| 项目数 | 20 | 20 | 100 | 100 |
+| 项目存储 | 20GB | 20GB | 50GB | 50GB |
+| 插件 | 15+ 种 | 15+ 种 | 15+ 种 | 15+ 种 |
+| Agent Swarm | ✅ | ✅ | ✅ | ✅ |
+| Swarm 并发子任务 | 2 | 4 | 8 | 8 |
+| 目标模式 | — | ✅ | ✅ | ✅ |
+| Kimi Claw（网页 / 安卓 / PC） | — | ✅ | ✅ | ✅ |
+| Claw 群聊 | — | 10 | 10 | 10 |
+
+年付：官方写每年最多可省 **$480**。Kimi Code 另有 **5 小时 / 每周** 速率限制。
+
+## 功能页上的另一套档位名
+
+[Projects](https://www.kimi.com/help/features/project) 与 [Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks) 使用 **Free / Go / Pro / Max / Ultra**。官方**没有**把它们逐档等于 Moderato…。不要自己对齐。
+
+Projects：
+
+| | Free | Go | Pro | Max | Ultra |
+|--|------|----|-----|-----|-------|
+| 项目数 | 2 | 20 | 20 | 100 | 100 |
+| 项目存储 | 500MB | 20GB | 20GB | 50GB | 50GB |
+
+Scheduled Tasks（**同时处于 active 的数量**，创建总数不限）：
+
+| | Free | Go | Pro | Max | Ultra |
+|--|------|----|-----|-----|-------|
+| 定时任务 | 2 | 6 | 15 | 20 | 25 |
+
+项目文件：每文件 ≤ **100 MB**，最多 **50** 个。
+
+定时任务默认过期：Daily +7 天；Weekly +1 月；Monthly +3 月。
+
+## 其它硬数字（均有出处）
+
+| 数字 | 出处 |
+|------|------|
+| Agent 20+ 工具 | Agent 概览 |
+| Swarm 最多 300 子 Agent、>4000 次工具调用、约 4.5× | Agent Swarm |
+| Deep Research 万字 / 10,000+ word | Agent 概览 |
+| Sheets 最多 1,000 行 Excel | Agent 概览 |
+| ClawHub 5,000+ 技能 | Agent 概览 / Claw 介绍 |
+| K3：2.8T 参数、1M token、原生视觉 | Agent 概览（2026-07-16） |
+| 一键 Claw：Allegretto+；默认 K2.6 | Claw overview |
+| 插件：K3 / K3 Swarm / Deep Research / Websites / PPT；Claw 与 Plus 不行 | Plugins |
+
+## 高质量信息源
+
+最后核实：2026-08-19。只收亲自打开过的官方页。
+
+### 一手官方
+
+| 来源 | 用途 |
+|------|------|
+| [kimi.com](https://www.kimi.com/) | 工作台本体 |
+| [zh-cn/products](https://www.kimi.com/zh-cn/products/) | 一级产品 |
+| [zh-hans/help](https://www.kimi.com/zh-hans/help) | 中文帮助总目 |
+| [help](https://www.kimi.com/help) | 英文帮助总目 |
+| [Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview) | Agent 步骤 |
+| [Agent Swarm](https://www.kimi.com/zh-hans/help/agent/agent-swarm) | Swarm |
+| [会员概览](https://www.kimi.com/zh-hans/help/membership/membership-overview) | 套餐与水池 |
+| [Claw overview](https://www.kimi.com/en/help/kimi-claw/overview) | 部署 |
+| [Claw 群聊](https://www.kimi.com/help/kimi-claw/group-chat) | Conductor / `/stop` |
+| [Projects](https://www.kimi.com/help/features/project) | 项目 |
+| [Skills](https://www.kimi.com/help/features/what-are-skills) | 技能 |
+| [Plugins](https://www.kimi.com/help/features/plugins) | 插件 |
+| [Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks) | 定时任务 |
+| [Memory](https://www.kimi.com/help/features/memory-space) | 记忆 |
+| [Kimi Work overview](https://www.kimi.com/help/kimi-work/overview) | 桌面端（本目录不展开） |
+| [moonshot.cn](https://www.moonshot.cn/) | 公司 / App |
+| [platform.moonshot.cn](https://platform.moonshot.cn/) | API |
+
+### 访问提示
+
+`www.kimi.com` 对部分自动化抓取会落到 198.18.x，命令行 GET 可能失败。帮助中心乱猜 slug 会进空搜索页。先打开分类页再抄链接。
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./kimi.md)
+- [Cookbook](./kimi-cookbook.md)
+- [术语表](./kimi-glossary.md)

--- a/docs/zh/products/kimi/kimi-cookbook.md
+++ b/docs/zh/products/kimi/kimi-cookbook.md
@@ -1,0 +1,128 @@
+---
+title: Kimi 对话与 Agent Cookbook
+description: "已经打得开 kimi.com。每个配方一个任务：目标、官方入口、步骤、坑。"
+domain: product
+tags:
+  - chat
+role: cookbook
+---
+
+# Kimi 对话与 Agent Cookbook
+
+已经打得开 [kimi.com](https://www.kimi.com/)。每个配方一个任务。安装 Kimi Code 不在这里——见 [Kimi Code](/zh/products/kimi-code/)。
+
+## 1. 用 Agent 交出可下载产物
+
+**目标：** 要网站、PPT、表格或报告，而不是一段聊天回复。
+
+**入口：** [kimi.com/agent](https://www.kimi.com/agent)；App 模型切换选 **K3**（[Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview)）。
+
+1. 用官方那种任务句：「帮我创建一个在线投票工具的网站代码」。
+2. 等它走完规划 / 工具 / 交付。
+3. 下载代码项目、Office 文件，或打开部署链接。
+
+**坑：** 这是浏览器里的 Agent，不会改你磁盘上的 git 仓库。
+
+## 2. 用 Swarm 做大规模搜集
+
+**目标：** 上百个来源、多视角评审、超长文，单 Agent 太慢。
+
+**入口：** [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm)；App 选 **K3 Swarm**（[Agent Swarm](https://www.kimi.com/zh-hans/help/agent/agent-swarm)）。
+
+官方例子可直接改：
+
+- 「收集 200+ 篇 Paul Graham 文章」
+- 「100 个 YouTube 细分领域中的 Top 3 创作者」
+- 「基于 40 份 PDF 生成 100 页文献综述」
+
+**坑：** 仅 Moderato 及以上；比标准 Agent 更吃额度；带 [Beta] 时可能不是全量开放。
+
+## 3. 给长期工作建 Project
+
+**目标：** 同一规范 / 同一批 PDF 要用很多轮。
+
+**入口：** 侧栏 Projects 旁 **+**，或首页 **+ New project**（[Projects](https://www.kimi.com/help/features/project)）。
+
+1. 名称 1–50 字符，可选项目指令（官方例子："You are a senior product manager. Reply in Chinese and output in Markdown."）。
+2. 上传参考文件：单文件 ≤ 100 MB，最多 50 个。
+3. 每个独立产出开一条项目内对话，不要全塞进一条线程。
+4. 项目内可用 plugins、Skills、Goal，可换模型。
+
+**坑：** 删除不可恢复。Kimi Work 的 Projects **不共享**这份数据。
+
+## 4. 定一个每天跑的任务
+
+**目标：** 日报 / 行业监测，不用每天手点。
+
+**入口：** 侧栏 **Create scheduled task**，或对话里用自然语言（[Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks)）。
+
+官方可复制提示：
+
+> Every day at 9:00, summarize the latest market news as 3 key points plus 1 risk note, in Chinese, within 200 words.
+
+1. 先在普通对话跑通，或用「Run once now」。
+2. 若依赖 Skill：先安装并试跑，再挂到定时任务。
+3. kimi.com 上创建的任务在云端跑，不必开着电脑。
+
+**坑：** 默认过期：Daily +7 天，Weekly +1 月，Monthly +3 月。Kimi Work **本地**任务关机不补跑。到上限时新任务会存成 inactive。
+
+## 5. 用 Skill 固定输出格式
+
+**目标：** 周报 / SOP / 深度研究格式不要每轮重讲。
+
+**入口：** [What are Skills?](https://www.kimi.com/help/features/what-are-skills)
+
+1. Skills 面板浏览官方 / 推荐技能，点 **+** 安装。
+2. 输入框键入 `/` 选用，或让 Kimi 按问题自动触发。
+3. 没有合适的：上传文档生成，或 `/skill-creator`。
+
+官方技能名可抄：`docx`、`deep-research`；推荐 `sop-writer`、`event-etf-study`。
+
+**坑：** Skill 只在相关任务加载。创建技能会耗额度（见帮助中心 Creating skills FAQ）。
+
+## 6. 给 Agent 接插件
+
+**目标：** 查工商 / GitHub / Notion，而不是只靠网页搜索。
+
+**入口：** 侧栏 **Plugins**，或输入框 **+** / `/`（[Plugins](https://www.kimi.com/help/features/plugins)）。
+
+1. 先把模型切到 **K3** 或 **K3 Swarm**（Deep Research / Websites / PPT 场景也可以）。
+2. 登录后安装；要 OAuth 的走第三方授权。
+3. 一次可以 `/` 调多个插件。
+
+**坑：** Claw 和 Kimi Plus 对话**还不能**用插件。未登录不能装。列表随地区（国内 / 海外）和是否企业账号变化。有的插件按调用扣会员额度。
+
+## 7. 一键部署一只 Claw
+
+**目标：** 24/7 云端助手，接到飞书 / 企微，不自己买服务器。
+
+**入口：** [kimi.com/bot](https://www.kimi.com/bot)（[Claw overview](https://www.kimi.com/en/help/kimi-claw/overview)）。
+
+1. 确认会员是 **Allegretto 或更高**。
+2. **Create** Kimi Claw，等自动配置。
+3. **Settings → Chat channels** 配渠道。
+
+已有自建 OpenClaw：选 **Link existing OpenClaw**，在那台机器装 Kimi 插件。
+
+**坑：** 默认模型是 **K2.6**，走会员额度。切 K3 要改 OpenClaw 配置文件，不是网页斜杠命令。
+
+## 8. 开一个 Claw 群聊
+
+**目标：** 多只 Claw 分工，Kimi Conductor 拆任务。
+
+**入口：** Claw 侧栏 **+** → **Start Group Chat**（[group-chat](https://www.kimi.com/help/kimi-claw/group-chat)）。
+
+1. 填 **Group Name** 和 **Group Goal**（都必填）。
+2. 勾选已连接的 Claw，Create。
+3. 用自然语言设群规则（输出格式、语言、谁干什么）。
+4. 文件在 **Workspace** 预览下载。
+5. 某只 Claw 说个没完：主聊天发 **`/stop`**。
+
+**坑：** 会员表 Claw 群聊从 Allegretto 起，10 个群。加不进去先查私聊是否在线。第三方 OpenClaw 版本以群聊帮助页为准（该页写过版本上下限）。
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./kimi.md)
+- [速查表](./kimi-cheatsheet.md)
+- [术语表](./kimi-glossary.md)

--- a/docs/zh/products/kimi/kimi-glossary.md
+++ b/docs/zh/products/kimi/kimi-glossary.md
@@ -1,0 +1,91 @@
+---
+title: Kimi 对话与 Agent 术语表
+description: 不教操作。把都叫 Kimi / Agent / Goal / Project 的东西拆开。
+domain: product
+tags:
+  - chat
+role: glossary
+---
+
+# Kimi 对话与 Agent 术语表
+
+不教操作。只回答「这个词在官方页上是什么、不是什么」。选产品面回 [学习地图](./index.md)。模型内部见 [Learn LLM](/zh/tech/fundamentals/LLM)。
+
+## 都叫 Kimi 的东西
+
+| 名字 | 是什么 | 在哪 |
+|------|--------|------|
+| **Kimi** | 一站式 AI 工作台 / All-in-one agentic AI workspace | [kimi.com](https://www.kimi.com/) |
+| **Kimi Agent** | 端到端自主助手，K3 + 20+ 工具 | [kimi.com/agent](https://www.kimi.com/agent) |
+| **Agent Swarm** | 最多 300 个子 Agent 并行 | [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm) |
+| **Kimi Claw** | 一键云端 OpenClaw，可接即时通讯渠道 | [kimi.com/bot](https://www.kimi.com/bot) |
+| **Kimi Code** | 终端与 IDE 编程助手 | [Kimi Code](/zh/products/kimi-code/) |
+| **Kimi Work** | Mac/Windows 桌面知识工作 Agent（Work / Chat 双模式） | [products/kimi-work](https://www.kimi.com/products/kimi-work) |
+| **Kimi WebBridge** | 给 Agent 用的浏览器插件 | 产品页 |
+| **Kimi Platform** | 官方模型 API | [platform.moonshot.cn](https://platform.moonshot.cn/) |
+| **Kimi Business** | 企业方案 | 帮助中心 |
+| **Kimi Plus** | 插件页点名「Kimi Plus 对话」暂不支持插件 | [Plugins](https://www.kimi.com/help/features/plugins) |
+| **K2.6 / K3 / K3 Swarm** | 工作台里的模型 / 模式开关 | 输入框上方模型切换 |
+| **Moonshot AI / 月之暗面** | 公司 | [moonshot.cn](https://www.moonshot.cn/) |
+
+## Agent 家族：三个调度面
+
+| | 单 Agent | Agent Swarm | Claw 群聊 |
+|--|----------|-------------|-----------|
+| **是什么** | 一只助手拆任务、调工具 | 一只 orchestrator 拉最多 300 个子 Agent | 多只 Claw + Kimi Conductor |
+| **入口** | `kimi.com/agent` 或 App 的 K3 | `kimi.com/agent-swarm` 或 K3 Swarm | `kimi.com/bot` 里 Start Group Chat |
+| **官方强调** | 20+ 工具、Office / 网站交付 | 横向扩展、不必手写工作流 | 跨人、跨设备、跨权限边界 |
+| **不是** | 不是 Kimi Code | 不是「把 Claw 开 300 个」 | 不是 Swarm 的另一个名字 |
+
+**OpenClaw ≠ Kimi Claw。** OpenClaw 是可自建的助手；Kimi Claw 是 Kimi 帮你部署或链上它的产品面。群聊里还可以带自己的 OpenClaw 当 Worker。
+
+**OK Computer** 是 2025-09-26 上线的早期 Agent 模式名称（Agent 时间线）。现在帮助中心主推 Kimi Agent / K3。
+
+## Goal 容易踩的坑
+
+| 说法 | 官方出现位置 | 不是 |
+|------|--------------|------|
+| Goal / 目标模式 | 会员表（Allegretto+）；项目对话可 use Goal | 不是全站免费开关 |
+| Kimi Work Goal Mode | Work 帮助 | 不是网页聊天的同一份文档 |
+| Kimi Code `/goal` | Code CLI | **不是** kimi.com 输入框命令 |
+
+没有独立的「Goal 产品」一级入口。家族图里只占一行。
+
+## 两份 Projects
+
+官方原文（[Projects](https://www.kimi.com/help/features/project)）：Kimi Work desktop app 也有 Projects，**与 Kimi (Chat) projects 不相连、不共享数据**。
+
+| | kimi.com Projects | Kimi Work Projects |
+|--|-------------------|--------------------|
+| **干什么** | 网页工作台的持久工作区 | 桌面端任务空间 |
+| **本目录** | Tutorial / Cookbook | 地图一行，不写步骤 |
+
+## 额度、记忆、Skills、插件
+
+**额度池：** 会员功能共用水池，按 token 计。聊天 K2.6 单独免费。Kimi Code 另有 5 小时 / 每周速率限制。不要把「Agent 额度 60」理解成「只能聊 60 句」——官方脚注写那是按典型任务折算的近似值。
+
+**两套套餐名：** 会员页 Moderato / Allegretto / Allegro / Vivace（美元）。Projects / Scheduled Tasks 页 Free / Go / Pro / Max / Ultra。以各自页面为准，禁止合并成一张「应该是」。
+
+**记忆：** 跨会话偏好。官方：不用于训练；不主动记未授权隐私。项目上下文会注入「全局主记忆」，但项目指令只在该项目生效。
+
+**Skills：** 按需加载的知识包。官方 / 推荐 / 开源 / 自定义。键入 `/`。
+
+**插件：** 接第三方。K3 / K3 Swarm 和部分场景可用；Claw、Plus 对话不行。和 Kimi Code 的插件系统不是同一套配置。
+
+**定时任务：** kimi.com 云端跑；Kimi Work 还可本地跑（应用得开着）。
+
+## 禁止写进正文的说法
+
+- 「Kimi 就是 Kimi Code」
+- 「网页输入 `/goal` 等于 CLI Goal」
+- 「Moderato 就是 Go」
+- 「Claw 群聊 = Agent Swarm」
+- 把 Code 安装脚本当本目录 Quickstart
+- 人民币价（本调研未打开独立中文标价页当唯一真源）
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [教程](./kimi.md)
+- [Cookbook](./kimi-cookbook.md)
+- [速查表](./kimi-cheatsheet.md)

--- a/docs/zh/products/kimi/kimi.md
+++ b/docs/zh/products/kimi/kimi.md
@@ -1,0 +1,200 @@
+---
+title: Kimi 对话与 Agent
+description: "写给谁：在选月之暗面产品面的前端工程师。你需要浏览器或 Kimi App，不需要仓库。"
+domain: product
+tags:
+  - chat
+role: tutorial
+---
+
+# Kimi 对话与 Agent
+
+> **Kimi** 是月之暗面的一站式 AI 工作台。官方定义（[zh-cn/products](https://www.kimi.com/zh-cn/products/)）：
+> 「从深度研究、幻灯片到表格、文档与网站，Kimi 内置强大的 Agent 能力。」
+>
+> **Kimi Agent** 的官方定义（[Agent 概览](https://www.kimi.com/zh-hans/help/agent/agent-overview)）：
+> 「Kimi Agent 是一款可端到端处理复杂任务的自主 AI 助手。它由 Kimi K3 驱动，可调用 20 多种工具来构建网站、生成文档、分析数据等。」
+>
+> 本页只根据 kimi.com、产品页和帮助中心写入口与步骤。它**不是** Kimi Code——编码 CLI 见 [Kimi Code](/zh/products/kimi-code/)。
+
+## 目标与非目标
+
+**写给谁：** 在选 Kimi 产品面的前端工程师。你需要浏览器或 Kimi App，不需要 checkout。
+
+**目标：** 打开 kimi.com，分清对话 / Agent / Swarm / Claw，跑完第一次 Agent 任务，知道额度从哪张官方表查。
+
+**非目标：** Kimi Code 安装；臆造人民币价；把 Moderato 写成 Go；讲解模型内部。机制见 [Learn LLM](/zh/tech/fundamentals/LLM)。
+
+## 它是什么
+
+一张工作台，几个官方客户端：
+
+| 客户端 | 官方入口 |
+|--------|----------|
+| Web | [kimi.com](https://www.kimi.com/) |
+| Agent | [kimi.com/agent](https://www.kimi.com/agent) |
+| Agent Swarm | [kimi.com/agent-swarm](https://www.kimi.com/agent-swarm) |
+| Kimi Claw | [kimi.com/bot](https://www.kimi.com/bot) |
+| App | [moonshot.cn](https://www.moonshot.cn/) 页脚「扫码下载 Kimi App」 |
+
+首页侧栏抄官方标签（[kimi.com](https://www.kimi.com/)）：**Plugins、Scheduled Tasks、Slides、Swarm、Deep Research、Docs、Websites、Sheets、Design**，以及 **Kimi Work / Kimi Code / Kimi Claw**。新对话快捷键首页写的是 **⌘K**。
+
+Agent 核心能力（[Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview)）：
+
+| 能力 | 官方说明 |
+|------|----------|
+| 网站（Websites） | 生成并部署响应式网站 / 应用 |
+| 文档（Docs） | Word、PDF、Markdown 等 |
+| 表格（Sheets） | Excel / CSV，官方写可整理 1000 行 Excel |
+| 幻灯片（Slides） | 自动生成 PPT |
+| 深度研究（Deep Research） | 万字级研究报告 |
+| Agent Swarm | 最多 300 个子代理并行，超过 4,000 次工具调用 |
+| Kimi Claw | 零部署云端自动化；帮助中心写内置 5,000+ 技能库（ClawHub） |
+
+工作步骤（同一页）：任务规划 → 工具调用（20 多种）→ 自主执行 → 异常处理 → 成果交付。
+
+## 第一次：打开对话
+
+1. 打开 [kimi.com](https://www.kimi.com/)，登录。未登录时侧栏写「Log in to sync chat history」。
+2. 在输入框提问。首页文案：「Ask anything, or task an agent...」
+3. 聊天额度口径以会员页为准：官方原文「在聊天中，K2.6 对所有用户免费，且不消耗额度」（[会员概览](https://www.kimi.com/zh-hans/help/membership/membership-overview)）。
+
+需要持久上下文时建 **Project**，不要每轮重贴同一批文件。见下一节。
+
+## 第一次：跑一个 Agent 任务
+
+官方入口（[Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview)）：
+
+- **网页：** [https://www.kimi.com/agent](https://www.kimi.com/agent)
+- **手机 / 平板：** 打开 Kimi App，在对话框上方的**模型切换按钮**里选 **K3** 或 **K3 集群**
+
+步骤（抄官方）：
+
+1. 清晰描述任务并发送。官方例子：「帮我创建一个在线投票工具的网站代码」、「分析 2025 年 AI 芯片行业的竞争格局」。
+2. 看执行过程：推理链路、工具、访问的网址、中间代码。
+3. 任务完成后下载或分享：代码项目、文件夹、数据分析、Word / PDF / PPT。
+
+适用场景（官方列表）：网站开发、内容生成、合同比对 / 长文档翻译、数据分析、PPT、文档互转。
+
+## Agent Swarm
+
+官方定义（[Agent Swarm](https://www.kimi.com/zh-hans/help/agent/agent-swarm)）：横向扩展，协调最多 **300** 个子 Agent，无需预设角色或手工编排。相比单 Agent，官方写任务完成速度约提升 **4.5 倍**；单任务可超过 **4,000** 次工具调用。当前由 **Kimi K3（K3 Swarm）** 驱动。
+
+**入口：**
+
+- Web：<https://www.kimi.com/agent-swarm>
+- 移动端：Kimi App 模型切换选 **K3 Swarm**
+
+**资格：** 面向 **Moderato、Allegretto、Allegro、Vivace** 会员。官方写：相比标准 Agent，此类任务会消耗明显更多额度。页上的 **[Beta]** 表示初期仅面向少量用户。
+
+步骤（官方）：描述任务 → 看子 Agent 并行 → 收交付物 → 后续轮次会在对话与 Agent 之间自动调度，无需手动切换。
+
+适合：大规模检索、批量下载、100+ 文档、超长写作、复杂编程、Office 自动化。不适合一句就能答完的闲聊。
+
+## Kimi Claw
+
+官方定位（[Claw overview](https://www.kimi.com/en/help/kimi-claw/overview)）：通过 Kimi Claw 在 Kimi 里和 **OpenClaw** 对话。OpenClaw 是「有鲜明个性和长期记忆」的助手。
+
+**一键部署（云端）：**
+
+1. 登录 [kimi.com/bot](https://www.kimi.com/bot)
+2. 点 **Create** Kimi Claw
+3. 等系统自动配置（官方：通常几分钟）
+4. 改昵称；在 **Settings → Chat channels** 配微信 / 飞书 / 企微等
+
+官方约束：一键部署仅 **Allegretto 及以上**。默认配置 **Kimi K2.6**，并挂到你的**会员额度**，同时打开 Kimi Web Search。可部署到飞书、企微、微博等。
+
+**接入已有 OpenClaw：** Claw 页选 **Link existing OpenClaw**，在跑 OpenClaw 的设备上按说明装 Kimi 插件。
+
+**Claw 群聊**（[group-chat](https://www.kimi.com/help/kimi-claw/group-chat)）：侧栏 **+** → **Start Group Chat**，填 Group Name 与 Group Goal，选已连接的 Claw。Kimi 自动指定 **Conductor**。主聊天发 `/stop` 可强制打断。群规则用自然语言让 Kimi 改。Allegretto 起；会员表写 10 个群聊。
+
+把 Claw 默认模型切到 K3 的命令在官方 Claw 页，路径是本机 `/root/.openclaw/openclaw.json`（或你的实际安装路径）。那是 **OpenClaw 配置**，不是 kimi.com 输入框命令。需要时打开 [Claw overview](https://www.kimi.com/en/help/kimi-claw/overview) 抄原文，改前先备份。
+
+## Projects、记忆、Skills、插件、定时任务
+
+这些是工作台横切能力，官方分类在 [Features](https://www.kimi.com/help/features)。
+
+### Projects
+
+[Projects](https://www.kimi.com/help/features/project)：把参考文件、对话、项目指令放在一起。侧栏 **Projects** 旁的 **+**，或首页选择器 **+ New project**。名称 1–50 字符。
+
+- 项目内对话可用 **项目文件、项目指令、plugins、Skills、Goal**，并可换模型。
+- 单文件 ≤ **100 MB**，最多 **50** 个文件；模型按需读取，不是每轮灌全文。
+- 删除项目会**永久删掉**其对话、文件和指令，不可恢复。
+- 上下文：system prompt + 全局主记忆 + 项目指令 + 按需文件。
+- **Kimi Work 里的 Projects 与这里不通、不共享数据。**
+
+### 记忆
+
+[Memory space](https://www.kimi.com/help/features/memory-space)：跨会话记偏好。官方说不会记住未授权的隐私（健康、密码、地址），除非你明确要求。管理入口：**Settings → Personalization → Memory Space**。可以说「记住… / 忘掉… / 你现在记得我什么」。官方：记忆不用于模型训练，可随时关或清。
+
+### Skills
+
+[What are Skills?](https://www.kimi.com/help/features/what-are-skills)：可复用知识包。输入框键入 **`/`** 选技能，或让 Kimi 自动触发。可用 **`/skill-creator`** 对话生成。官方技能例子：`docx`、`deep-research`；推荐例子：`sop-writer`、`event-etf-study`。
+
+### 插件
+
+[Plugins](https://www.kimi.com/help/features/plugins)：接外部服务。可用范围：模型切到 **K3** 或 **K3 Swarm**，以及 Deep Research / Websites / PPT。**Kimi Claw 和 Kimi Plus 对话尚不支持。** 入口：侧栏 **Plugins**、输入框 **+**、或 **`/`**。部分要 OAuth。未登录不能装。部分插件按实际调用扣会员额度。
+
+### 定时任务
+
+[Scheduled Tasks](https://www.kimi.com/help/features/scheduled-tasks)：在 **Kimi** 和 **Kimi Work** 都有。侧栏「Create scheduled task」，或在对话里用自然语言让它建。周期：daily / weekly / monthly / 一次性。云端任务不用开着客户端。Kimi Work **本地**任务要桌面端开着，关掉期间错过的不会补跑。跑完可在结果对话换模型继续问，并用 `/` 调插件和 Skills。
+
+官方提示模板：At [time], do [task], output as [format], and follow [constraints]。
+
+## Goal
+
+官方出现位置：
+
+- 会员对比表有 **Goal Mode / 目标模式**：Moderato 为 —，**Allegretto / Allegro / Vivace** 为 ✅（[会员概览](https://www.kimi.com/zh-hans/help/membership/membership-overview)）。
+- 项目对话「use plugins, Skills, and Goal」（[Projects](https://www.kimi.com/help/features/project)）。
+
+帮助中心没有单独的「kimi.com Goal 产品页」。Kimi Work 另有 Goal Mode（[Work overview](https://www.kimi.com/help/kimi-work/overview)）。Kimi Code 的 `/goal` 是 CLI，**不要**在 kimi.com 输入框当命令用。
+
+## 会员与额度
+
+[会员概览](https://www.kimi.com/zh-hans/help/membership/membership-overview)（2026-08-19 打开）：
+
+- 四档：**Moderato $19/月、Allegretto $39/月、Allegro $99/月、Vivace $199/月**。
+- **所有会员功能共用一个额度池**（网站部署、Deep Research、幻灯片、Kimi Code、Kimi Work、Kimi Claw、K3、K3 Swarm）。按 token 计量。
+- 聊天里 **K2.6 免费且不耗额度**。
+- 额度每个计费周期重置。年付官方写最多可省 **$480/年**。
+- Kimi Code **另外**有 5 小时 / 每周速率限制，不影响其它会员功能。
+
+同一页第二张表还写了：Agent 并发、K3 超长对话（Allegro / Vivace，最高 100 万 tokens）、定时任务数、项目数、Swarm 并发子任务、Goal、Claw、Claw 群聊等。完整数字进 [速查表](./kimi-cheatsheet.md)。
+
+**两套官方套餐名：** Projects / Scheduled Tasks 页使用 **Free / Go / Pro / Max / Ultra**，且数字与会员概览不完全相同。本页**不以意译对齐**。查价与会员权益以会员概览为准；查项目数 / 定时任务上限时打开对应功能页，冲突先看该功能页并链会员页。
+
+本页**不**写人民币价。以你账号里的会员 / 用量页为准。
+
+## 常见陷阱
+
+- 把对话里出的网站代码当成已经改好了本地仓库。要改 checkout，去 [Kimi Code](/zh/products/kimi-code/)。
+- 没开会员就进 `kimi.com/agent-swarm` 或 `kimi.com/bot`，对照会员表：Swarm 要 Moderato+，一键 Claw 要 Allegretto+。
+- 把 Kimi Work 桌面项目和 kimi.com Projects 当成同步盘。
+- 把 Kimi Code `/goal` 打进网页输入框。
+- 用一份「应该是」的套餐对照表合并 Moderato 和 Go。
+- 在 Claw / Kimi Plus 对话里找网页插件——官方写尚未支持。
+- 指望 Kimi Work 本地定时任务在关机后补跑。
+
+## 官方文档
+
+| 页面 | 用来干什么 |
+|------|------------|
+| [kimi.com](https://www.kimi.com/) | 产品本体 |
+| [zh-cn/products](https://www.kimi.com/zh-cn/products/) | 一级产品家族 |
+| [Agent 概览](https://www.kimi.com/zh-cn/help/agent/agent-overview) | Agent 入口与步骤 |
+| [Agent Swarm](https://www.kimi.com/zh-hans/help/agent/agent-swarm) | Swarm 入口与限制 |
+| [会员概览](https://www.kimi.com/zh-hans/help/membership/membership-overview) | 套餐与额度池 |
+| [Claw overview](https://www.kimi.com/en/help/kimi-claw/overview) | 一键部署 / 连接已有 OpenClaw |
+| [Claw 群聊](https://www.kimi.com/help/kimi-claw/group-chat) | Conductor、Thread、`/stop` |
+| [帮助中心](https://www.kimi.com/zh-hans/help) | 分类总入口 |
+| [moonshot.cn](https://www.moonshot.cn/) | 公司站、App 下载 |
+
+## 相关页面
+
+- [学习地图](./index.md)
+- [Cookbook](./kimi-cookbook.md)
+- [速查表](./kimi-cheatsheet.md)
+- [术语表](./kimi-glossary.md)
+- [Kimi Code](/zh/products/kimi-code/)


### PR DESCRIPTION
Closes #70

## Summary

From-scratch handbook for **Kimi chat / Agent on kimi.com** (Moonshot). Chinese first, then English. Kimi Code install is **not** the main tutorial.

## Family (official first-class AI)

Retrieved from https://www.kimi.com/zh-cn/products/ , https://www.kimi.com/ , https://www.kimi.com/help , https://www.moonshot.cn/ .

| Official entry | This site |
|----------------|-----------|
| Kimi workspace / Agent / Swarm / Claw / Goal | This directory |
| Slides / Docs / Sheets / Deep Research / Websites / Design / Features | Map row |
| **Kimi Code** | One row → `/zh/products/kimi-code/` (#71) |
| Kimi Work / WebBridge / Platform / Business | Map row |
| Research / doodles / careers | Out of scope |

## Files

- `.claude/skills/doc-research/references/kimi.md` — research notes before writing
- `docs/zh/products/kimi/` — ZH Diataxis (index / tutorial / cookbook / cheatsheet / glossary)
- `docs/products/kimi/` — EN isomorphic

## Explicit non-goals

- **Did not** change `products-gallery.js` or sidebars (task instruction overrides the issue checkbox).
- **Did not** write Kimi Code CLI install (`install.sh`, `@moonshot-ai/kimi-code`).
- Did not invent CNY prices or merge Moderato with Free/Go/Pro/Max/Ultra (two official naming systems left side by side).

## Checks

- `node scripts/frontmatter-audit.mjs` PASS
- `pnpm docs:build` PASS