### PR TITLE
docs(trae): add Trae handbook for #80

### DIFF
--- a/.claude/skills/doc-research/references/learn-ai-bindings.md
+++ b/.claude/skills/doc-research/references/learn-ai-bindings.md
@@ -12,5 +12,6 @@
 | Gemini | [`gemini.md`](./gemini.md) | `docs/zh/products/ai-coding/gemini/` |
 | Grok | [`grok.md`](./grok.md) | `docs/zh/products/ai-coding/grok/` |
 | Copilot | [`copilot.md`](./copilot.md) | `docs/zh/products/ai-coding/copilot/` |
+| Trae | [`trae.md`](./trae.md) | `docs/zh/products/trae/` |
 
 数据源清单写在对应 `<tool>-cheatsheet.md` 的「高质量信息源」，不要在维护参考里再抄一份。

--- a/.claude/skills/doc-research/references/trae.md
+++ b/.claude/skills/doc-research/references/trae.md
@@ -1,0 +1,93 @@
+# Trae 维护参考
+
+> 这是 [`_template.md`](./_template.md) 针对 Trae / TraeCode 的具体化。读者可见的数据源写在 `docs/zh/products/trae/trae-cheatsheet.md` 的「高质量信息源」，不要在本文件再抄一份。
+
+## 基本信息
+
+- 工具名：TraeCode（品牌名 TRAE；本目录只展开编程 IDE）
+- 官方文档根地址：国际站 <https://docs.trae.ai>；中国站 <https://docs.trae.cn>（提供 `llms.txt` 与同路径 `.md`）
+- 发版节奏：文档站 Changelog 按小版本连续发（国际站可见 3.5.x 线；中国站 Changelog 单独记）
+- 当前覆盖版本：2026-08-19 打开的官方首页 / 下载中心 / docs 侧栏
+
+## 官方一级导航（产品家族）
+
+文档站顶栏（2026-08-19 打开 <https://docs.trae.ai/ide/device-limit>）和营销首页（<https://www.trae.ai/>）对账：
+
+| 官方一级入口 | 官方 URL | 本站去向（独立页 / 地图一行 / 缺失） | 不拆页理由（若一行） |
+|--------------|----------|--------------------------------------|----------------------|
+| **TraeCode**（AI 编程 IDE） | [www.trae.ai](https://www.trae.ai/) · [下载](https://www.trae.ai/download) · [docs.trae.ai](https://docs.trae.ai/ide/what-is-trae) | 独立页：本目录 Tutorial | 本 issue 主路径 |
+| **TraeWork**（办公 / 工作台） | [www.trae.ai/work](https://www.trae.ai/work) · [What is TRAE Work?](https://docs.trae.ai/solo/what-is-trae-solo) | 地图一行 | 官方一级，但是办公 Agent，不是本目录 Tutorial |
+| **TraeCode Plugin** | 文档站顶栏 · 企业页描述 VS Code / JetBrains | 地图一行 | 独立文档根 URL 未单独打开；企业页有职责说明 |
+| **TRAE Enterprise** | [www.trae.ai/enterprise](https://www.trae.ai/enterprise) | 地图一行 | 团队采购，不是个人 Tutorial |
+| **TraeCode CLI** | 企业页写 **coming soon** | 地图一行 | 官方标明尚未上线，禁止编命令 |
+| **TRAE Editor for Unity** | [docs.trae.cn 教程](https://docs.trae.cn/ide_trae-editor-for-unity-tutorial.md) | 地图一行 | Unity 插件，不是前端主路径 |
+| **中国站** | [www.trae.cn](https://www.trae.cn/) · 快速开始链 [www.trae.com.cn](https://www.trae.com.cn) · [docs.trae.cn](https://docs.trae.cn/ide_what-is-trae-code) | 地图一行 + Tutorial 分表面写 | 与 `trae.ai` 不是同一套登录 / 额度 / 设备上限 |
+| **火山引擎 TRAE** | [volcengine.com/product/trae](https://www.volcengine.com/product/trae) | 地图一行 | CN 云产品位，不是第二套 IDE 教程 |
+| **豆包** | 另 issue #79 | 地图一行 | 同厂，不在本目录展开 |
+| **扣子 Coze** | 另 issue #81 | 地图一行 | 同厂，不在本目录展开 |
+| **火山方舟 Ark** | 另 issue #82 | 地图一行 | 同厂，不在本目录展开 |
+
+易撞名（可执行文件名 ≠ 营销名 / Mode ≠ 同名产品）：
+
+- **TRAE（品牌）≠ TraeCode（编程 IDE）≠ TraeWork（办公工作台）**
+- **TraeCode 里的 SOLO 模式 ≠ TraeWork**。官方原文：TraeWork builds upon TraeCode's SOLO mode
+- **旧名 TRAE IDE / TRAE SOLO 独立端** 已收进 TraeCode / TraeWork，不要拆成第三个产品
+- **CUE** 是 TraeCode 补全，不是 Cursor
+- **TraeCode Plugin**（嵌进 VS Code / JetBrains）≠ TraeCode 桌面 IDE 里的扩展市场
+- **trae.ai 国际站 ≠ trae.cn / trae.com.cn 中国站**。设备上限、登录方式、旧 macOS 回退版本号以各自文档为准
+
+## 文档文件结构（Diataxis）
+
+```
+docs/zh/products/trae/
+├── index.md                 # 🗺️ 学习地图
+├── trae.md                  # 📘 Tutorial — 官方下载、第一项目、IDE / SOLO
+└── trae-cheatsheet.md       # 📐 Reference — 官方入口、OS、设备上限、数据源
+```
+
+英文镜像在 `docs/products/trae/`，文件名相同。
+
+**不写** `trae-cookbook.md` / `trae-glossary.md`：官方 How-to（Figma / MCP / Skill）已经成树；易撞名收进地图。密度不够再拆第三份「是什么」。
+
+| 文件 | 象限 | 写什么 | 不写什么 |
+|------|------|--------|----------|
+| `index.md` | 导航 + 速查 | 家族全景 + IDE/SOLO/Work 决策 | 逐步点击路径 |
+| `trae.md` | Tutorial | 选表面、官方下载、打开项目、切模式 | 套餐金额表、Unity、TraeWork 教程 |
+| `trae-cheatsheet.md` | Reference | OS 表、设备上限、官方 URL 索引 | 概念长文 |
+
+## 监控页面
+
+- 国际站产品首页：<https://www.trae.ai/>
+- 国际站下载：<https://www.trae.ai/download>
+- 国际站定价：<https://www.trae.ai/pricing>
+- 国际站营销 Changelog：<https://www.trae.ai/changelog>（2026-08-19 抓到的正文几乎空，以文档站为准）
+- 国际站文档 Changelog：<https://docs.trae.ai/ide/changelog>
+- What is TraeCode：<https://docs.trae.ai/ide/what-is-trae>
+- Quickstart：<https://docs.trae.ai/ide/set-up-trae>
+- Device limit：<https://docs.trae.ai/ide/device-limit>
+- SOLO mode：<https://docs.trae.ai/ide/solo-mode>
+- Models：<https://docs.trae.ai/ide/models>
+- TraeWork 文档：<https://docs.trae.ai/solo/what-is-trae-solo>
+- 中国站：<https://www.trae.cn/> · 快速开始原文链 <https://www.trae.com.cn>
+- 中国站文档 / `llms.txt`：<https://docs.trae.cn/llms.txt>
+- 中国站快速开始（`.md`）：<https://docs.trae.cn/ide_get-started-with-trae.md>
+- 中国站设备上限（`.md`）：<https://docs.trae.cn/ide_device-limit.md>
+- 火山引擎产品位：<https://www.volcengine.com/product/trae>
+
+## Git 提交 scope
+
+```
+docs(trae): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+- **两套表面不要混抄。** 国际站设备上限是 **3** 台（[device-limit](https://docs.trae.ai/ide/device-limit)）；中国站 `.md` 写 **10** 台（[ide_device-limit.md](https://docs.trae.cn/ide_device-limit.md)）。登录方式、旧 macOS 回退版本号也不同。写之前先标表面。
+- **中国站旧 macOS 回退版本号是 3.3.25**（[ide_get-started-with-trae.md](https://docs.trae.cn/ide_get-started-with-trae.md)）。国际站中文 Quickstart 搜索摘要写过 **3.5.25**。不要合成一个数字。
+- **中国站快速开始链的下载域是 `www.trae.com.cn`**，营销首页还有 `www.trae.cn`。两份都是官方入口，不要宣布其中一个作废。
+- **套餐：跟现行定价页，不跟 Legacy。** 国际站营销页 <https://www.trae.ai/pricing> 写 Lite / Pro / Pro+ / Ultra；文档站另有 `(Legacy) Plans & billing`。只抄能打开的现行页；Lite / Pro+ / Ultra 的完整月费没抓全就链过去，禁止补「应该是」。
+- **TraeWork 模式数官方页打架。** 营销页写 Work / Code / Design；国际站 What is TRAE Work 英文页写 Work 与 Code 两种。不要用「通常」抹平，写清以哪页为准。
+- **不要编 CLI 安装命令。** 企业页写 TraeCode CLI coming soon。Quickstart 只说首次设置里「添加 TRAE 相关的命令行」，没有 `brew install` / `npm i -g` 原文。
+- **不要编国际站登录方式。** 中国站快速开始原文：手机号、抖音、苹果、稀土掘金。国际站 Quickstart 英文正文 2026-08-19 没抓到登录列表。
+- **文档站 HTML 常是 SPA。** 国际站优先打开已确认路径；中国站优先 `llms.txt` 和同路径 `.md`。
+- **本仓导航。** issue 原文提过 gallery / sidebar；执行指令禁止改 `config.mjs`、gallery、sidebar。只写 `docs/products/trae/` 与 `docs/zh/products/trae/`。

--- a/docs/products/trae/index.md
+++ b/docs/products/trae/index.md
@@ -1,0 +1,127 @@
+---
+title: Trae learning map
+description: "TraeCode is ByteDance's AI coding IDE (IDE mode + SOLO mode). TraeWork, Doubao, Coze, and Ark are different products. This directory only covers installing TraeCode from the official download page and opening a first project."
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# Trae learning map
+
+> **TraeCode** is the AI coding IDE under the TRAE brand. Official copy ([What is TraeCode?](https://docs.trae.ai/ide/what-is-trae)): a development tool deeply integrated with AI, covering coding, project understanding, debugging, and change management. You can stay in control as in a traditional IDE, or hand complex work to agents.
+>
+> The marketing homepage ([www.trae.ai](https://www.trae.ai/)) lists it next to **TraeWork**: **TraeCode: Your 10x AI Coding Engineer**; **TraeWork: Your Professional AI Work Assistant**. This directory expands TraeCode only.
+
+## Audience / prerequisites
+
+- **Who**: frontend engineers who already use a desktop IDE and want ByteDance's Cursor analogue.
+- **Need**: an OS from the official [Quickstart](https://docs.trae.ai/ide/set-up-trae) / [CN getting started](https://docs.trae.cn/ide_get-started-with-trae.md) table; a TRAE account.
+- **Non-goals**: no TraeWork office tutorial; no Doubao / Coze / Ark; no model internals (see Learn LLM); no invented TraeCode CLI commands (the enterprise page says **coming soon**).
+
+## Product family
+
+Official first-level entries first. This directory **only expands TraeCode**. Everything else is one row. Names below are copied from official pages opened 2026-08-19.
+
+| Official name | Official URL | This site |
+|---------------|--------------|-----------|
+| **TraeCode** (AI coding IDE) | [www.trae.ai](https://www.trae.ai/) · [Download Center](https://www.trae.ai/download) | This directory |
+| **TraeCode docs** | [docs.trae.ai · What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) · [Quickstart](https://docs.trae.ai/ide/set-up-trae) | This page · [Tutorial](./trae.md) |
+| **TraeWork** | [www.trae.ai/work](https://www.trae.ai/work) · [What is TRAE Work?](https://docs.trae.ai/solo/what-is-trae-solo) | One row: office workspace, no tutorial here |
+| **TraeCode Plugin** | [Enterprise](https://www.trae.ai/enterprise) (copy: VS Code, JetBrains and other mainstream editors) | One row: embed into an existing editor |
+| **TRAE Enterprise** | [www.trae.ai/enterprise](https://www.trae.ai/enterprise) | One row: team sales |
+| **TraeCode CLI** | Enterprise page: **coming soon** | One row: not shipped; do not invent commands |
+| **TRAE Editor for Unity** | [CN tutorial](https://docs.trae.cn/ide_trae-editor-for-unity-tutorial.md) | One row: Unity plugin |
+| **China site TraeCode / TraeWork** | [www.trae.cn](https://www.trae.cn/) · Quickstart links [www.trae.com.cn](https://www.trae.com.cn) · [docs.trae.cn](https://docs.trae.cn/ide_what-is-trae-code) | [Tutorial · pick a surface](./trae.md#1-pick-a-surface-china-vs-international) |
+| **Volcengine TRAE** | [volcengine.com/product/trae](https://www.volcengine.com/product/trae) | One row: CN cloud catalog slot |
+| **Doubao** | Issue #79 | One row → forthcoming [Doubao family](/products/doubao/) |
+| **Coze** | Issue #81 | One row → forthcoming [Coze family](/products/coze/) |
+| **Ark (Volcengine)** | Issue #82 | One row → forthcoming [Ark family](/products/ark/) |
+
+Sources: [www.trae.ai](https://www.trae.ai/), [docs.trae.ai header](https://docs.trae.ai/ide/what-is-trae), [Enterprise](https://www.trae.ai/enterprise), [www.trae.cn](https://www.trae.cn/), [docs.trae.cn/llms.txt](https://docs.trae.cn/llms.txt).
+
+```
+TRAE (brand)
+├── TraeCode — desktop AI coding IDE (this directory)
+│   ├── IDE mode (editor / terminal / debug / extensions / Git)
+│   ├── SOLO mode (AI-led: plan → generate → test → preview)
+│   ├── CUE / Agent / Skills / Rules / MCP
+│   ├── TraeCode Plugin (VS Code / JetBrains; map row)
+│   └── TraeCode CLI (official coming soon)
+├── TraeWork — standalone office workspace (Web / Desktop / Mobile)
+│   └── Work / Code (marketing page also lists Design)
+├── TRAE Enterprise — teams
+└── Same vendor, not this directory
+    ├── Doubao #79
+    ├── Coze #81
+    └── Ark #82
+```
+
+**Names that collide:**
+
+- **TraeCode ≠ TraeWork.** Coding IDE vs office workspace. Official: [TraeWork builds upon TraeCode's SOLO mode](https://docs.trae.ai/ide/what-is-trae).
+- **SOLO mode inside TraeCode ≠ TraeWork.** SOLO is the top-left mode switch. TraeWork is a separate client (Web / Desktop / Mobile).
+- **Legacy names TRAE IDE / TRAE SOLO standalone** folded into TraeCode / TraeWork. Do not install a third product.
+- **CUE ≠ Cursor.** CUE is TraeCode completion / multi-line edit / next-edit prediction.
+- **TraeCode Plugin ≠ the in-IDE extension marketplace.** Plugin embeds Trae into VS Code / JetBrains.
+- **`trae.ai` ≠ `trae.cn` / `trae.com.cn`.** The international header has a China-site link. Login, quota, and device limits are separate.
+
+### Quick decision: which surface?
+
+```
+What do I want to do?
+├── Write / edit / debug / complete in a local repo
+│   └── → TraeCode
+│       ├── Fine-grained control? → IDE mode
+│       ├── Natural language through to preview? → SOLO mode
+│       └── Stay in VS Code / JetBrains? → TraeCode Plugin (map row)
+├── Slides / docs / data / dispatch tasks across devices
+│   └── → TraeWork (not this directory)
+├── Team procurement, repo-index limits, SOC 2
+│   └── → TRAE Enterprise
+├── General chat assistant
+│   └── → Doubao (#79)
+├── Bots / workflows
+│   └── → Coze (#81)
+└── Metered model API in my own service
+    └── → Ark (#82)
+```
+
+## Learning path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Pick a surface | [Tutorial · China vs international](./trae.md#1-pick-a-surface-china-vs-international) | Do not mix installers or accounts |
+| 2. Install and open a project | [Tutorial](./trae.md) | Official download, then a local folder or clone |
+| 3. Split the two modes | [Tutorial · IDE / SOLO](./trae.md#5-switch-ide-mode-and-solo-mode) | Top-left switch; SOLO is not TraeWork |
+| 4. Look up facts | [Cheatsheet](./trae-cheatsheet.md) | OS, device limit, official URLs |
+
+## Feature lookup
+
+Only capabilities the official docs already state.
+
+| Capability | One line | Official page |
+|------------|----------|---------------|
+| IDE mode | Editor, terminal, debug, extensions, source control | [What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) |
+| SOLO mode | AI-led: requirements → generate → test → preview; top-left switch | [SOLO mode overview](https://docs.trae.ai/ide/solo-mode) |
+| Open a project | Local folder / clone from GitHub / clone from URL | [Quickstart](https://docs.trae.ai/ide/set-up-trae) |
+| CUE | Completion, chained completion, multi-line edits, next-edit prediction; smart import/rename for Py / TS / Go | [What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) |
+| Agents | Natural-language tasks, repo search, tools; custom agents + MCP | Same |
+| Context | Files, folders, snippets, terminal, repos, doc sets, web pages | Same |
+| Privacy mode | Chats / snippets / outputs not used for analysis, optimization, or training; codebase stays local | Same |
+| Sandbox | Agent commands in a restricted environment | Same |
+| Remote | Remote SSH, WSL | Same |
+| Device limit | International **3**; China **10**. TraeWork Web does not count | [intl](https://docs.trae.ai/ide/device-limit) · [CN](https://docs.trae.cn/ide_device-limit.md) |
+
+## Plans (official pages only)
+
+- Current international tiers: [www.trae.ai/pricing](https://www.trae.ai/pricing) — **Lite / Pro / Pro+ / Ultra**. That page says Pro is **Free for 7 days. Then $10/month.** AI requests are billed as tokens converted to Dollar Usage against a monthly balance. Full monthly prices for Lite / Pro+ / Ultra stay on that page.
+- Docs also keep [(Legacy) Plans & billing](https://docs.trae.ai/ide/billing). Do not treat the old Free/Pro request table as current.
+- China-site credits: follow [docs.trae.cn](https://docs.trae.cn/llms.txt). This site does not invent CN prices.
+- Enterprise: pricing page says Contact us via BytePlus; product page [Enterprise](https://www.trae.ai/enterprise).
+
+## Next steps
+
+1. Open the [TraeCode tutorial](./trae.md). Pick China or international, then install from the official download page.
+2. OS, device limits, and URLs: [cheatsheet](./trae-cheatsheet.md).
+3. Official deep-dive: [docs.trae.ai](https://docs.trae.ai/ide/what-is-trae) or [docs.trae.cn](https://docs.trae.cn/ide_what-is-trae-code).

--- a/docs/products/trae/trae-cheatsheet.md
+++ b/docs/products/trae/trae-cheatsheet.md
@@ -1,0 +1,91 @@
+---
+title: Trae cheatsheet
+description: "Lookup only. OS, device limits, mode decisions, and official URLs copied from docs.trae.ai / docs.trae.cn. Plan prices follow the live pricing page, not the Legacy table."
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# Trae cheatsheet
+
+Lookup only. Install steps: [tutorial](./trae.md). Family boundaries: [learning map](./index.md). Coverage: official pages opened 2026-08-19.
+
+## Which surface
+
+| Job | Go here |
+|-----|---------|
+| Local coding, repo edits, CUE | **TraeCode** desktop IDE |
+| Fine-grained control | TraeCode **IDE mode** |
+| Natural language through preview / deploy | TraeCode **SOLO mode** (top-left switch) |
+| Slides / docs / data / cross-device dispatch | **TraeWork** (not this directory) |
+| Stay in VS Code / JetBrains | **TraeCode Plugin** (enterprise page; no tutorial here) |
+| Terminal batch / CI | **TraeCode CLI** (official coming soon; do not invent commands) |
+| Mainland China account, Juejin / Douyin login | **China site** `trae.cn` / `trae.com.cn` |
+| International pricing, English docs | **International** `trae.ai` |
+
+## Install entries (no official CLI install string)
+
+| Surface | Entry |
+|---------|-------|
+| International TraeCode | [www.trae.ai/download](https://www.trae.ai/download) → **TraeCode** block |
+| China | [www.trae.com.cn](https://www.trae.com.cn) top-right **下载 IDE** (marketing homepage also at [www.trae.cn](https://www.trae.cn/)) |
+| China macOS &lt; 12 | Below **3.3.25**: [arm64 dmg](https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.4283/darwin/Trae%20CN-darwin-arm64.dmg) · [x64 dmg](https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.4283/darwin/Trae%20CN-darwin-x64.dmg) |
+
+## Operating systems
+
+Sources: [Quickstart](https://docs.trae.ai/ide/set-up-trae), [ide_get-started-with-trae.md](https://docs.trae.cn/ide_get-started-with-trae.md)
+
+| OS | Arch | Version / format |
+|----|------|------------------|
+| macOS | Apple Silicon, Intel | 12.0+ |
+| Windows | x64 | 10, 11 |
+| Linux | x64, ARM64 | `.deb` Ubuntu 20.04 / Debian 11; `.rpm` Fedora 42 / RHEL 9.x |
+
+## Device limit
+
+| | International | China |
+|--|---------------|-------|
+| Cap | **3** | **10** |
+| Counts | TraeCode, TraeWork Desktop, TRAE mobile | Same |
+| Does not count | TraeWork Web | Same |
+| Same PC | TraeCode + TraeWork Desktop = 1 device | Same |
+
+Sources: [docs.trae.ai/ide/device-limit](https://docs.trae.ai/ide/device-limit), [docs.trae.cn/ide_device-limit.md](https://docs.trae.cn/ide_device-limit.md)
+
+## Open a project
+
+| Action | Official entry |
+|--------|----------------|
+| Local folder | **Open Folder** or **Select project > Open Folder** |
+| GitHub | **Clone Git Repository** → **Clone from GitHub** |
+| Any Git URL | **Clone Git Repository** → paste URL → **Repository URL {URL}** |
+
+## Plan pointer
+
+- Live international: [www.trae.ai/pricing](https://www.trae.ai/pricing) — Lite / Pro / Pro+ / Ultra. Pro copy: **Free for 7 days. Then $10/month.**
+- Do not treat [Legacy billing](https://docs.trae.ai/ide/billing) as current
+- China credits: follow [docs.trae.cn](https://docs.trae.cn/llms.txt); this table does not invent amounts
+
+## High-quality sources
+
+| Source | URL | Use for |
+|--------|-----|---------|
+| International homepage | <https://www.trae.ai/> | TraeCode / TraeWork split |
+| Download Center | <https://www.trae.ai/download> | Packages; do not grab TraeWork |
+| Pricing | <https://www.trae.ai/pricing> | Current tiers |
+| Enterprise | <https://www.trae.ai/enterprise> | Plugin / CLI coming soon / teams |
+| TraeWork marketing | <https://www.trae.ai/work> | Office-workspace job |
+| What is TraeCode? | <https://docs.trae.ai/ide/what-is-trae> | IDE / SOLO / CUE / privacy |
+| Quickstart | <https://docs.trae.ai/ide/set-up-trae> | Install, open project, switch modes |
+| SOLO | <https://docs.trae.ai/ide/solo-mode> | SOLO UI and capabilities |
+| Device limit | <https://docs.trae.ai/ide/device-limit> | International cap of 3 |
+| Changelog (docs) | <https://docs.trae.ai/ide/changelog> | Versions |
+| Models | <https://docs.trae.ai/ide/models> | Built-in model table |
+| What is TRAE Work? | <https://docs.trae.ai/solo/what-is-trae-solo> | TraeWork three clients |
+| China homepage | <https://www.trae.cn/> | CN marketing |
+| China Quickstart download link | <https://www.trae.com.cn> | CN download entry |
+| China docs | <https://docs.trae.cn/ide_what-is-trae-code> | CN What is |
+| China llms.txt | <https://docs.trae.cn/llms.txt> | CN doc tree |
+| China getting started .md | <https://docs.trae.cn/ide_get-started-with-trae.md> | CN install source |
+| Volcengine listing | <https://www.volcengine.com/product/trae> | CN cloud catalog |

--- a/docs/products/trae/trae.md
+++ b/docs/products/trae/trae.md
@@ -1,0 +1,180 @@
+---
+title: TraeCode tutorial
+description: "Install TraeCode from the official download center, finish first-run setup, open a first project, and switch IDE mode and SOLO mode. The China site and the international site are separate surfaces."
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# TraeCode tutorial
+
+> This page gets **TraeCode** installed and a first project open. Install paths are copied from the international [Quickstart](https://docs.trae.ai/ide/set-up-trae) and the China [getting started](https://docs.trae.cn/ide_get-started-with-trae.md) page. Family boundaries: [learning map](./index.md). OS / device limits / URLs: [cheatsheet](./trae-cheatsheet.md).
+
+## Goals and non-goals
+
+**Goals**
+
+- Tell the China site (`trae.cn` / `trae.com.cn`) from the international site (`trae.ai`)
+- Install the TraeCode desktop IDE from the official download page
+- Open a local folder, or clone a repo with the official steps
+- Switch **IDE mode** and **SOLO mode** at the top left
+
+**Non-goals**
+
+- No TraeWork / Doubao / Coze / Ark tutorial
+- No invented `brew` / `npm` / curl install commands (official install is a downloadable package)
+- No TraeCode CLI (enterprise page: **coming soon**)
+- No Legacy quota table presented as current pricing
+
+## Prerequisites
+
+OS table from the international [Quickstart](https://docs.trae.ai/ide/set-up-trae) and China [getting started](https://docs.trae.cn/ide_get-started-with-trae.md):
+
+| OS | Arch | Official versions / formats |
+|----|------|-----------------------------|
+| macOS | Apple Silicon, Intel | **12.0** or later |
+| Windows | 64-bit (x64) | **Windows 10, Windows 11** |
+| Linux | 64-bit (x64), 64-bit (ARM64) | `.deb`: Ubuntu 20.04, Debian 11; `.rpm`: Fedora 42, RHEL 9.x |
+
+Account: a TRAE account. Login methods differ by surface; see section 3.
+
+## 1. Pick a surface: China vs international
+
+The international header includes a China-site link. These are not mirrors.
+
+| | International | China |
+|--|---------------|-------|
+| Marketing / download | [www.trae.ai](https://www.trae.ai/) · [www.trae.ai/download](https://www.trae.ai/download) | [www.trae.cn](https://www.trae.cn/) · Quickstart links [www.trae.com.cn](https://www.trae.com.cn) |
+| Docs | [docs.trae.ai](https://docs.trae.ai/ide/what-is-trae) | [docs.trae.cn](https://docs.trae.cn/ide_what-is-trae-code) ([`llms.txt`](https://docs.trae.cn/llms.txt)) |
+| Device limit | **3** ([device-limit](https://docs.trae.ai/ide/device-limit)) | **10** ([ide_device-limit.md](https://docs.trae.cn/ide_device-limit.md)) |
+| Login (official text) | <!-- TODO: 待核实 —— 2026-08-19 international Quickstart English body did not yield a login-provider list --> | Phone number, Douyin, Apple, Juejin ([getting started](https://docs.trae.cn/ide_get-started-with-trae.md)) |
+
+Do not treat the two installers as the same product on one machine. Accounts, quota, and device counts are separate.
+
+## 2. Install from the official download
+
+There is **no** official `curl | bash` or global npm package. The install entry is the download center.
+
+### International
+
+1. Open the [Download Center](https://www.trae.ai/download).
+2. Use the **TraeCode** block (copy: Your 10x AI Coding Engineer; **Seamless switch between IDE and SOLO Mode**). Do not download **TraeWork** from the same page.
+3. Pick macOS (12.0+, including Intel), Windows 10/11, or `.deb` / `.rpm`.
+4. Install and launch.
+
+International Quickstart: go to the official site, click **Download IDE** in the top right, download the package, install it.
+
+macOS older than 12: the international Chinese Quickstart has said to download a build **below 3.5.25**. Use the Apple Silicon / Intel links on that page that day. This page does not invent extra URLs.
+
+<!-- TODO: 待核实 —— international legacy-macOS package URLs were not extracted from the doc body on 2026-08-19. -->
+
+### China site
+
+China [getting started](https://docs.trae.cn/ide_get-started-with-trae.md):
+
+1. Go to the [TRAE site](https://www.trae.com.cn), click **下载 IDE** in the top right, download and install.
+2. If macOS is below 12, download a TRAE IDE build **below 3.3.25**:
+   - [Apple Silicon](https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.4283/darwin/Trae%20CN-darwin-arm64.dmg)
+   - [Intel](https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.4283/darwin/Trae%20CN-darwin-x64.dmg)
+
+Do not merge China `3.3.25` with the international `3.5.25` note into one number.
+
+## 3. First-run setup and login
+
+Follow the wizard. China getting started lists:
+
+- Theme and language
+- Import settings from **VS Code or Cursor**
+- Add TRAE-related command-line tools
+- Sign in (China account types: section 1)
+
+International [What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) describes a full editor + Git + extension ecosystem. First-run wording follows the wizard of the build you downloaded.
+
+「Add TRAE-related command-line tools」 is a wizard step. Official pages **do not** publish a binary name or a `brew install` string. This page does not invent one.
+
+China extra step (same getting-started page): **Settings > Development environment**, configure Node.js. Add a local SDK, or download the Node.js SDK bundled with TRAE IDE.
+
+## 4. Open the first project
+
+Three official entries (international Quickstart and China getting started match):
+
+**Import a local folder**
+
+1. Click **Open Folder** in the center of the left panel, or **Select project > Open Folder** at the top left.
+2. Choose a local folder.
+
+**Clone from GitHub**
+
+1. Click **Clone Git Repository**, or **Select project > Clone Git Repository**.
+2. In the top panel, click **Clone from GitHub**.
+3. Finish GitHub authorization, clone, and open.
+
+**Clone from a URL**
+
+1. Same **Clone Git Repository** entry.
+2. Paste the Git URL, click **Repository URL {URL}**.
+3. Follow the prompts, clone, and open.
+
+Once it is open, confirm the tree and terminal in IDE mode. Ask the agent for a read-only repo survey before edits. Review the diff. Do not turn on auto-run on the first pass.
+
+## 5. Switch IDE mode and SOLO mode
+
+Official: [What is TraeCode?](https://docs.trae.ai/ide/what-is-trae), [SOLO mode overview](https://docs.trae.ai/ide/solo-mode), [Quickstart](https://docs.trae.ai/ide/set-up-trae).
+
+Use the mode switch at the **top left**.
+
+| Mode | Official behavior | Use when |
+|------|-------------------|----------|
+| **IDE mode** | Editor, terminal, debug, extensions, source control; you control each step | Fine-grained edits in an existing repo |
+| **SOLO mode** | AI leads planning through requirement understanding, generation, testing, and preview (the SOLO page also mentions deploy) | A vertical feature from natural language |
+
+How to open SOLO: switch the mode to **SOLO**. Left to right: task panel, AI chat, tool panel ([SOLO mode overview](https://docs.trae.ai/ide/solo-mode)).
+
+Input (SOLO page): natural language, voice, local file upload.
+
+The SOLO page also lists SOLO Agent, multitasking, the tool panel (editor / docs / browser), Figma import, Supabase, deploy (Vercel is the example), AI services, payments (Stripe is the example), and the change diff. Follow those official child pages. This tutorial does not grow a second How-to.
+
+**Do not** install TraeWork because you want SOLO. TraeWork is a separate client. Official copy: it builds upon TraeCode SOLO mode.
+
+## 6. Agents and CUE
+
+[What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) / [CN same page](https://docs.trae.cn/ide_what-is-trae-code):
+
+- **Agents**: define tasks in natural language; search the codebase, plan steps, call tools. Custom agents can take prompts, MCP servers, and toolsets.
+- **CUE**: completion, chained completion, multi-line edits, next-edit prediction and navigation; smart import and rename in **Python, TypeScript, and Golang**.
+- **Context**: files, folders, snippets, terminal output, repos, document sets, web pages.
+- **Models**: several built-in models; add custom models with an API key. The live list is the table on [models](https://docs.trae.ai/ide/models) that day. This page does not copy a roster that goes stale.
+
+The China What-is page also documents a 「速通」 boost when a model is queued. That paragraph is **not** on the international English What-is page as of 2026-08-19.
+
+Safety (both What-is pages):
+
+- **Privacy mode**: chats, snippets, and AI outputs are not used for analysis, product optimization, or training. Codebase files stay on the local device.
+- **Sandbox**: agent commands can run in a restricted environment with file-access controls and high-risk command blocking.
+
+## 7. Device limit
+
+Clients that count (same structure on both sites): **TraeCode**, **TraeWork Desktop**, **TRAE mobile**. **TraeWork Web does not count**. TraeCode + TraeWork Desktop on the same PC count as **1** device.
+
+The cap differs:
+
+- International: **3** ([device-limit](https://docs.trae.ai/ide/device-limit))
+- China: **10** ([ide_device-limit.md](https://docs.trae.cn/ide_device-limit.md))
+
+At the cap, login shows Device limit reached / **设备数量已达上限**. **Sign out** on a device you already use. Signing out a machine that has both TraeCode and TraeWork Desktop signed in signs both out.
+
+## Common pitfalls
+
+1. **Downloading TraeWork from the download page.** This tutorial is TraeCode.
+2. **Mixing China and international packages or accounts.** Device caps and login providers differ.
+3. **Treating SOLO mode as a separate TraeWork install.** SOLO is the top-left switch inside TraeCode.
+4. **Inventing a CLI install command.** Official install is a package; CLI is coming soon on the enterprise page.
+5. **Copying the Legacy quota table as current pricing.** Use [pricing](https://www.trae.ai/pricing) and the current plans page.
+6. **Using the other site's old-macOS fallback.** China official direct links are Trae CN dmgs **below 3.3.25**.
+
+## Next steps
+
+- Official URLs, OS, device limits → [cheatsheet](./trae-cheatsheet.md)
+- Family boundaries → [learning map](./index.md)
+- Skills / MCP / custom agents → [docs.trae.ai](https://docs.trae.ai/ide/what-is-trae) or [docs.trae.cn/llms.txt](https://docs.trae.cn/llms.txt)

--- a/docs/zh/products/trae/index.md
+++ b/docs/zh/products/trae/index.md
@@ -1,0 +1,127 @@
+---
+title: Trae 学习地图
+description: "TraeCode 是字节跳动面向开发者的 AI 编程 IDE（IDE 模式 + SOLO 模式）。同厂的 TraeWork、豆包、扣子、火山方舟不是这个产品。本目录只教你从官方下载装上 TraeCode，打开第一个项目。"
+domain: product
+tags:
+  - coding-agent
+role: map
+---
+
+# Trae 学习地图
+
+> **TraeCode** 是 TRAE 品牌下的 AI 编程 IDE。官方原文（[What is TraeCode?](https://docs.trae.ai/ide/what-is-trae)）：深度融合 AI 的开发工具，覆盖编码、项目理解、调试运行和变更管理。你可以像传统 IDE 一样掌控每一步，也可以把复杂任务交给智能体。
+>
+> 营销首页（[www.trae.ai](https://www.trae.ai/)）把它和 **TraeWork** 并排：**TraeCode: Your 10x AI Coding Engineer**；**TraeWork: Your Professional AI Work Assistant**。本目录只展开 TraeCode。
+
+## 写给谁 / 先决条件
+
+- **写给谁**：已经会用桌面 IDE 的前端工程师，想对位 Cursor 的字节跳动 AI IDE。
+- **先决条件**：官方 [快速开始](https://docs.trae.ai/ide/set-up-trae) / [中国站快速开始](https://docs.trae.cn/ide_get-started-with-trae.md) 列出的操作系统（见下表）；一个 TRAE 账号。
+- **非目标**：不教 TraeWork 办公工作台；不教豆包 / 扣子 / 火山方舟；不教模型内部机制（去 Learn LLM）；不编 TraeCode CLI 命令（企业页写 **coming soon**）。
+
+## 产品家族
+
+字节跳动 TRAE 官方一级入口必须先对账。本目录**只展开 TraeCode**。其余各占一行。下表「官方名称」抄自 2026-08-19 打开的官方页，不是本站自造名。
+
+| 官方名称 | 官方 URL | 本站去向 |
+|----------|----------|----------|
+| **TraeCode**（AI 编程 IDE） | [www.trae.ai](https://www.trae.ai/) · [Download Center](https://www.trae.ai/download) | 本目录主路径 |
+| **TraeCode 文档** | [docs.trae.ai · What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) · [快速开始](https://docs.trae.ai/ide/set-up-trae) | 本页 · [教程](./trae.md) |
+| **TraeWork** | [www.trae.ai/work](https://www.trae.ai/work) · [What is TRAE Work?](https://docs.trae.ai/solo/what-is-trae-solo) | 地图一行：办公工作台，不拆教程 |
+| **TraeCode Plugin** | [企业页](https://www.trae.ai/enterprise)（原文：VS Code、JetBrains and other mainstream editors） | 地图一行：嵌进已有编辑器，不是本 IDE 教程 |
+| **TRAE Enterprise** | [www.trae.ai/enterprise](https://www.trae.ai/enterprise) | 地图一行：团队采购 |
+| **TraeCode CLI** | 企业页原文 **coming soon** | 地图一行：未上线，禁止编命令 |
+| **TRAE Editor for Unity** | [中国站教程](https://docs.trae.cn/ide_trae-editor-for-unity-tutorial.md) | 地图一行：Unity 插件 |
+| **中国站 TraeCode / TraeWork** | [www.trae.cn](https://www.trae.cn/) · 快速开始链 [www.trae.com.cn](https://www.trae.com.cn) · [docs.trae.cn](https://docs.trae.cn/ide_what-is-trae-code) | [教程 · 分表面安装](./trae.md#1-选表面中国站-vs-国际站) |
+| **火山引擎 TRAE** | [volcengine.com/product/trae](https://www.volcengine.com/product/trae) | 地图一行：CN 云产品位 |
+| **豆包** | 另 issue #79 | 一行 → 将有的 [豆包家族](/zh/products/doubao/) |
+| **扣子 Coze** | 另 issue #81 | 一行 → 将有的 [扣子家族](/zh/products/coze/) |
+| **火山方舟 Ark** | 另 issue #82 | 一行 → 将有的 [方舟家族](/zh/products/ark/) |
+
+来源：[www.trae.ai](https://www.trae.ai/)、[docs.trae.ai 顶栏](https://docs.trae.ai/ide/what-is-trae)、[企业页](https://www.trae.ai/enterprise)、[www.trae.cn](https://www.trae.cn/)、[docs.trae.cn/llms.txt](https://docs.trae.cn/llms.txt)。
+
+```
+TRAE（品牌）
+├── TraeCode — 桌面 AI 编程 IDE（本目录）
+│   ├── IDE 模式（编辑器 / 终端 / 调试 / 插件 / Git）
+│   ├── SOLO 模式（AI 主导：规划 → 生成 → 测试 → 预览）
+│   ├── CUE / Agent / Skills / Rules / MCP
+│   ├── TraeCode Plugin（嵌进 VS Code / JetBrains，地图一行）
+│   └── TraeCode CLI（官方 coming soon）
+├── TraeWork — 独立办公工作台（Web / Desktop / Mobile）
+│   └── Work / Code（营销页另写 Design）
+├── TRAE Enterprise — 团队
+└── 同厂其它 AI（本目录不展开）
+    ├── 豆包 #79
+    ├── 扣子 #81
+    └── 火山方舟 #82
+```
+
+**容易撞名：**
+
+- **TraeCode ≠ TraeWork。** 前者是编程 IDE；后者是办公工作台。官方：[TraeWork builds upon TraeCode's SOLO mode](https://docs.trae.ai/ide/what-is-trae)。
+- **TraeCode 里的 SOLO 模式 ≠ TraeWork。** SOLO 是 IDE 左上角的模式开关；TraeWork 是独立客户端（Web / Desktop / Mobile）。
+- **旧名 TRAE IDE / TRAE SOLO 独立端** 已收进 TraeCode / TraeWork，不要再当第三个产品装。
+- **CUE ≠ Cursor。** CUE 是 TraeCode 的补全 / 多行修改 / 修改点预测。
+- **TraeCode Plugin ≠ TraeCode 扩展市场。** Plugin 把能力嵌进 VS Code / JetBrains；扩展市场是 IDE 里装语言/调试插件。
+- **`trae.ai` ≠ `trae.cn` / `trae.com.cn`。** 国际站顶栏有「前往中国站」。两套登录、额度、设备上限。不要混用账号。
+
+### 快速决策：我该用哪个？
+
+```
+我要做什么？
+├── 在本机仓库里写代码 / 改代码 / 调试 / 补全
+│   └── → TraeCode
+│       ├── 要精细控制每一步？ → IDE 模式
+│       ├── 用自然语言从需求推到预览？ → SOLO 模式
+│       └── 人已经在 VS Code / JetBrains？ → TraeCode Plugin（地图一行，跟企业页）
+├── 做 PPT / 文档 / 数据分析 / 跨端派任务
+│   └── → TraeWork（不在本目录）
+├── 团队采购、仓库索引上限、SOC 2
+│   └── → TRAE Enterprise
+├── 聊天 / 通用助手
+│   └── → 豆包（#79）
+├── 搭 Bot / 工作流
+│   └── → 扣子（#81）
+└── 在自己的服务里调模型 API
+    └── → 火山方舟（#82）
+```
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 选对表面 | [教程 · 中国站 vs 国际站](./trae.md#1-选表面中国站-vs-国际站) | 不要装错站、登错号 |
+| 2. 装上能开项目 | [教程 · 安装与第一项目](./trae.md) | 从官方下载页装上，打开本地文件夹或克隆仓库 |
+| 3. 分清两种模式 | [教程 · IDE / SOLO](./trae.md#5-切换-ide-模式与-solo-模式) | 左上角切换，不要把 SOLO 当成 TraeWork |
+| 4. 回查入口 | [速查表](./trae-cheatsheet.md) | OS、设备上限、官方 URL |
+
+## 功能速查
+
+只列官方文档已经写明的能力。细节进教程或官方页。
+
+| 能力 | 一句话 | 官方页 |
+|------|--------|--------|
+| IDE 模式 | 保留编辑器、终端、调试、插件、源代码管理 | [What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) |
+| SOLO 模式 | AI 主导：需求 → 生成 → 测试 → 预览；左上角切换 | [SOLO 模式概览](https://docs.trae.ai/ide/solo-mode) |
+| 打开项目 | 导入本地文件夹 / 从 GitHub 克隆 / 从 URL 克隆 | [快速开始](https://docs.trae.ai/ide/set-up-trae) |
+| CUE | 补全、链式补全、多行修改、修改点预测；Py / TS / Go 智能导入与重命名 | [What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) |
+| 智能体 | 自然语言拆任务、检索仓库、调工具；可自定义 + MCP | 同上 |
+| 上下文 | 文件、文件夹、片段、终端、仓库、文档集、网页 | 同上 |
+| 隐私模式 | 开启后对话 / 代码 / 生成结果不用于分析、优化或训练；代码文件留在本地 | 同上 |
+| 沙箱 | 智能体命令在受限环境执行 | 同上 |
+| 远程 | Remote SSH、WSL | 同上 |
+| 设备上限 | 国际站 **3** 台；中国站 **10** 台。Web 版 TraeWork 不计入 | [intl](https://docs.trae.ai/ide/device-limit) · [CN](https://docs.trae.cn/ide_device-limit.md) |
+
+## 套餐（只抄官方，不猜价格）
+
+- 国际站现行档位在 [www.trae.ai/pricing](https://www.trae.ai/pricing)：**Lite / Pro / Pro+ / Ultra**。该页写 Pro **Free for 7 days. Then $10/month.**；AI 请求按 token 折成 Dollar Usage 从月度余额扣。Lite / Pro+ / Ultra 的完整月费以该页为准，本站不补未抓全的数字。
+- 文档站另有 [(Legacy) Plans & billing](https://docs.trae.ai/ide/billing)。官方已标 Legacy，不要把旧免费/Pro 次数表当现行。
+- 中国站 [llms.txt](https://docs.trae.cn/llms.txt) 有「以积分为核心的计费模式」条目。金额与折算去中国站文档，这里不写死。
+- 企业方案：定价页写 Contact us via BytePlus；产品页 [Enterprise](https://www.trae.ai/enterprise)。
+
+## 下一步
+
+1. 打开 [TraeCode 教程](./trae.md)，先选中国站或国际站，再从官方下载页安装。
+2. OS、设备上限、官方 URL 去 [速查表](./trae-cheatsheet.md)。
+3. 官方深读从 [docs.trae.ai](https://docs.trae.ai/ide/what-is-trae) 或 [docs.trae.cn](https://docs.trae.cn/ide_what-is-trae-code) 进。

--- a/docs/zh/products/trae/trae-cheatsheet.md
+++ b/docs/zh/products/trae/trae-cheatsheet.md
@@ -1,0 +1,91 @@
+---
+title: Trae 速查表
+description: "只查不学。操作系统、设备上限、模式决策和官方 URL 抄自 docs.trae.ai / docs.trae.cn。套餐金额以现行定价页为准，不抄 Legacy 表。"
+domain: product
+tags:
+  - coding-agent
+role: cheatsheet
+---
+
+# Trae 速查表
+
+只查不学。安装步骤走 [教程](./trae.md)。家族边界走 [学习地图](./index.md)。覆盖 2026-08-19 打开的官方页。
+
+## 该用哪一个
+
+| 场景 | 去哪 |
+|------|------|
+| 本机写代码、改仓库、CUE 补全 | **TraeCode** 桌面 IDE |
+| 精细控制每一步 | TraeCode **IDE 模式** |
+| 自然语言推到预览 / 部署 | TraeCode **SOLO 模式**（左上角切换） |
+| PPT / 文档 / 数据 / 跨端派任务 | **TraeWork**（不在本目录） |
+| 人留在 VS Code / JetBrains | **TraeCode Plugin**（企业页；本站不拆教程） |
+| 终端批量 / CI | **TraeCode CLI**（官方 coming soon，不要编命令） |
+| 中国大陆账号、掘金 / 抖音登录 | **中国站** `trae.cn` / `trae.com.cn` |
+| 国际站定价页、英文文档 | **国际站** `trae.ai` |
+
+## 安装入口（没有官方 CLI 安装串）
+
+| 表面 | 入口 |
+|------|------|
+| 国际站 TraeCode | [www.trae.ai/download](https://www.trae.ai/download) → **TraeCode** 区块 |
+| 中国站 | [www.trae.com.cn](https://www.trae.com.cn) 右上角 **下载 IDE**（营销首页还有 [www.trae.cn](https://www.trae.cn/)） |
+| 中国站 macOS &lt; 12 | 低于 **3.3.25**：[arm64 dmg](https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.4283/darwin/Trae%20CN-darwin-arm64.dmg) · [x64 dmg](https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.4283/darwin/Trae%20CN-darwin-x64.dmg) |
+
+## 操作系统
+
+来源：[Quickstart](https://docs.trae.ai/ide/set-up-trae)、[ide_get-started-with-trae.md](https://docs.trae.cn/ide_get-started-with-trae.md)
+
+| OS | 架构 | 版本 / 格式 |
+|----|------|-------------|
+| macOS | Apple Silicon、Intel | 12.0+ |
+| Windows | x64 | 10、11 |
+| Linux | x64、ARM64 | `.deb` Ubuntu 20.04 / Debian 11；`.rpm` Fedora 42 / RHEL 9.x |
+
+## 设备上限
+
+| | 国际站 | 中国站 |
+|--|--------|--------|
+| 上限 | **3** | **10** |
+| 计入 | TraeCode、TraeWork 桌面、TRAE 移动端 | 同左 |
+| 不计入 | TraeWork 网页版 | 同左 |
+| 同机双端 | TraeCode + TraeWork 桌面 = 1 台 | 同左 |
+
+来源：[docs.trae.ai/ide/device-limit](https://docs.trae.ai/ide/device-limit)、[docs.trae.cn/ide_device-limit.md](https://docs.trae.cn/ide_device-limit.md)
+
+## 打开项目
+
+| 动作 | 官方入口 |
+|------|----------|
+| 本地文件夹 | **打开文件夹** 或 **选择项目 > 打开文件夹** |
+| GitHub | **克隆 Git 仓库** → **从 GitHub 克隆** |
+| 任意 Git URL | **克隆 Git 仓库** → 输入 URL → **存储库 URL {URL}** |
+
+## 套餐指针
+
+- 国际站现行：[www.trae.ai/pricing](https://www.trae.ai/pricing) — Lite / Pro / Pro+ / Ultra。Pro 页文案：**Free for 7 days. Then $10/month.**
+- 文档站 [Legacy billing](https://docs.trae.ai/ide/billing) 不要当现行表
+- 中国站积分方案：跟 [docs.trae.cn](https://docs.trae.cn/llms.txt)，本表不写金额
+
+## 高质量信息源
+
+| 源 | URL | 用来干什么 |
+|----|-----|------------|
+| 国际站首页 | <https://www.trae.ai/> | 家族拆分 TraeCode / TraeWork |
+| 下载中心 | <https://www.trae.ai/download> | 安装包，不要下成 TraeWork |
+| 定价 | <https://www.trae.ai/pricing> | 现行档位 |
+| 企业 | <https://www.trae.ai/enterprise> | Plugin / CLI coming soon / 团队 |
+| TraeWork 营销 | <https://www.trae.ai/work> | 办公工作台职责 |
+| What is TraeCode? | <https://docs.trae.ai/ide/what-is-trae> | IDE / SOLO / CUE / 隐私 |
+| Quickstart | <https://docs.trae.ai/ide/set-up-trae> | 安装、打开项目、切模式 |
+| SOLO | <https://docs.trae.ai/ide/solo-mode> | SOLO 界面与能力 |
+| Device limit | <https://docs.trae.ai/ide/device-limit> | 国际站 3 台 |
+| Changelog（文档站） | <https://docs.trae.ai/ide/changelog> | 版本 |
+| Models | <https://docs.trae.ai/ide/models> | 内置模型表 |
+| What is TRAE Work? | <https://docs.trae.ai/solo/what-is-trae-solo> | TraeWork 三端 |
+| 中国站首页 | <https://www.trae.cn/> | CN 营销 |
+| 中国站快速开始链 | <https://www.trae.com.cn> | CN 下载入口 |
+| 中国站文档 | <https://docs.trae.cn/ide_what-is-trae-code> | CN What is |
+| 中国站 llms.txt | <https://docs.trae.cn/llms.txt> | CN 文档树 |
+| 中国站快速开始 .md | <https://docs.trae.cn/ide_get-started-with-trae.md> | CN 安装原文 |
+| 火山引擎产品位 | <https://www.volcengine.com/product/trae> | CN 云目录 |

--- a/docs/zh/products/trae/trae.md
+++ b/docs/zh/products/trae/trae.md
@@ -1,0 +1,180 @@
+---
+title: TraeCode 教程
+description: "从官方下载中心安装 TraeCode，完成首次设置，打开第一个项目，并在 IDE 模式与 SOLO 模式之间切换。中国站与国际站是两套表面，不要混装。"
+domain: product
+tags:
+  - coding-agent
+role: tutorial
+---
+
+# TraeCode 教程
+
+> 本页带你把 **TraeCode** 装上并打开第一个项目。安装路径抄自国际站 [Quickstart](https://docs.trae.ai/ide/set-up-trae) 和中国站 [快速开始](https://docs.trae.cn/ide_get-started-with-trae.md)。家族边界见 [学习地图](./index.md)。OS / 设备上限 / 官方 URL 见 [速查表](./trae-cheatsheet.md)。
+
+## 目标与非目标
+
+**目标**
+
+- 分清中国站（`trae.cn` / `trae.com.cn`）和国际站（`trae.ai`）
+- 从官方下载页装上 TraeCode 桌面 IDE
+- 打开本地文件夹，或按官方步骤克隆仓库
+- 在左上角切换 **IDE 模式** 与 **SOLO 模式**
+
+**非目标**
+
+- 不写 TraeWork / 豆包 / 扣子 / 方舟教程
+- 不编 `brew` / `npm` / curl 安装命令（官方安装是下载安装包）
+- 不编 TraeCode CLI（企业页写 **coming soon**）
+- 不把 Legacy 套餐次数表抄成现行价格
+
+## 先决条件
+
+国际站 [Quickstart](https://docs.trae.ai/ide/set-up-trae) 与中国站 [快速开始](https://docs.trae.cn/ide_get-started-with-trae.md) 列出的操作系统：
+
+| 操作系统 | 架构 | 官方写明的版本 / 格式 |
+|----------|------|------------------------|
+| macOS | Apple Silicon、Intel | **12.0** 或更高 |
+| Windows | 64 位（x64） | **Windows 10、Windows 11** |
+| Linux | 64 位（x64）、64 位（ARM64） | `.deb`：Ubuntu 20.04、Debian 11；`.rpm`：Fedora 42、RHEL 9.x |
+
+账号：一个 TRAE 账号。登录方式随表面不同，见第 3 节。
+
+## 1. 选表面：中国站 vs 国际站
+
+官方国际站顶栏有「前往中国站」。两套不是镜像。
+
+| | 国际站 | 中国站 |
+|--|--------|--------|
+| 营销 / 下载 | [www.trae.ai](https://www.trae.ai/) · [www.trae.ai/download](https://www.trae.ai/download) | [www.trae.cn](https://www.trae.cn/) · 快速开始链 [www.trae.com.cn](https://www.trae.com.cn) |
+| 文档 | [docs.trae.ai](https://docs.trae.ai/ide/what-is-trae) | [docs.trae.cn](https://docs.trae.cn/ide_what-is-trae-code)（有 [`llms.txt`](https://docs.trae.cn/llms.txt)） |
+| 设备上限 | **3** 台（[device-limit](https://docs.trae.ai/ide/device-limit)） | **10** 台（[ide_device-limit.md](https://docs.trae.cn/ide_device-limit.md)） |
+| 登录（官方已写明） | <!-- TODO: 待核实 —— 2026-08-19 国际站 Quickstart 英文正文未抓到登录列表 --> | 手机号、抖音账号、苹果账号、稀土掘金账号（[快速开始](https://docs.trae.cn/ide_get-started-with-trae.md)） |
+
+在同一台电脑上不要混用两套安装包当「同一个产品」。账号、额度、设备计数各自独立。
+
+## 2. 从官方下载安装
+
+官方**没有**给出 `curl | bash` 或 npm 全局包。安装入口是下载中心。
+
+### 国际站
+
+1. 打开 [Download Center](https://www.trae.ai/download)。
+2. 找到 **TraeCode** 区块（原文：Your 10x AI Coding Engineer；**Seamless switch between IDE and SOLO Mode**）。不要下成同页的 **TraeWork**。
+3. 按本机选择 macOS（12.0+，含 Intel）、Windows 10/11，或 `.deb` / `.rpm`。
+4. 装完启动。
+
+国际站 Quickstart：前往官网，点右上角 **下载 IDE**，把安装包下到本地并安装。
+
+macOS 低于 12：国际站中文 Quickstart 写过「下载低于 3.5.25 版本」。具体安装包链接以该页当时给出的 Apple Silicon / Intel 链为准，本页不另造 URL。
+
+<!-- TODO: 待核实 —— 国际站旧 macOS 安装包直链 2026-08-19 未从文档正文抽出。 -->
+
+### 中国站
+
+中国站 [快速开始](https://docs.trae.cn/ide_get-started-with-trae.md) 原文：
+
+1. 前往 [TRAE 官网](https://www.trae.com.cn)，点击右上角的 **下载 IDE** 按钮，将安装包下载到本地并完成安装。
+2. 若 macOS 低于 12，直接下载**低于 3.3.25** 版本的 TRAE IDE：
+   - [Apple Silicon 芯片](https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.4283/darwin/Trae%20CN-darwin-arm64.dmg)
+   - [Intel 芯片](https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.4283/darwin/Trae%20CN-darwin-x64.dmg)
+
+不要把中国站的 `3.3.25` 和国际站摘要里的 `3.5.25` 合成一个数字。
+
+## 3. 首次设置与登录
+
+启动后跟随界面指引。中国站快速开始列出的步骤：
+
+- 选择主题和语言
+- 从 **VS Code 或 Cursor** 导入已有配置
+- 添加 TRAE 相关的命令行
+- 登录（中国站账号类型见第 1 节）
+
+国际站 [What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) 同样把 IDE 能力写成完整编辑器 + Git + 扩展生态。首次设置的具体文案以你下载的那一站安装向导为准。
+
+「添加 TRAE 相关的命令行」是官方向导里的一步。官方页**没有**写出可执行文件名或 `brew install` 字符串，本页不补。
+
+中国站额外步骤（同一篇快速开始）：前往 **设置 > 开发环境**，配置 Node.js。可以添加本机已装的 SDK，或下载 TRAE IDE 内置的 Node.js SDK。
+
+## 4. 打开第一个项目
+
+官方提供三种入口（国际站 Quickstart / 中国站快速开始原文一致）：
+
+**导入本地文件夹**
+
+1. 点左侧面板中央的 **打开文件夹**，或左上角 **选择项目 > 打开文件夹**。
+2. 选一个本地文件夹打开。
+
+**从 GitHub 克隆**
+
+1. 点 **克隆 Git 仓库**，或 **选择项目 > 克隆 Git 仓库**。
+2. 在顶部面板点 **从 GitHub 克隆**。
+3. 完成 GitHub 授权，把仓库克隆到本地并打开。
+
+**从 URL 克隆**
+
+1. 同样进入 **克隆 Git 仓库**。
+2. 输入仓库 URL，点 **存储库 URL {URL}**。
+3. 按提示克隆并打开。
+
+打开之后，先在 IDE 模式里看目录和终端是否正常。再让智能体只读摸底仓库结构。改文件前看清 diff，不要一上来开自动运行。
+
+## 5. 切换 IDE 模式与 SOLO 模式
+
+官方：[What is TraeCode?](https://docs.trae.ai/ide/what-is-trae)、[SOLO 模式概览](https://docs.trae.ai/ide/solo-mode)、[快速开始](https://docs.trae.ai/ide/set-up-trae)。
+
+在界面**左上角**用模式切换按钮切换。
+
+| 模式 | 官方行为 | 适合 |
+|------|----------|------|
+| **IDE 模式** | 保留编辑器、终端、调试、插件、源代码管理；你控制每一步 | 精细改已有仓库 |
+| **SOLO 模式** | AI 主导，自动规划并走完需求理解、代码生成、测试、成果预览（SOLO 页还写到部署） | 从自然语言推一条垂直功能 |
+
+SOLO 怎么开：把模式切到 **SOLO**。界面从左到右是任务管理面板、AI 对话面板、工具面板（[SOLO 模式概览](https://docs.trae.ai/ide/solo-mode)）。
+
+输入方式（SOLO 页原文）：自然语言、语音、上传本地文件。
+
+SOLO 页还列出：SOLO Agent、多任务、工具面板（编辑器 / 文档 / 浏览器）、Figma 导入、Supabase、部署（举例 Vercel）、AI 服务、支付（举例 Stripe）、变更 diff。逐步操作跟对应官方子页，本教程不展开成第二份 How-to。
+
+**不要**为了「SOLO」去装 TraeWork。TraeWork 是独立客户端，官方写它建立在 TraeCode SOLO 模式之上。
+
+## 6. 智能体与 CUE
+
+[What is TraeCode?](https://docs.trae.ai/ide/what-is-trae) / [中国站同页](https://docs.trae.cn/ide_what-is-trae-code)：
+
+- **智能体**：自然语言定义任务；检索代码库、多步计划、调工具。可自建智能体，并配提示词、MCP Server、工具集。
+- **CUE**：代码补全、链式补全、多行修改、修改点预测与跳转；在 **Python、TypeScript、Golang** 项目里辅助导入依赖和重命名引用。
+- **上下文**：文件、文件夹、代码片段、终端输出、仓库、文档集、网页。
+- **模型**：内置多模型，也可用 API Key 加自定义模型（名单以 [models](https://docs.trae.ai/ide/models) 当天表格为准，本页不抄易过期名单）。
+
+中国站 What is TraeCode 另有「速通」权益：模型排队时加速当次 Query。规则去中国站该节，国际站英文 What is TraeCode 2026-08-19 **没有**同一段。
+
+安全（两站 What is 页一致）：
+
+- **隐私模式**：开启后，对话、代码片段、AI 输出不用于数据分析、产品优化或模型训练。代码库文件留在本地设备。
+- **沙箱**：智能体命令可在受限环境执行，带文件访问控制和高风险命令拦截。
+
+## 7. 设备数量
+
+计入设备的客户端（两站原文结构相同）：**TraeCode**、**TraeWork 桌面版**、**TRAE 移动端**。**TraeWork 网页版不计入**。同一台电脑同时登 TraeCode 和 TraeWork 桌面版，计 **1** 台。
+
+上限数字不同：
+
+- 国际站：**3** 台（[device-limit](https://docs.trae.ai/ide/device-limit)）
+- 中国站：**10** 台（[ide_device-limit.md](https://docs.trae.cn/ide_device-limit.md)）
+
+达到上限后，登录页会进入 Device limit reached / **设备数量已达上限**。先在已登录设备上 **Sign out** / **退出登录**。若该设备同时开着 TraeCode 和 TraeWork 桌面版，登出一次会一并退出。
+
+## 常见陷阱
+
+1. **下载页点成 TraeWork。** TraeCode 才是本教程的 IDE。
+2. **中国站包和国际站包混用、账号混登。** 设备上限和登录方式都不同。
+3. **把 SOLO 模式当成要另装的 TraeWork。** SOLO 是 TraeCode 左上角的模式。
+4. **编了一个 CLI 安装命令。** 官方当前是下载安装包；CLI 在企业页是 coming soon。
+5. **把 Legacy 套餐次数表当成现行价格。** 跟 [pricing](https://www.trae.ai/pricing) 和现行「套餐与计费」页。
+6. **旧 macOS 回退链抄错站。** 中国站官方直链版本是低于 **3.3.25** 的 Trae CN dmg；不要套到国际站。
+
+## 下一步
+
+- 官方 URL、OS、设备上限 → [速查表](./trae-cheatsheet.md)
+- 家族边界 → [学习地图](./index.md)
+- Skills / MCP / 自定义智能体 → 官方 [docs.trae.ai](https://docs.trae.ai/ide/what-is-trae) 或 [docs.trae.cn/llms.txt](https://docs.trae.cn/llms.txt)


### PR DESCRIPTION
Closes #80

TraeCode handbook (ZH + EN). Family table from official pages opened 2026-08-19.

| 官方名称 | 官方 URL | 本站去向 |
|----------|----------|----------|
| **TraeCode**（AI 编程 IDE） | https://www.trae.ai/ · https://www.trae.ai/download · https://docs.trae.ai/ide/what-is-trae | 本目录主路径（Tutorial） |
| **TraeWork** | https://www.trae.ai/work · https://docs.trae.ai/solo/what-is-trae-solo | 地图一行，不拆教程 |
| **TraeCode Plugin** | https://www.trae.ai/enterprise | 地图一行 |
| **TRAE Enterprise** | https://www.trae.ai/enterprise | 地图一行 |
| **TraeCode CLI** | 企业页 coming soon | 地图一行 |
| **TRAE Editor for Unity** | https://docs.trae.cn/ide_trae-editor-for-unity-tutorial.md | 地图一行 |
| **中国站** | https://www.trae.cn/ · https://www.trae.com.cn · https://docs.trae.cn/ide_what-is-trae-code | 教程分表面写 |
| **火山引擎 TRAE** | https://www.volcengine.com/product/trae | 地图一行 |
| **豆包** | #79 | 地图一行 |
| **扣子 Coze** | #81 | 地图一行 |
| **火山方舟 Ark** | #82 | 地图一行 |

Notes:
- Did **not** edit gallery, sidebar, or `config.mjs` (execution instruction).
- Cookbook / glossary omitted: official How-to tree already exists; name collisions live on the map.
- China vs international are separate surfaces (device cap 10 vs 3; different login and old-macOS fallback). Unverified international login list marked `<!-- TODO: 待核实 -->`.