### PR TITLE
docs(figma-ai): add Figma AI handbook for #105

### DIFF
--- a/.claude/skills/doc-research/references/figma-ai.md
+++ b/.claude/skills/doc-research/references/figma-ai.md
@@ -1,0 +1,20 @@
+# Figma AI 维护参考
+
+调研：2026-08-19。官方 Help：First Draft、Figma agent、Config 2026。
+
+## 形态
+
+本目录只写 **Figma 官方 AI**（画布里的 Agent / First Draft / Make）。不是 Relume、Magician、Midjourney。
+
+- First Draft：https://help.figma.com/hc/en-us/articles/23955143044247
+  - 从 2026-05-20 起，Figma’s agent 成为该能力的新入口（beta，逐步开放）。
+  - 旧路径：Actions → First Draft → Library → prompt。
+- Agent：https://help.figma.com/hc/en-us/articles/37998629035799 ；Config 2026 文：Professional / Organization / Enterprise，Full seat，can edit。
+- Make：https://www.figma.com/make/ （站点存在；细节以打开的帮助页为准）
+- AI 总览检索入口：https://www.figma.com/ai/
+
+第三方插件只地图一行。无第一方 CLI。
+
+```
+docs(figma-ai): ...
+```

--- a/docs/products/figma-ai/figma-ai-cheatsheet.md
+++ b/docs/products/figma-ai/figma-ai-cheatsheet.md
@@ -1,0 +1,16 @@
+---
+title: Figma AI cheatsheet
+description: Official Figma AI doors. No CLI.
+domain: product
+tags:
+  - design
+role: reference
+---
+
+# Figma AI cheatsheet
+
+- Agent: https://help.figma.com/hc/en-us/articles/37998629035799
+- First Draft: https://help.figma.com/hc/en-us/articles/23955143044247
+- Config 2026: https://help.figma.com/hc/en-us/articles/39582753756695
+- Make: https://www.figma.com/make/
+- Marketing: https://www.figma.com/ai/

--- a/docs/products/figma-ai/figma-ai-glossary.md
+++ b/docs/products/figma-ai/figma-ai-glossary.md
@@ -1,0 +1,12 @@
+---
+title: Figma AI glossary
+description: Agent, First Draft, Make, and third-party plugins are not the same product.
+domain: product
+tags:
+  - design
+role: explanation
+---
+
+# Figma AI glossary
+
+**Figma agent** — New official entry for First Draft from 20 May 2026 (beta). **First Draft** — older Actions menu. **Make** — figma.com/make. **Relume** — third-party, not documented here.

