### PR TITLE
docs(pi-agent): add Pi Agent handbook for #103

### DIFF
--- a/.claude/skills/doc-research/references/pi-agent.md
+++ b/.claude/skills/doc-research/references/pi-agent.md
@@ -1,0 +1,56 @@
+# Pi Agent 维护参考
+
+调研时间：2026-08-19。先写这一节再动教程。
+
+## 产品形态调研结论
+
+**结论一：Pi 是终端 coding-agent harness，不是聊天 App，也不是 OpenClaw。**
+
+- [pi.dev](https://pi.dev/) title：Pi Coding Agent。description：「A terminal-based coding agent」。
+- 官方：minimal agent harness。可装 extensions / skills / prompt templates / themes，打成 Pi packages。
+- 现行 npm：`@earendil-works/pi-coding-agent`。[news 2026-05-07](https://pi.dev/news/2026/5/7/pi-has-a-new-home)：仓库迁到 `earendil-works/pi`。
+- 旧包 `@mariozechner/pi-coding-agent` npm 原文：`please use @earendil-works/pi-coding-agent instead going forward`。
+- 可执行文件名是 **`pi`**。
+
+**结论二：官方安装只抄文档。**
+
+[Quickstart](https://pi.dev/docs/latest/quickstart)：
+
+```
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
+
+Linux/macOS 还可：`curl -fsSL https://pi.dev/install.sh | sh`。
+
+**结论三：官方一级是一套 harness，不是五六个独立产品。**
+
+GitHub [earendil-works/pi](https://github.com/earendil-works/pi) 包表：`pi-coding-agent` / `pi-agent-core` / `pi-ai` / `pi-tui` / `pi-telemetry`。Slack/chat 另见 `earendil-works/pi-chat`（地图一行）。OpenClaw 用 SDK 接入（pi.dev 原文），正文归 #104。
+
+**结论四：默认不做的功能是官方卖点，不要写成缺陷补丁。**
+
+pi.dev：跳过 sub-agents、plan mode；No MCP（可用 extension / skill 自己加）。无内置权限系统（README）。
+
+## 基本信息
+
+- 工具名：Pi / Pi Coding Agent
+- 官方站：<https://pi.dev/>
+- 文档：<https://pi.dev/docs/latest>
+- 仓库：<https://github.com/earendil-works/pi>
+- 现行包：`@earendil-works/pi-coding-agent`
+
+## 官方一级导航
+
+| 官方一级入口 | 官方 URL | 本站去向 |
+|--------------|----------|----------|
+| Pi Coding Agent | https://pi.dev/ | 独立 Tutorial |
+| Docs / Quickstart | https://pi.dev/docs/latest/quickstart | Tutorial |
+| GitHub monorepo | https://github.com/earendil-works/pi | 地图 + 速查 |
+| Packages 目录 | https://pi.dev/packages | 地图一行 |
+| pi-chat | GitHub earendil-works/pi-chat | 地图一行 |
+| OpenClaw | https://openclaw.ai/ | 地图一行（#104） |
+
+## Git
+
+```
+docs(pi-agent): ...
+```

--- a/docs/products/pi-agent/index.md
+++ b/docs/products/pi-agent/index.md
@@ -1,0 +1,46 @@
+---
+title: Pi Agent learning map
+description: Pi is a minimal terminal coding-agent harness. This directory covers Pi only. OpenClaw uses its SDK; that handbook is separate.
+domain: product
+tags:
+  - harness
+  - coding-agent
+role: map
+---
+
+# Pi Agent learning map
+
+> **Pi** is a terminal coding agent. Official site ([pi.dev](https://pi.dev/)):
+> **Pi Coding Agent** — “A terminal-based coding agent”.
+>
+> Same page: Pi is a **minimal agent harness**. It skips sub-agents and plan mode by default. Add them with extensions, skills, or packages.
+>
+> This directory is the slim harness counterpart to Claude Code / Kimi Code. It is not a chat app and not OpenClaw.
+
+## Audience / non-goals
+
+**Audience:** frontend engineers who live in a terminal and want to own the harness.
+
+**Non-goals:** OpenClaw install (#104); using deprecated `@mariozechner/pi-coding-agent` as the main path; inventing an official MCP toggle; model internals ([Learn LLM](/tech/fundamentals/LLM)).
+
+## Landscape
+
+| Official first-level door | Official URL | This site |
+|---------------------------|--------------|-----------|
+| **Pi Coding Agent** | [pi.dev](https://pi.dev/) | [Tutorial](./pi-agent.md) |
+| Docs / Quickstart | [quickstart](https://pi.dev/docs/latest/quickstart) | Tutorial |
+| GitHub | [earendil-works/pi](https://github.com/earendil-works/pi) | Cheatsheet |
+| Packages | [pi.dev/packages](https://pi.dev/packages) | Map row |
+| New home (2026-05-07) | [news](https://pi.dev/news/2026/5/7/pi-has-a-new-home) | Tutorial |
+| pi-chat | `earendil-works/pi-chat` | Map row |
+| OpenClaw | [openclaw.ai](https://openclaw.ai/) | One row → [OpenClaw](/products/openclaw/) |
+
+**Collisions:** Pi ≠ OpenClaw; command `pi` ≠ a math library; current package ≠ `@mariozechner/pi-coding-agent`; no built-in MCP ≠ never MCP.
+
+## Path
+
+| Stage | Read | Goal |
+|-------|------|------|
+| 1. Install | [Tutorial](./pi-agent.md) | First `pi` session |
+| 2. Lookup | [Cheatsheet](./pi-agent-cheatsheet.md) | Commands and doors |
+| 3. Names | [Glossary](./pi-agent-glossary.md) | Stop calling OpenClaw “Pi” |

--- a/docs/products/pi-agent/pi-agent-cheatsheet.md
+++ b/docs/products/pi-agent/pi-agent-cheatsheet.md
@@ -1,0 +1,27 @@
+---
+title: Pi Agent cheatsheet
+description: Official Pi install commands, modes, and doors. Do not use the old npm package.
+domain: product
+tags:
+  - harness
+role: reference
+---
+
+# Pi Agent cheatsheet
+
+Verified 2026-08-19.
+
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+curl -fsSL https://pi.dev/install.sh | sh
+```
+
+| Action | Official |
+|--------|----------|
+| Interactive | `pi` |
+| Script | `pi -p "query"` |
+| JSON | `--mode json` |
+| Model | `/model` or `Ctrl+L` |
+| Package | `pi install npm:@foo/pi-tools` |
+
+Doors: https://pi.dev/ · https://pi.dev/docs/latest/quickstart · https://github.com/earendil-works/pi

--- a/docs/products/pi-agent/pi-agent-glossary.md
+++ b/docs/products/pi-agent/pi-agent-glossary.md
@@ -1,0 +1,18 @@
+---
+title: Pi Agent glossary
+description: Pi, OpenClaw, and the old npm package are not the same thing.
+domain: product
+tags:
+  - harness
+role: explanation
+---
+
+# Pi Agent glossary
+
+**Pi / Pi Coding Agent** — Terminal harness at [pi.dev](https://pi.dev/). Command `pi`. Package `@earendil-works/pi-coding-agent`.
+
+**OpenClaw** — Multi-channel gateway. pi.dev names it as an SDK integration. See [OpenClaw](/products/openclaw/).
+
+**`@mariozechner/pi-coding-agent`** — Deprecated npm name. Old repo `badlogic/pi-mono`.
+
+**Earendil** — Org that owns Pi as of [2026-05-07](https://pi.dev/news/2026/5/7/pi-has-a-new-home).

--- a/docs/products/pi-agent/pi-agent.md
+++ b/docs/products/pi-agent/pi-agent.md
@@ -1,0 +1,43 @@
+---
+title: Pi Agent tutorial
+description: Install Pi from the official npm package or install.sh and send the first prompt. Do not use the deprecated package as the main path.
+domain: product
+tags:
+  - harness
+  - coding-agent
+role: tutorial
+---
+
+# Pi Agent tutorial
+
+> Official steps: [Quickstart](https://pi.dev/docs/latest/quickstart).
+
+## Install
+
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
+
+Linux / macOS also:
+
+```bash
+curl -fsSL https://pi.dev/install.sh | sh
+```
+
+[2026-05-07](https://pi.dev/news/2026/5/7/pi-has-a-new-home): primary package is `@earendil-works/pi-coding-agent`. Do not install `@mariozechner/pi-coding-agent`.
+
+## First prompt
+
+```bash
+pi
+```
+
+Print mode: `pi -p "query"`. Event stream: `--mode json`. Model switch: `/model` or `Ctrl+L`.
+
+Project files from pi.dev: `AGENTS.md` (loaded from `~/.pi/agent/`, parents, cwd) and `SYSTEM.md`. Packages: `pi install npm:@foo/pi-tools`.
+
+Defaults (pi.dev + README): no built-in sub-agents, plan mode, MCP, or permission system.
+
+## Next
+
+[Cheatsheet](./pi-agent-cheatsheet.md) · [Glossary](./pi-agent-glossary.md) · [OpenClaw](/products/openclaw/)

--- a/docs/zh/products/pi-agent/index.md
+++ b/docs/zh/products/pi-agent/index.md
@@ -1,0 +1,90 @@
+---
+title: Pi Agent 学习地图
+description: Pi 是极简终端 coding-agent harness。本目录只写 Pi。OpenClaw 用它的 SDK，正文在另页。
+domain: product
+tags:
+  - harness
+  - coding-agent
+role: map
+---
+
+# Pi Agent 学习地图
+
+> **Pi** 是终端里的 coding agent。官方站（[pi.dev](https://pi.dev/)）title：
+> **Pi Coding Agent**。description：「A terminal-based coding agent」。
+>
+> 同页原文：Pi is a **minimal agent harness**。默认跳过 sub-agents 和 plan mode。需要就自己用 extension / skill / package 加。
+>
+> 本目录对位 Claude Code / Kimi Code 的**极简 harness**，不是聊天 App，也不是 OpenClaw。
+
+## 写给谁 / 不写什么
+
+**写给谁：** 会用终端、想自己掌控 harness 的前端工程师。
+
+**非目标：**
+
+- OpenClaw 安装（#104）
+- 旧 npm `@mariozechner/pi-coding-agent` 当主安装路径
+- 编造 MCP / plan mode 官方开关
+- 模型内部机制（去 [Learn LLM](/zh/tech/fundamentals/LLM)）
+
+## 产品全景
+
+```
+Pi / Earendil（本目录只展开 Pi CLI）
+├── @earendil-works/pi-coding-agent — 命令 `pi`（本目录）
+├── pi-agent-core / pi-ai / pi-tui / pi-telemetry — 同仓库
+├── Pi packages — pi.dev/packages
+├── pi-chat — Slack/chat 自动化（一行）
+└── OpenClaw — 用 Pi SDK 的自托管网关（#104）
+```
+
+| 官方一级入口 | 官方 URL | 本站去向 |
+|--------------|----------|----------|
+| **Pi Coding Agent** | [pi.dev](https://pi.dev/) | 独立页 [pi-agent.md](./pi-agent.md) |
+| Docs / Quickstart | [docs/latest/quickstart](https://pi.dev/docs/latest/quickstart) | Tutorial |
+| GitHub | [earendil-works/pi](https://github.com/earendil-works/pi) | 速查 |
+| Packages | [pi.dev/packages](https://pi.dev/packages) | 地图一行 |
+| 新家公告 | [2026-05-07](https://pi.dev/news/2026/5/7/pi-has-a-new-home) | Tutorial 一节 |
+| pi-chat | GitHub `earendil-works/pi-chat` | 地图一行 |
+| OpenClaw | [openclaw.ai](https://openclaw.ai/) | **一行** → [OpenClaw](/zh/products/openclaw/) |
+
+**容易撞名：**
+
+- **Pi ≠ OpenClaw。** Pi 是终端 harness。OpenClaw 是多通道网关，官方把 OpenClaw 写成 Pi SDK 的真实集成。
+- **`pi` ≠ 圆周率库。** 装的是 `@earendil-works/pi-coding-agent`。
+- **现行包 ≠ `@mariozechner/pi-coding-agent`。** 后者 npm 已写 deprecated。
+- **默认无 MCP ≠ 永远不能 MCP。** 官网：用 skill / extension 自己加。
+
+### 快速决策
+
+```
+我要做什么？
+├── 在仓库终端里改代码、自己扩展 harness
+│   └── → Pi（本目录）
+├── 把助手接到 Telegram / 飞书 / WhatsApp
+│   └── → OpenClaw（#104）
+└── 要开箱即用的 IDE Agent
+    └── → Cursor / Claude Code / Trae（其它手册）
+```
+
+## 学习路径
+
+| 阶段 | 读什么 | 目标 |
+|------|--------|------|
+| 1. 装上并跑起来 | [教程](./pi-agent.md) | `pi --version`，发出第一句 |
+| 2. 回查命令 | [速查](./pi-agent-cheatsheet.md) | 安装、模式、官方链接 |
+| 3. 分清名字 | [术语表](./pi-agent-glossary.md) | 不再把 OpenClaw 叫成 Pi |
+
+官方 How-to 树在 pi.dev/docs。本目录**不硬凑 cookbook**。
+
+## 功能速查（只抄官方页）
+
+| 能力 | 出处 |
+|------|------|
+| 终端 coding agent / minimal harness | [pi.dev](https://pi.dev/) |
+| 四种模式：interactive、print/JSON、RPC、SDK | pi.dev |
+| 15+ providers | pi.dev |
+| `__AGENTS.md` / `SYSTEM.md` / Skills / 模板 | pi.dev |
+| `pi install npm:@foo/pi-tools` | pi.dev |
+| 无内置权限系统，需容器化 | [README](https://github.com/earendil-works/pi) |

--- a/docs/zh/products/pi-agent/pi-agent-cheatsheet.md
+++ b/docs/zh/products/pi-agent/pi-agent-cheatsheet.md
@@ -1,0 +1,44 @@
+---
+title: Pi Agent 速查表
+description: Pi 官方安装命令、模式和入口。旧 npm 包不要用。
+domain: product
+tags:
+  - harness
+role: reference
+---
+
+# Pi Agent 速查表
+
+最后核实：2026-08-19。
+
+## 安装（只抄官方）
+
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
+
+```bash
+curl -fsSL https://pi.dev/install.sh | sh
+```
+
+来源：[Quickstart](https://pi.dev/docs/latest/quickstart)。
+
+## 常用
+
+| 动作 | 官方原文 |
+|------|----------|
+| 交互 | `pi` |
+| 脚本 | `pi -p "query"` |
+| JSON 事件 | `--mode json` |
+| 切模型 | `/model` 或 `Ctrl+L` |
+| 装包 | `pi install npm:@foo/pi-tools` |
+
+## 入口
+
+| 页 | URL |
+|----|-----|
+| 产品 | https://pi.dev/ |
+| Docs | https://pi.dev/docs/latest |
+| 新家 | https://pi.dev/news/2026/5/7/pi-has-a-new-home |
+| GitHub | https://github.com/earendil-works/pi |
+| 旧包（deprecated） | https://www.npmjs.com/package/@mariozechner/pi-coding-agent |

--- a/docs/zh/products/pi-agent/pi-agent-glossary.md
+++ b/docs/zh/products/pi-agent/pi-agent-glossary.md
@@ -1,0 +1,30 @@
+---
+title: Pi Agent 术语表
+description: Pi、OpenClaw、旧 npm 包不是同一个东西。
+domain: product
+tags:
+  - harness
+role: explanation
+---
+
+# Pi Agent 术语表
+
+## Pi / Pi Coding Agent
+
+[pi.dev](https://pi.dev/) 上的终端 coding-agent harness。命令 `pi`。现行包 `@earendil-works/pi-coding-agent`。
+
+## Harness
+
+官网自称 minimal agent harness：核心很小，能力用 extension / skill / package 加。
+
+## OpenClaw
+
+自托管多通道网关。pi.dev 把它写成 SDK 的真实集成。安装见 [OpenClaw](/zh/products/openclaw/)。
+
+## `@mariozechner/pi-coding-agent`
+
+旧 npm 名。包页原文请改用 `@earendil-works/pi-coding-agent`。仓库旧址 `badlogic/pi-mono`。
+
+## Earendil
+
+2026-05-07 起 Pi 的组织归属（[公告](https://pi.dev/news/2026/5/7/pi-has-a-new-home)）。

--- a/docs/zh/products/pi-agent/pi-agent.md
+++ b/docs/zh/products/pi-agent/pi-agent.md
@@ -1,0 +1,81 @@
+---
+title: Pi Agent 教程
+description: 用官方 npm 或 install.sh 装上 Pi，在仓库里发出第一句。旧包不要当主路径。
+domain: product
+tags:
+  - harness
+  - coding-agent
+role: tutorial
+---
+
+# Pi Agent 教程
+
+> 官方文档：[Quickstart](https://pi.dev/docs/latest/quickstart)。本页只抄能打开的安装命令。
+
+## 目标与非目标
+
+**你会完成：** 装上现行包，跑 `pi`，知道四种模式和「默认没有什么」。
+
+**不会做：** 把 deprecated 包当主安装；把 OpenClaw 通道写进来。
+
+## 先决条件
+
+- Node.js（Quickstart 走 npm）。packages 页有的扩展写 **Node >= 22.19.0**，本页不合成一个全站最低版本。<!-- TODO: 待核实 --> 以你打开的那页为准。
+- 一个模型供应商的 API key 或 OAuth（pi.dev：Authenticate via API keys or OAuth）。
+
+## 15 分钟内打开
+
+### 1. 装现行包
+
+[Quickstart](https://pi.dev/docs/latest/quickstart) 原文：
+
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
+
+`--ignore-scripts`：官方写明安装时关掉依赖生命周期脚本；Pi 正常 npm 安装不需要这些脚本。
+
+Linux / macOS 还可：
+
+```bash
+curl -fsSL https://pi.dev/install.sh | sh
+```
+
+[2026-05-07 公告](https://pi.dev/news/2026/5/7/pi-has-a-new-home)：主安装包改为 `@earendil-works/pi-coding-agent`，仓库从 `badlogic/pi-mono` 迁到 `earendil-works/pi`。不要再 `npm i -g @mariozechner/pi-coding-agent`。
+
+### 2. 发出第一句
+
+在真实仓库目录里：
+
+```bash
+pi
+```
+
+进入 interactive TUI。脚本场景用官方的 print 模式：`pi -p "query"`；事件流加 `--mode json`（[pi.dev](https://pi.dev/)）。
+
+切模型：官网写 `/model` 或 `Ctrl+L`；收藏夹 `Ctrl+P`。
+
+### 3. 项目说明放哪
+
+官网 Context engineering：
+
+- **`AGENTS.md`**：启动时从 `~/.pi/agent/`、父目录、当前目录加载。
+- **`SYSTEM.md`**：按项目替换或追加默认系统提示。
+
+需要别人写好的能力：`pi install npm:@foo/pi-tools` 或 `pi install git:github.com/badlogic/pi-doom`（pi.dev 示例，原样抄）。
+
+## 默认没有什么
+
+来自 [pi.dev](https://pi.dev/) 与 [README](https://github.com/earendil-works/pi)：
+
+- 没有内置 sub-agents、plan mode。
+- 没有内置 MCP（可用 skill / extension）。
+- 没有内置权限系统；要隔离去官方 containerization 文档。
+
+这些是设计，不是漏写的开关。
+
+## 下一步
+
+- [速查](./pi-agent-cheatsheet.md)
+- [术语](./pi-agent-glossary.md)
+- 接到聊天通道 → [OpenClaw](/zh/products/openclaw/)


### PR DESCRIPTION
Closes #103

Pi / Pi Coding Agent only. Official install: `npm install -g --ignore-scripts @earendil-works/pi-coding-agent` and `curl -fsSL https://pi.dev/install.sh | sh`. OpenClaw is one map row (#104). Deprecated `@mariozechner/pi-coding-agent` is named, not used as the main path.

| Official | This site |
|----------|-----------|
| pi.dev / docs / earendil-works/pi | This directory |
| Packages / pi-chat | Map row |
| OpenClaw | #104 |

Did not edit gallery/sidebar (parent integration pass).