### PR TITLE
docs(doubao): add Doubao handbook for #79

### DIFF
--- a/.claude/skills/doc-research/references/doubao.md
+++ b/.claude/skills/doc-research/references/doubao.md
@@ -1,0 +1,105 @@
+# 豆包 维护参考
+
+> 复制自 [`_template.md`](./_template.md)。读者可见的数据源写进 `docs/zh/products/doubao/doubao-cheatsheet.md`，不要在本文件再抄一份。
+
+## 产品形态调研结论（写教程前必须先有这一节）
+
+调研时间：2026-08-19。每条都来自打开过的官方页。
+
+**结论一：豆包是字节跳动消费级 AI 助手，不是 Trae、不是扣子、不是火山方舟。**
+
+- [doubao.com](https://www.doubao.com/) 收录 description：「豆包 是你的AI 聊天智能对话问答助手，写作文案翻译编程工具。」
+- 同页还写：「Seedance 2.0 视频生成模型现已全面接入 豆包 ，现在登录即可免费使用！」
+- 没有官方 How-to 文档树、`llms.txt`、CLI。禁止写成「豆包 CLI / 豆包 IDE」。
+
+**结论二：官方交付面是网页 + 桌面客户端 + 手机 App。**
+
+| 形态 | 官方出处 | 本站 |
+|------|----------|------|
+| 网页 | https://www.doubao.com/ | Tutorial |
+| 桌面客户端 | https://www.doubao.com/download/ 、https://www.doubao.com/download/desktop | Tutorial |
+| 手机 App | 应用宝 `com.larus.nova`；Microsoft Store id `XPDDTBMM6TZ365` | Tutorial 一行 |
+| 豆包手机助手 | https://o.doubao.com/ | 地图一行：硬件 / 手机助手，不是聊天 App 本体 |
+| Seed 研究 | https://seed.bytedance.com/zh/ | 地图一行：研究品牌，不是助手 |
+
+桌面落地页可见原文（[download/desktop](https://www.doubao.com/download/desktop)）：「下载豆包客户端，解锁全链路AI 生产力：日常工作可高效写作翻译、一键生成PPT、智能处理Excel 数据；创意创作依托专业版Seedream 5.0 生图，专业版Seedance 2.5 生视频核心模型……内置自主规划执行的 Agent 智能体」。
+
+**结论三：两份官方视频模型文案必须并列，禁止选边。**
+
+- 首页 / 下载页 meta：Seedance **2.0** 现已全面接入，登录即可免费使用。
+- 桌面落地页正文：专业版 Seedance **2.5**、专业版 Seedream **5.0**。
+
+**结论四：同厂其它 AI 产品只在家族图一行。**
+
+- Trae（#80）、扣子 / Coze（#81）、火山方舟（#82）不写正文。
+- 抖音 / 飞书 / 今日头条标「非本站」。
+- 部分网络打不开首页时，页面提示可改用 **Dola**。Dola 不是本 issue 产品，地图一行。
+
+**结论五：没有官方价目表。禁止编造会员价。**
+
+应用宝抽查：开发者 / 运营者 **北京春田知韵科技有限公司**；包名 `com.larus.nova`。不要把第三方「每日 N 次」写进正文。
+
+**结论六：对前端工程师——可以收进货架，不要硬凑仓库级编程教程。**
+
+官方「编程工具」是对话里写文案 / 辅助编程。仓库 / IDE 走 Trae（#80）。接豆包模型 API 走火山方舟（#82）。
+
+## 基本信息
+
+- 工具名：豆包 / Doubao
+- 厂商：字节跳动。应用宝开发者：北京春田知韵科技有限公司
+- 官方产品根：<https://www.doubao.com/>
+- 发版节奏：不绑定单一版本号
+- 当前覆盖：2026-08-19 打开的官方页
+
+## 官方一级导航（产品家族）
+
+| 官方一级入口 | 官方 URL | 本站去向 | 不拆页理由（若一行） |
+|--------------|----------|----------|----------------------|
+| 豆包（网页 / 客户端） | https://www.doubao.com/ | 独立页 `doubao.md` | |
+| 下载中心 / 桌面版 | https://www.doubao.com/download/ 、https://www.doubao.com/download/desktop | Tutorial | 同一产品 |
+| 豆包手机助手 | https://o.doubao.com/ | 地图一行 | 硬件助手，不是聊天本体 |
+| ByteDance Seed | https://seed.bytedance.com/zh/ | 地图一行 | 研究品牌 |
+| Dola | 首页区域限制提示 | 地图一行 | 另一入口，本 issue 不写 |
+| Trae | https://www.trae.ai/ 、https://www.trae.cn/ | 地图一行（#80） | 不写 IDE |
+| 扣子 / Coze | https://www.coze.cn/ | 地图一行（#81） | 不写 Agent 搭建 |
+| 火山方舟 | https://www.volcengine.com/product/ark | 地图一行（#82） | 不写 API |
+| 抖音 / 飞书 / 头条 | 非本站 | 标「非本站」 | 非本 issue |
+
+易撞名：豆包 ≠ Trae ≠ 扣子 ≠ 方舟；豆包 App ≠ 豆包大模型 API；豆包 ≠ 豆包手机助手；Seedance 2.0（首页）≠ Seedance 2.5（桌面页）。
+
+## 文档文件结构（Diataxis）
+
+官方没有 How-to 文档树，**不写 cookbook**。
+
+```
+docs/zh/products/doubao/
+├── index.md
+├── doubao.md
+├── doubao-cheatsheet.md
+└── doubao-glossary.md
+docs/products/doubao/
+```
+
+## 监控页面
+
+- 产品首页：<https://www.doubao.com/>
+- 下载：<https://www.doubao.com/download/>
+- 桌面落地：<https://www.doubao.com/download/desktop>
+- 应用宝：<https://sj.qq.com/appdetail/com.larus.nova>
+- Microsoft Store：<https://apps.microsoft.com/detail/xpddtbmm6tz365>
+- Seed：<https://seed.bytedance.com/zh/>
+- 手机助手：<https://o.doubao.com/>
+
+## Git 提交 scope
+
+```
+docs(doubao): ...
+```
+
+## 已知踩坑 / 特殊约定
+
+1. 首页 SPA。无 JS 抓取经常只剩 meta。能力以 description + 桌面落地页原文为准。
+2. Seedance 版本号两份官方页打架，并列引用。
+3. 部分环境解析到 `198.18.0.0/15`，`web_fetch` 会 SSRF。
+4. 不要改 gallery / sidebar / `config.mjs`。
+5. 禁止把 Trae 安装、方舟 API、扣子编排写进本目录。

--- a/docs/products/doubao/doubao-cheatsheet.md
+++ b/docs/products/doubao/doubao-cheatsheet.md
@@ -1,0 +1,51 @@
+---
+title: Doubao cheatsheet
+description: Official Doubao doors, sibling products, and quoted capabilities. No CLI.
+domain: product
+tags:
+  - chat
+role: reference
+---
+
+# Doubao cheatsheet
+
+Lookup only. No official CLI. Verified 2026-08-19.
+
+## Where to go
+
+| Job | Door |
+|-----|------|
+| Chat / write / translate in a browser | [doubao.com](https://www.doubao.com/) |
+| Desktop client | [download](https://www.doubao.com/download/), [desktop](https://www.doubao.com/download/desktop) |
+| Repo / IDE | [Trae](https://www.trae.ai/) (#80) |
+| Build an agent | [Coze](https://www.coze.cn/) (#81) |
+| Call Doubao models | [Volcengine Ark](https://www.volcengine.com/product/ark) (#82) |
+
+## Official doors
+
+| Surface | URL or id |
+|---------|-----------|
+| Web | https://www.doubao.com/ |
+| Download | https://www.doubao.com/download/ |
+| Desktop landing | https://www.doubao.com/download/desktop |
+| Microsoft Store | `XPDDTBMM6TZ365` |
+| Yingyongbao | `com.larus.nova` |
+| Phone assistant | https://o.doubao.com/ |
+| Seed | https://seed.bytedance.com/zh/ |
+
+## Capabilities (quoted only)
+
+| Capability | Source |
+|------------|--------|
+| Chat, writing, copy, translation, coding helper | Homepage description |
+| Seedance 2.0, free after login | Homepage / download meta |
+| PPT, Excel, writing, translation | Desktop landing |
+| Seedream 5.0 / Seedance 2.5 | Desktop landing |
+| Planning Agent | Desktop landing |
+
+## Sources
+
+- https://www.doubao.com/
+- https://www.doubao.com/download/desktop
+- https://sj.qq.com/appdetail/com.larus.nova
+- https://apps.microsoft.com/detail/xpddtbmm6tz365

--- a/docs/products/doubao/doubao-glossary.md
+++ b/docs/products/doubao/doubao-glossary.md
@@ -1,0 +1,48 @@
+---
+title: Doubao glossary
+description: Doubao, Trae, Coze, Ark, and Seed are not the same product.
+domain: product
+tags:
+  - chat
+role: explanation
+---
+
+# Doubao glossary
+
+Boundaries only. How-to stays on the [tutorial](./doubao.md).
+
+## Doubao
+
+ByteDance consumer AI assistant at [doubao.com](https://www.doubao.com/). Web, desktop, and mobile are one product.
+
+## Doubao models
+
+The Seed / Ark model brand. Call them from your own app via [Volcengine Ark](/products/volcengine-ark/), not by opening the Doubao chat app.
+
+## Trae
+
+Same-vendor coding IDE. Not documented here. See #80.
+
+## Coze
+
+Same-vendor agent builder. See #81.
+
+## Volcengine Ark
+
+Same-vendor model API and model square. See #82.
+
+## Seed
+
+[ByteDance Seed](https://seed.bytedance.com/zh/) is the research / model brand, not the chat app.
+
+## Doubao phone assistant
+
+[o.doubao.com](https://o.doubao.com/) is a hardware / system-assistant line, not the doubao.com chat product.
+
+## Dola
+
+Alternate door shown when the homepage is geo-restricted. Not documented here.
+
+## Seedance / Seedream
+
+Official video / image model names. Homepage meta says Seedance **2.0**. Desktop landing says Seedance **2.5** and Seedream **5.0**. Both strings are official.

--- a/docs/products/doubao/doubao.md
+++ b/docs/products/doubao/doubao.md
@@ -1,0 +1,75 @@
+---
+title: Doubao tutorial
+description: Open Doubao on the web or desktop and send the first message. Only official doors and copy.
+domain: product
+tags:
+  - chat
+role: tutorial
+---
+
+# Doubao tutorial
+
+> Start at [doubao.com](https://www.doubao.com/) or the [desktop landing](https://www.doubao.com/download/desktop). This page only repeats doors you can check on official pages.
+
+## Goals and non-goals
+
+**Audience:** a frontend engineer opening Doubao for the first time.
+
+**You will:** send a first message on web or desktop, and see what the desktop page adds.
+
+**You will not:** install Trae, call the Ark API, build a Coze agent, or invent prices.
+
+## Prerequisites
+
+- You can open `doubao.com`. Some networks resolve it into `198.18.0.0/15`. Change DNS / disable Fake-IP before you decide the site is down.
+- Some regions ask you to sign in first, or suggest **Dola**. Dola is not this tutorial.
+
+## Open it in 15 minutes
+
+### 1. Pick an official door
+
+| Surface | How | Source |
+|---------|-----|--------|
+| Web | Open [doubao.com](https://www.doubao.com/), sign in, ask | Homepage |
+| Web from desktop landing | [download/desktop](https://www.doubao.com/download/desktop) → **使用网页版** | Desktop page |
+| Windows / macOS | [download](https://www.doubao.com/download/) or **下载豆包桌面版** | Official download |
+| Microsoft Store | App id `XPDDTBMM6TZ365` | [Store](https://apps.microsoft.com/detail/xpddtbmm6tz365) |
+| Android | Yingyongbao package `com.larus.nova` (Beijing Chuntian Zhiyun Technology Co., Ltd.) | [Yingyongbao](https://sj.qq.com/appdetail/com.larus.nova) |
+
+Minimum OS versions were **not** visible in the no-JS scrape on 2026-08-19. <!-- TODO: 待核实 --> Use the installer page.
+
+### 2. Send the first message
+
+After login, type in the box. Official copy positions Doubao as chat, writing, copy, translation, and a coding helper. Treat it as a conversation assistant. Do not expect it to clone a repo or open a PR.
+
+### 3. What the desktop page adds
+
+Install the desktop client only if you need local productivity. Official desktop copy:
+
+- Writing, translation, one-click PPT, Excel
+- Seedream 5.0 image and Seedance 2.5 video (Pro)
+- A built-in planning Agent
+
+There is no official click-path tree. This page does not invent one.
+
+## Official capabilities
+
+### Homepage / download meta
+
+Seedance **2.0** is on Doubao and free after login. Doubao is described as a chat assistant for writing, copy, translation, and coding help.
+
+### Desktop landing
+
+[download/desktop](https://www.doubao.com/download/desktop) names **Seedream 5.0**, **Seedance 2.5**, and an **Agent**.
+
+**The two official Seedance version strings disagree.** This site quotes both.
+
+### Coding boundary
+
+Repo-level coding is [Trae](https://www.trae.ai/) (#80). Calling Doubao models from your service is [Volcengine Ark](https://www.volcengine.com/product/ark) (#82).
+
+## Next
+
+- [Cheatsheet](./doubao-cheatsheet.md)
+- [Glossary](./doubao-glossary.md)
+- [Learn LLM](/tech/fundamentals/LLM)

--- a/docs/products/doubao/index.md
+++ b/docs/products/doubao/index.md
@@ -1,0 +1,102 @@
+---
+title: Doubao learning map
+description: Doubao is ByteDance's consumer AI assistant. This directory covers the Doubao app and web UI only. Trae, Coze, and Volcengine Ark each get one row.
+domain: product
+tags:
+  - chat
+role: map
+---
+
+# Doubao learning map
+
+> **Doubao** is ByteDance's consumer AI assistant. Official listing description ([doubao.com](https://www.doubao.com/)):
+>
+> Doubao is your AI chat assistant for writing, copy, translation, and coding help.
+>
+> This directory is the Claude.ai / Yuanbao counterpart. It is **not** Trae and **not** the Doubao model API on Volcengine Ark.
+
+## Audience / non-goals
+
+**Audience:** frontend engineers who want a China-region web or desktop assistant for writing, translation, PPT / sheets, and light coding questions.
+
+**Non-goals:**
+
+- Trae IDE install (#80)
+- Coze agent building (#81)
+- Volcengine Ark API / CLI (#82)
+- Douyin / Feishu / Toutiao how-tos
+- Invented subscription prices or a default model slug
+- Model internals (see [Learn LLM](/tech/fundamentals/LLM))
+
+## Landscape
+
+```
+ByteDance AI (this directory expands Doubao only)
+├── Doubao — consumer assistant (this directory)
+│   ├── Web doubao.com
+│   ├── Windows / macOS desktop
+│   └── Mobile app
+├── Doubao phone assistant — o.doubao.com (one row)
+├── ByteDance Seed — research brand (one row)
+├── Trae — coding IDE (#80, one row)
+├── Coze — agent builder (#81, one row)
+└── Volcengine Ark — model API (#82, one row)
+```
+
+| Official first-level door | Official URL | This site |
+|---------------------------|--------------|-----------|
+| **Doubao** (web / clients) | [doubao.com](https://www.doubao.com/) | [Tutorial](./doubao.md) |
+| Download / desktop | [download](https://www.doubao.com/download/), [download/desktop](https://www.doubao.com/download/desktop) | Tutorial |
+| Doubao phone assistant | [o.doubao.com](https://o.doubao.com/) | Map row |
+| ByteDance Seed | [seed.bytedance.com/zh](https://seed.bytedance.com/zh/) | Map row |
+| Dola | Geo-restriction prompt on the homepage | Map row |
+| Trae | [trae.ai](https://www.trae.ai/), [trae.cn](https://www.trae.cn/) | One row → #80 |
+| Coze | [coze.cn](https://www.coze.cn/) | One row → #81 |
+| Volcengine Ark | [volcengine.com/product/ark](https://www.volcengine.com/product/ark) | One row → #82 |
+| Douyin / Feishu / Toutiao | — | **Out of scope** |
+
+**Easy collisions:**
+
+- **Doubao ≠ Trae.** Doubao is a chat assistant. Trae is a coding IDE.
+- **Doubao app ≠ Doubao model API.** The API lives on Volcengine Ark.
+- **Doubao ≠ Coze.** Coze is the agent-building platform.
+- **Doubao ≠ Doubao phone assistant.** `o.doubao.com` is a hardware / system-assistant line.
+- **Homepage Seedance 2.0 ≠ desktop Seedance 2.5.** Quote both official strings. Do not pick a winner.
+
+### Quick decision
+
+```
+What do you need?
+├── Chat, write, translate, PPT, Excel, image / video in a browser or desktop app
+│   └── → Doubao (this directory)
+├── Edit a real repo
+│   └── → Trae (#80)
+├── Ship an agent / workflow
+│   └── → Coze (#81)
+├── Call Doubao models from your own frontend or Node service
+│   └── → Volcengine Ark (#82)
+└── Douyin / Feishu itself
+    └── → Out of scope
+```
+
+## Path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Open and chat | [Tutorial](./doubao.md) | First message on web or desktop |
+| 2. Look up URLs | [Cheatsheet](./doubao-cheatsheet.md) | Downloads, stores, sibling doors |
+| 3. Names | [Glossary](./doubao-glossary.md) | Stop calling Trae / Ark “Doubao” |
+
+There is no official how-to tree. **No cookbook.**
+
+## Capability table (official pages only)
+
+| Capability | Official source |
+|------------|-----------------|
+| Chat, writing, copy, translation, coding helper | [Homepage description](https://www.doubao.com/) |
+| Seedance 2.0 video generation, free after login | Homepage / download meta |
+| Writing, translation, one-click PPT, Excel | [Desktop landing](https://www.doubao.com/download/desktop) |
+| Seedream 5.0 / Seedance 2.5 (Pro) | Desktop landing |
+| Built-in planning Agent | Desktop landing |
+
+Pricing: no official Doubao price table found on 2026-08-19. Do not copy third-party quota numbers.

--- a/docs/zh/products/doubao/doubao-cheatsheet.md
+++ b/docs/zh/products/doubao/doubao-cheatsheet.md
@@ -1,0 +1,51 @@
+---
+title: 豆包速查表
+description: 豆包官方入口、同厂去向和已核对的能力原文。没有 CLI。
+domain: product
+tags:
+  - chat
+role: reference
+---
+
+# 豆包速查表
+
+只查不学。没有官方 CLI，本页没有命令表。最后核实：2026-08-19。
+
+## 我该用哪个？
+
+| 场景 | 去哪 |
+|------|------|
+| 浏览器里聊天 / 写 / 译 | [doubao.com](https://www.doubao.com/) |
+| 装桌面客户端 | [download](https://www.doubao.com/download/)、[desktop](https://www.doubao.com/download/desktop) |
+| 仓库 / IDE 编程 | [Trae](https://www.trae.ai/)（#80） |
+| 搭 Agent | [扣子](https://www.coze.cn/)（#81） |
+| 调豆包模型 API | [火山方舟](https://www.volcengine.com/product/ark)（#82） |
+
+## 官方入口
+
+| 端 | URL 或标识 |
+|----|------------|
+| Web | https://www.doubao.com/ |
+| 下载 | https://www.doubao.com/download/ |
+| 桌面介绍 | https://www.doubao.com/download/desktop |
+| Microsoft Store | id `XPDDTBMM6TZ365` |
+| 应用宝 | `com.larus.nova`（北京春田知韵科技有限公司） |
+| 手机助手 | https://o.doubao.com/ |
+| Seed | https://seed.bytedance.com/zh/ |
+
+## 能力对照（有原文才进表）
+
+| 能力 | 出处 |
+|------|------|
+| 聊天、写作、文案、翻译、编程工具 | 首页 description |
+| Seedance 2.0 已接入，登录免费使用 | 首页 / 下载页 meta |
+| PPT、Excel、写作翻译 | 桌面落地页 |
+| Seedream 5.0 / Seedance 2.5 | 桌面落地页 |
+| Agent 智能体 | 桌面落地页 |
+
+## 高质量信息源
+
+- 产品首页：https://www.doubao.com/
+- 桌面落地：https://www.doubao.com/download/desktop
+- 应用宝：https://sj.qq.com/appdetail/com.larus.nova
+- Microsoft Store：https://apps.microsoft.com/detail/xpddtbmm6tz365

--- a/docs/zh/products/doubao/doubao-glossary.md
+++ b/docs/zh/products/doubao/doubao-glossary.md
@@ -1,0 +1,48 @@
+---
+title: 豆包术语表
+description: 豆包、Trae、扣子、方舟、Seed 不是同一个产品。
+domain: product
+tags:
+  - chat
+role: explanation
+---
+
+# 豆包术语表
+
+只解释边界。操作回 [教程](./doubao.md)。
+
+## 豆包
+
+字节跳动消费级 AI 助手。入口是 [doubao.com](https://www.doubao.com/)。网页、桌面客户端、手机 App 是同一产品的不同端。
+
+## 豆包大模型
+
+Seed / 火山方舟上的模型品牌。在自己的程序里调用走 [火山方舟](/zh/products/volcengine-ark/)，不是打开豆包 App。
+
+## Trae
+
+同厂编程 IDE。本目录不写安装。见 #80。
+
+## 扣子 / Coze
+
+同厂 Agent 搭建平台。见 #81。
+
+## 火山方舟
+
+同厂模型 API 与模型广场。见 #82。
+
+## Seed
+
+[ByteDance Seed](https://seed.bytedance.com/zh/) 是研究与模型品牌，不是聊天 App。
+
+## 豆包手机助手
+
+[o.doubao.com](https://o.doubao.com/) 是另一条「大模型时代的手机助手 / 硬件」线，不是 doubao.com 聊天本体。
+
+## Dola
+
+部分区域打不开豆包首页时，官方页提示的替代入口。本目录不写教程。
+
+## Seedance / Seedream
+
+官方生视频 / 生图模型名。首页 meta 写 Seedance **2.0**；桌面落地页写 Seedance **2.5** 与 Seedream **5.0**。两份都是官方原文，不要合成一个版本号。

--- a/docs/zh/products/doubao/doubao.md
+++ b/docs/zh/products/doubao/doubao.md
@@ -1,0 +1,77 @@
+---
+title: 豆包教程
+description: 打开豆包网页或桌面客户端，发出第一句。只复述能在官方页核对的入口和能力。
+domain: product
+tags:
+  - chat
+role: tutorial
+---
+
+# 豆包教程
+
+> 先打开 [doubao.com](https://www.doubao.com/) 或 [桌面下载页](https://www.doubao.com/download/desktop)。本页只复述能在官方页核对的入口。
+
+## 目标与非目标
+
+**写给谁：** 第一次用豆包的前端工程师。
+
+**你会完成：** 在网页或客户端里发出第一句；知道桌面页比首页多写了什么。
+
+**不会做：** Trae 安装、方舟 API、扣子编排、编造会员价。
+
+## 先决条件
+
+- 能打开 `doubao.com`。部分网络会把该域名解析到 `198.18.0.0/15`，先换 DNS / 关 Fake-IP 再判断「打不开」。
+- 部分区域首页会提示先登录，或改用 **Dola**。Dola 不是本教程对象。
+
+## 15 分钟内打开
+
+### 1. 选一个官方入口
+
+| 端 | 怎么走 | 来源 |
+|----|--------|------|
+| 网页 | 打开 [doubao.com](https://www.doubao.com/)，登录后提问 | 首页 |
+| 网页（桌面落地页） | [download/desktop](https://www.doubao.com/download/desktop) 点 **使用网页版** | 桌面页 |
+| Windows / macOS | [download](https://www.doubao.com/download/) 或桌面页 **下载豆包桌面版** | 官方下载 |
+| Windows 商店 | Microsoft Store 应用「豆包」，id `XPDDTBMM6TZ365` | [商店页](https://apps.microsoft.com/detail/xpddtbmm6tz365) |
+| Android | 应用宝包名 `com.larus.nova`（开发者：北京春田知韵科技有限公司） | [应用宝](https://sj.qq.com/appdetail/com.larus.nova) |
+
+系统最低版本官方下载页 2026-08-19 **没有**在无 JS 抓取里给出数字。<!-- TODO: 待核实 --> 以安装包页为准。
+
+### 2. 发出第一句
+
+登录后在输入框提问。首页把豆包定位成聊天、写作、文案、翻译、编程工具。把它当对话助手用，不要期待它克隆仓库、开 PR。
+
+### 3. 桌面版多写了什么
+
+只在需要本地生产力时装客户端。官方桌面页原文：
+
+- 「日常工作可高效写作翻译、一键生成PPT、智能处理Excel 数据」
+- 「创意创作依托专业版Seedream 5.0 生图，专业版Seedance 2.5 生视频核心模型」
+- 「内置自主规划执行的 Agent 智能体，自动统筹多类任务」
+
+逐步点击路径官方没有文档树，本页不编。
+
+## 官方能力（按出处分组）
+
+### 首页 / 下载页 meta 在说什么
+
+> Seedance 2.0 视频生成模型现已全面接入 豆包 ，现在登录即可免费使用！
+
+> 豆包 是你的 AI 聊天智能对话问答助手，写作文案翻译编程工具。
+
+### 桌面落地页在说什么
+
+[download/desktop](https://www.doubao.com/download/desktop) 把同一产品写成「全链路 AI 生产力」，并点名 **Seedream 5.0**、**Seedance 2.5**、**Agent 智能体**。
+
+**两份官方页的视频模型版本号不一致。** 本站并列引用，不宣布哪一个「才算现行」。
+
+### 和编程相关的边界
+
+官方把「编程」写在助手能力里。仓库级、带 diff / 终端的编码去 [Trae](https://www.trae.ai/)（本站 #80）。在自己的服务里调豆包模型去 [火山方舟](https://www.volcengine.com/product/ark)（本站 #82）。
+
+## 下一步
+
+- 回查入口：[速查表](./doubao-cheatsheet.md)
+- 分清同厂名字：[术语表](./doubao-glossary.md)
+- 模型内部：[Learn LLM](/zh/tech/fundamentals/LLM)

--- a/docs/zh/products/doubao/index.md
+++ b/docs/zh/products/doubao/index.md
@@ -1,0 +1,102 @@
+---
+title: 豆包学习地图
+description: 豆包是字节跳动的消费级 AI 助手。本目录只写豆包 App / 网页。Trae、扣子、火山方舟各占一行。
+domain: product
+tags:
+  - chat
+role: map
+---
+
+# 豆包学习地图
+
+> **豆包**是字节跳动的消费级 AI 助手。官方收录 description（[doubao.com](https://www.doubao.com/)）：
+>
+> 「豆包 是你的AI 聊天智能对话问答助手，写作文案翻译编程工具。」
+>
+> 本目录对位 Claude.ai / 元宝。它**不是** Trae，也**不是**火山方舟上的豆包大模型 API。
+
+## 写给谁 / 不写什么
+
+**写给谁：** 需要一个国内网页或桌面助手写文案、翻译、做 PPT / 表、偶尔问代码的前端工程师。
+
+**非目标：**
+
+- Trae 编程 IDE 安装（#80）
+- 扣子 / Coze 搭 Agent（#81）
+- 火山方舟 API / CLI（#82）
+- 抖音 / 飞书 / 今日头条操作
+- 臆造会员价、默认模型 slug
+- 模型内部机制（去 [Learn LLM](/zh/tech/fundamentals/LLM)）
+
+## 产品全景
+
+```
+字节跳动 AI（本目录只展开豆包助手）
+├── 豆包 — 消费级助手（本目录）
+│   ├── 网页 doubao.com
+│   ├── Windows / macOS 桌面客户端
+│   └── 手机 App
+├── 豆包手机助手 — o.doubao.com（硬件 / 系统助手，一行）
+├── ByteDance Seed — 研究品牌（一行）
+├── Trae — 编程 IDE（#80，一行）
+├── 扣子 / Coze — Agent 搭建（#81，一行）
+└── 火山方舟 — 模型 API（#82，一行）
+```
+
+| 官方一级入口 | 官方 URL | 本站去向 |
+|--------------|----------|----------|
+| **豆包**（网页 / 客户端） | [doubao.com](https://www.doubao.com/) | 独立页 [doubao.md](./doubao.md) |
+| 下载中心 / 桌面版 | [download](https://www.doubao.com/download/)、[download/desktop](https://www.doubao.com/download/desktop) | Tutorial |
+| 豆包手机助手 | [o.doubao.com](https://o.doubao.com/) | 地图一行 |
+| ByteDance Seed | [seed.bytedance.com/zh](https://seed.bytedance.com/zh/) | 地图一行 |
+| Dola | 首页区域限制提示 | 地图一行 |
+| Trae | [trae.ai](https://www.trae.ai/)、[trae.cn](https://www.trae.cn/) | **一行** → #80 |
+| 扣子 / Coze | [coze.cn](https://www.coze.cn/) | **一行** → #81 |
+| 火山方舟 | [volcengine.com/product/ark](https://www.volcengine.com/product/ark) | **一行** → #82 |
+| 抖音 / 飞书 / 头条 | — | **非本站** |
+
+**容易撞名：**
+
+- **豆包 ≠ Trae。** 豆包是聊天助手。Trae 是编程 IDE。
+- **豆包 App ≠ 豆包大模型 API。** 后者走火山方舟。
+- **豆包 ≠ 扣子。** 扣子是搭 Agent 的平台。
+- **豆包 ≠ 豆包手机助手。** `o.doubao.com` 是另一条硬件 / 系统助手线。
+- **首页 Seedance 2.0 ≠ 桌面页 Seedance 2.5。** 两份官方文案并列，本站不选边。
+
+### 快速决策：我该用哪个？
+
+```
+我要做什么？
+├── 浏览器或桌面里聊天、写作、翻译、PPT、Excel、生图 / 生视频
+│   └── → 豆包（本目录）
+├── 对着真实仓库改代码
+│   └── → Trae（#80）
+├── 搭一个可发布的 Agent / 工作流
+│   └── → 扣子（#81）
+├── 在自己的前端或 Node 服务里调豆包模型
+│   └── → 火山方舟（#82）
+└── 刷抖音 / 用飞书本身
+    └── → 非本站
+```
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 打开能聊 | [豆包教程](./doubao.md) | 网页或客户端发出第一句 |
+| 2. 回查链接 | [速查表](./doubao-cheatsheet.md) | 下载、商店、同厂入口 |
+| 3. 名字分清 | [术语表](./doubao-glossary.md) | 不再把 Trae / 方舟叫成豆包 |
+
+官方没有 How-to 文档树，本目录**不设 cookbook**。
+
+## 功能速查（只抄官方页）
+
+| 能力 | 官方原文出处 |
+|------|----------------|
+| AI 聊天、写作、文案、翻译、编程工具 | [首页 description](https://www.doubao.com/) |
+| Seedance 2.0 视频生成已接入，登录即可免费使用 | 首页 / 下载页 meta |
+| 写作翻译、一键生成 PPT、智能处理 Excel | [桌面落地页](https://www.doubao.com/download/desktop) |
+| 专业版 Seedream 5.0 生图、专业版 Seedance 2.5 生视频 | 桌面落地页 |
+| 内置自主规划执行的 Agent 智能体 | 桌面落地页 |
+
+套餐与额度：2026-08-19 **没有**找到豆包官方价目表。不要把第三方次数写进正文。


### PR DESCRIPTION
Closes #79

## Summary

From-scratch handbook for **豆包 (Doubao) consumer assistant**. Chinese first, then English. Trae / Coze / Volcengine Ark are **not** tutorials here.

## Family (official first-class AI)

Retrieved from https://www.doubao.com/ , https://www.doubao.com/download/desktop , https://seed.bytedance.com/zh/ , store listings.

| Official entry | This site |
|----------------|-----------|
| Doubao web / desktop / app | This directory |
| Doubao phone assistant (o.doubao.com) | Map row |
| ByteDance Seed | Map row |
| Dola (geo prompt) | Map row |
| Trae | One row → #80 |
| Coze | One row → #81 |
| Volcengine Ark | One row → #82 |
| Douyin / Feishu / Toutiao | Out of scope |

## Files

- `.claude/skills/doc-research/references/doubao.md`
- `docs/zh/products/doubao/` — ZH map / tutorial / cheatsheet / glossary (no cookbook: no official how-to tree)
- `docs/products/doubao/` — EN isomorphic

## Guardrails

- Did not change gallery / sidebar / `config.mjs`.
- Seedance 2.0 (homepage meta) vs Seedance 2.5 + Seedream 5.0 (desktop landing) quoted side by side.
- No invented prices or OS minimums (`<!-- TODO: 待核实 -->` for OS).