--- a/docs/products/figma-ai/figma-ai.md
+++ b/docs/products/figma-ai/figma-ai.md
@@ -1,0 +1,18 @@
+---
+title: Figma AI tutorial
+description: Open the official Figma agent or First Draft and generate an editable draft. Steps copied from Help Center.
+domain: product
+tags:
+  - design
+role: tutorial
+---
+
+# Figma AI tutorial
+
+> [First Draft](https://help.figma.com/hc/en-us/articles/23955143044247) · [Agent](https://help.figma.com/hc/en-us/articles/37998629035799)
+
+Config 2026: agent on Professional / Organization / Enterprise with AI enabled; Full seats chat in Design files; needs **can edit**. View/Dev/Collab: Draft files only.
+
+Prefer **Agent** after 20 May 2026 (official new entry). If your seat has no Agent yet, use **Actions → First Draft → Library → prompt** (help example: “A pricing page for a developer tools startup”).
+
+Do not install Relume here as the main path.

--- a/docs/products/figma-ai/index.md
+++ b/docs/products/figma-ai/index.md
@@ -1,0 +1,22 @@
+---
+title: Figma AI learning map
+description: This directory covers official Figma AI only (Agent / First Draft / Make). Relume and Midjourney do not get tutorials.
+domain: product
+tags:
+  - design
+role: map
+---
+
+# Figma AI learning map
+
+> Official First Draft help ([article](https://help.figma.com/hc/en-us/articles/23955143044247)): beginning **20 May 2026**, **Figma’s agent** is the new entry point for this functionality (beta, gradual rollout).
+
+| Official door | URL | This site |
+|---------------|-----|-----------|
+| Figma agent | [help](https://help.figma.com/hc/en-us/articles/37998629035799) | [Tutorial](./figma-ai.md) |
+| First Draft | [help](https://help.figma.com/hc/en-us/articles/23955143044247) | Tutorial section |
+| Make | [figma.com/make](https://www.figma.com/make/) | Map row |
+| Relume / plugins | third-party | Directory row, no tutorial |
+| Midjourney | external | Out of scope |
+
+[Tutorial](./figma-ai.md) · [Cheatsheet](./figma-ai-cheatsheet.md) · [Glossary](./figma-ai-glossary.md)

--- a/docs/zh/products/figma-ai/figma-ai-cheatsheet.md
+++ b/docs/zh/products/figma-ai/figma-ai-cheatsheet.md
@@ -1,0 +1,20 @@
+---
+title: Figma AI 速查表
+description: Figma 官方 AI 入口和帮助中心链接。没有 CLI。
+domain: product
+tags:
+  - design
+role: reference
+---
+
+# Figma AI 速查表
+
+| 入口 | URL |
+|------|-----|
+| Agent | https://help.figma.com/hc/en-us/articles/37998629035799 |
+| First Draft | https://help.figma.com/hc/en-us/articles/23955143044247 |
+| Config 2026 | https://help.figma.com/hc/en-us/articles/39582753756695 |
+| Make | https://www.figma.com/make/ |
+| AI 营销 | https://www.figma.com/ai/ |
+
+First Draft 旧步骤：Actions → First Draft → Library → prompt。

--- a/docs/zh/products/figma-ai/figma-ai-glossary.md
+++ b/docs/zh/products/figma-ai/figma-ai-glossary.md
@@ -1,0 +1,18 @@
+---
+title: Figma AI 术语表
+description: Agent、First Draft、Make、第三方插件不是同一个产品。
+domain: product
+tags:
+  - design
+role: explanation
+---
+
+# Figma AI 术语表
+
+**Figma agent** — 2026-05-20 起 First Draft 的新官方入口（beta）。
+
+**First Draft** — 帮助中心里把想法变成可编辑线框/设计的旧菜单名。
+
+**Figma Make** — figma.com/make，和画布 Agent 不是同一扇门。
+
+**Relume / Magician** — 第三方，本目录不写教程。

--- a/docs/zh/products/figma-ai/figma-ai.md
+++ b/docs/zh/products/figma-ai/figma-ai.md
@@ -1,0 +1,41 @@
+---
+title: Figma AI 教程
+description: 在 Figma 里打开官方 Agent 或 First Draft，用一句话起一版可编辑稿。步骤只抄帮助中心。
+domain: product
+tags:
+  - design
+role: tutorial
+---
+
+# Figma AI 教程
+
+> 官方：[First Draft](https://help.figma.com/hc/en-us/articles/23955143044247)、[Agent](https://help.figma.com/hc/en-us/articles/37998629035799)。
+
+## 先决条件
+
+Config 2026 帮助文：Agent 在 **Professional / Organization / Enterprise**，且工作区打开了 AI；**Full seat** 可在 Design 文件里聊；需要该文件的 **can edit**。View / Dev / Collab 只能在 **Draft** 文件试用。<!-- 以你账号实际开关为准 -->
+
+## 15 分钟内打开
+
+### 1. 优先走 Agent（2026-05-20 之后的官方入口）
+
+First Draft 文原文：从 2026-05-20 起，Figma’s agent 是该能力的新入口，beta 逐步开放。在 Design 文件里打开 Agent（帮助中心「collaborate with the Figma agent」），用自然语言起稿 / 改稿 / 要反馈。具体菜单名以你客户端为准。<!-- TODO: 待核实 --> 若账号还没有 Agent，用下一节旧入口。
+
+### 2. 旧入口：First Draft
+
+帮助中心步骤：
+
+1. 工具栏点 **Actions**
+2. 选 **First Draft**
+3. 需要时点 **Library** 选网站或移动线框 / 基础设计；不选则 Figma AI 自己挑
+4. 输入 prompt，例如帮助中心例句：`A pricing page for a developer tools startup`
+
+输出是可编辑线框或设计，不是整站代码。
+
+### 3. 不要在这里装第三方插件当主路径
+
+Relume / Magician 不是 Figma 官方一级产品。本页不写安装。
+
+## 下一步
+
+[速查](./figma-ai-cheatsheet.md) · [术语](./figma-ai-glossary.md)

--- a/docs/zh/products/figma-ai/index.md
+++ b/docs/zh/products/figma-ai/index.md
@@ -1,0 +1,39 @@
+---
+title: Figma AI 学习地图
+description: 本目录只写 Figma 官方 AI（Agent / First Draft / Make）。Relume、Midjourney 不拆教程。
+domain: product
+tags:
+  - design
+role: map
+---
+
+# Figma AI 学习地图
+
+> 本目录写 **Figma 画布里的官方 AI**，对位「设计师在 Figma 里怎么用 AI」，不是一个独立 CLI。
+>
+> First Draft 帮助中心（[文章](https://help.figma.com/hc/en-us/articles/23955143044247)）原文：从 **2026-05-20** 起，**Figma’s agent** 成为该功能的新入口，能力更强；agent 目前 beta、逐步放开。
+
+## 写给谁 / 不写什么
+
+**写给谁：** 会用 Figma、想用官方 AI 起稿或改稿的前端 / 设计师。
+
+**非目标：** Relume / Magician / Midjourney 安装教程；Figma 组织计费非 AI 部分；编造「免费无限生成」。
+
+## 产品全景
+
+| 官方一级入口 | 官方 URL | 本站去向 |
+|--------------|----------|----------|
+| **Figma agent** | [Collaborate with the Figma agent](https://help.figma.com/hc/en-us/articles/37998629035799) · [Config 2026](https://help.figma.com/hc/en-us/articles/39582753756695) | [教程](./figma-ai.md) |
+| **First Draft** | [Use First Draft](https://help.figma.com/hc/en-us/articles/23955143044247) | Tutorial 一节（旧入口） |
+| Figma Make | [figma.com/make](https://www.figma.com/make/) | 地图一行 |
+| Figma AI 营销 | [figma.com/ai](https://www.figma.com/ai/) | 地图一行 |
+| Relume / 第三方插件 | 各插件站 | **目录一行**，不拆教程 |
+| Midjourney | 外部 | **非本站**（情绪板，不是 Figma 产品） |
+
+**容易撞名：** Figma AI ≠ Figma Make ≠ First Draft ≠ Agent（帮助中心把 Agent 写成 First Draft 的新入口，两套名字并存）；Figma AI ≠ Relume。
+
+## 学习路径
+
+[教程](./figma-ai.md) → [速查](./figma-ai-cheatsheet.md) → [术语](./figma-ai-glossary.md)
+
+无官方 CLI，**不设 cookbook**。


### PR DESCRIPTION
Closes #105

Official Figma AI only (agent / First Draft / Make). Relume / Midjourney are not tutorials. First Draft help: agent is the new entry from 2026-05-20.

| Official | This site |
|----------|-----------|
| Figma agent / First Draft help | Tutorial |
| Make / figma.com/ai | Map row |
| Relume | Directory row |

Did not edit gallery/sidebar (parent integration pass).