### PR TITLE
docs(testing-ai): add Testing AI directory and Midscene tutorial for #106

### DIFF
--- a/.claude/skills/doc-research/references/testing-ai.md
+++ b/.claude/skills/doc-research/references/testing-ai.md
@@ -1,0 +1,22 @@
+# Testing AI 维护参考
+
+调研：2026-08-19。这不是单一厂商产品，是本站「AI 测试」货架位。
+
+## 形态
+
+目录 + **一条主 Tutorial：Midscene**（官方文档密度最高、开源、对前端 Playwright 最贴）。
+
+| 产品 | 官方 | 本站 |
+|------|------|------|
+| Midscene | https://midscenejs.com/ · https://midscenejs.com/introduction · https://midscenejs.com/integrate-with-playwright · https://github.com/web-infra-dev/midscene | 独立 Tutorial |
+| Qodo（原 Codium） | https://www.qodo.ai/ · 更名文 https://www.qodo.ai/blog/introducing-qodo-a-new-name-the-same-commitment-to-quality/ | 目录一行 |
+| ZeroStep | https://zerostep.com/ | 目录一行 |
+| Reflect | https://reflect.run/ | 目录一行 |
+| Playwright | https://playwright.dev/ | 非 AI 产品，一行 |
+| 本站 Midscene 技术笔记 | /zh/tech/testing/midscene-ui-automation | 链走 |
+
+不给每个工具写五文件。不编造 ZeroStep 现包名（旧文过时）。
+
+```
+docs(testing-ai): ...
+```

--- a/docs/products/testing-ai/index.md
+++ b/docs/products/testing-ai/index.md
@@ -1,0 +1,22 @@
+---
+title: Testing AI learning map
+description: Not a single vendor product. This directory is an AI-testing table. The main tutorial is Midscene (official Playwright / vision automation).
+domain: product
+tags:
+  - testing
+role: map
+---
+
+# Testing AI learning map
+
+> **Testing AI** on this shelf is a category, not a company name. The core path is **Midscene** ([introduction](https://midscenejs.com/introduction)): an open-source vision-driven UI testing SDK. You describe the goal; a multimodal model operates from **screenshots**.
+
+| Official name | Official URL | This site |
+|---------------|--------------|-----------|
+| Midscene | [midscenejs.com](https://midscenejs.com/) · [GitHub](https://github.com/web-infra-dev/midscene) | [Tutorial](./testing-ai.md) |
+| Qodo (formerly Codium) | [qodo.ai](https://www.qodo.ai/) | Directory row |
+| ZeroStep | [zerostep.com](https://zerostep.com/) | Directory row |
+| Reflect | [reflect.run](https://reflect.run/) | Directory row |
+| Playwright | [playwright.dev](https://playwright.dev/) | Not an AI product; host only |
+
+[Tutorial](./testing-ai.md) · [Cheatsheet](./testing-ai-cheatsheet.md) · [Glossary](./testing-ai-glossary.md)

--- a/docs/products/testing-ai/testing-ai-cheatsheet.md
+++ b/docs/products/testing-ai/testing-ai-cheatsheet.md
@@ -1,0 +1,16 @@
+---
+title: Testing AI cheatsheet
+description: Official doors for Midscene, Qodo, ZeroStep. Copy install commands from each site.
+domain: product
+tags:
+  - testing
+role: reference
+---
+
+# Testing AI cheatsheet
+
+- Midscene: https://midscenejs.com/ · https://midscenejs.com/integrate-with-playwright · https://github.com/web-infra-dev/midscene
+- Qodo: https://www.qodo.ai/
+- ZeroStep: https://zerostep.com/
+- Reflect: https://reflect.run/
+- Playwright: https://playwright.dev/

--- a/docs/products/testing-ai/testing-ai-glossary.md
+++ b/docs/products/testing-ai/testing-ai-glossary.md
@@ -1,0 +1,12 @@
+---
+title: Testing AI glossary
+description: The Testing AI shelf, Midscene, Qodo, and Playwright are not the same product.
+domain: product
+tags:
+  - testing
+role: explanation
+---
+
+# Testing AI glossary
+
+**Testing AI** — shelf category on this site. **Midscene** — vision UI-testing SDK. **Qodo** — formerly Codium/CodiumAI. **Playwright** — Microsoft E2E library, not an AI product.

--- a/docs/products/testing-ai/testing-ai.md
+++ b/docs/products/testing-ai/testing-ai.md
@@ -1,0 +1,18 @@
+---
+title: Testing AI tutorial (Midscene)
+description: Wire Midscene into Playwright from the official docs. Do not invent API names beyond the official pages.
+domain: product
+tags:
+  - testing
+role: tutorial
+---
+
+# Testing AI tutorial (Midscene)
+
+> [Introduction](https://midscenejs.com/introduction) · [Integrate with Playwright](https://midscenejs.com/integrate-with-playwright)
+
+Official: open-source vision SDK; two ways (Playwright/Vitest or Skills); APIs include `aiAct`, `aiQuery`, `aiAssert` (see official reference). Do **not** paste the old ZeroStep `await ai('...')` snippet as Midscene.
+
+Copy install commands from the official Playwright page. Example repos named there: `web-infra-dev/midscene-example` `playwright-demo` and `playwright-testing-demo`.
+
+Qodo / ZeroStep / Reflect stay one row on the map.

--- a/docs/zh/products/testing-ai/index.md
+++ b/docs/zh/products/testing-ai/index.md
@@ -1,0 +1,50 @@
+---
+title: Testing AI 学习地图
+description: 这不是单一厂商产品。本目录是 AI 测试工具表，主教程走 Midscene（官方 Playwright / 视觉自动化）。
+domain: product
+tags:
+  - testing
+role: map
+---
+
+# Testing AI 学习地图
+
+> 货架上的 **Testing AI** 是本站分类，不是某个公司的产品名。
+>
+> 主路径选 **Midscene**：开源、视觉驱动 UI 测试，可嵌进 Playwright / Vitest。官方（[introduction](https://midscenejs.com/introduction)）：
+> 用自然语言描述操作目标，多模态模型根据**截图**规划并操作界面。
+
+## 写给谁 / 不写什么
+
+**写给谁：** 已经会 Playwright 或想用自然语言补 UI 断言的前端。
+
+**非目标：** 把 Jest/Vitest 本身写成 AI 产品；给 Qodo / ZeroStep / Reflect 各写一套五文件；编造已失效的 `ai()` helper 当现行官方 API。
+
+## 产品目录（官方一级）
+
+| 官方名称 | 官方 URL | 一句话 | 本站去向 |
+|----------|----------|--------|----------|
+| **Midscene** | [midscenejs.com](https://midscenejs.com/) · [introduction](https://midscenejs.com/introduction) · [GitHub](https://github.com/web-infra-dev/midscene) | 视觉驱动 UI 测试 SDK | [教程](./testing-ai.md) |
+| Qodo（原 Codium / CodiumAI） | [qodo.ai](https://www.qodo.ai/) · [更名](https://www.qodo.ai/blog/introducing-qodo-a-new-name-the-same-commitment-to-quality/) | AI code review + 测例生成 | **目录一行** |
+| ZeroStep | [zerostep.com](https://zerostep.com/) | Playwright 上的自然语言步骤 | 目录一行；旧站摘抄勿当现行 API |
+| Reflect | [reflect.run](https://reflect.run/) | 无代码 E2E | 目录一行 |
+| Playwright | [playwright.dev](https://playwright.dev/) | 微软 E2E，**不是** AI 产品 | 一行：宿主，不是本货架主角 |
+| 本站 Midscene 笔记 | | 技术向 | [Midscene UI 自动化](/zh/tech/testing/midscene-ui-automation) |
+
+**容易撞名：** Testing AI ≠ Midscene ≠ Qodo；CodiumAI 已更名 **Qodo**；Playwright ≠ Midscene。
+
+### 快速决策
+
+```
+我要做什么？
+├── 在已有 Playwright / Vitest 里用自然语言点界面
+│   └── → Midscene（本目录教程）
+├── PR / IDE 里审代码、补单测
+│   └── → Qodo（官网，本目录不写安装）
+└── 只要稳定选择器 E2E
+    └── → Playwright 本身（非本站 AI 产品）
+```
+
+## 学习路径
+
+[教程 · Midscene](./testing-ai.md) → [速查](./testing-ai-cheatsheet.md) → [术语](./testing-ai-glossary.md)

--- a/docs/zh/products/testing-ai/testing-ai-cheatsheet.md
+++ b/docs/zh/products/testing-ai/testing-ai-cheatsheet.md
@@ -1,0 +1,22 @@
+---
+title: Testing AI 速查表
+description: Midscene、Qodo、ZeroStep 官方入口。安装命令以各官方页为准。
+domain: product
+tags:
+  - testing
+role: reference
+---
+
+# Testing AI 速查表
+
+| 产品 | URL |
+|------|-----|
+| Midscene | https://midscenejs.com/ |
+| Introduction | https://midscenejs.com/introduction |
+| Playwright 集成 | https://midscenejs.com/integrate-with-playwright |
+| GitHub | https://github.com/web-infra-dev/midscene |
+| Qodo | https://www.qodo.ai/ |
+| Qodo 更名 | https://www.qodo.ai/blog/introducing-qodo-a-new-name-the-same-commitment-to-quality/ |
+| ZeroStep | https://zerostep.com/ |
+| Reflect | https://reflect.run/ |
+| Playwright | https://playwright.dev/ |

--- a/docs/zh/products/testing-ai/testing-ai-glossary.md
+++ b/docs/zh/products/testing-ai/testing-ai-glossary.md
@@ -1,0 +1,18 @@
+---
+title: Testing AI 术语表
+description: Testing AI 货架位、Midscene、Qodo、Playwright 不是同一个产品。
+domain: product
+tags:
+  - testing
+role: explanation
+---
+
+# Testing AI 术语表
+
+**Testing AI** — 本站货架分类，不是公司名。
+
+**Midscene** — web-infra-dev 的视觉 UI 测试 SDK。
+
+**Qodo** — 原 Codium / CodiumAI。
+
+**Playwright** — 微软 E2E 库，不是 AI 产品；Midscene 可以接到它上面。

--- a/docs/zh/products/testing-ai/testing-ai.md
+++ b/docs/zh/products/testing-ai/testing-ai.md
@@ -1,0 +1,49 @@
+---
+title: Testing AI 教程（Midscene）
+description: 按 Midscene 官方文档把视觉 UI 测试接到 Playwright。不编造 npm 包名以外的 API。
+domain: product
+tags:
+  - testing
+role: tutorial
+---
+
+# Testing AI 教程（Midscene）
+
+> 本页主路径是 **Midscene**。官方：[Introduction](https://midscenejs.com/introduction)、[Integrate with Playwright](https://midscenejs.com/integrate-with-playwright)、[GitHub](https://github.com/web-infra-dev/midscene)。
+
+## 目标与非目标
+
+**你会完成：** 知道 Midscene 和 DOM 选择器方案差在哪，打开官方 Playwright 集成页做第一次接入。
+
+**不会做：** 把仓库旧文里的 ZeroStep `ai()` 示例当现行官方 API；给 Qodo 写安装。
+
+## Midscene 是什么（官方原文）
+
+Introduction：
+
+- 开源 SDK，视觉驱动 UI 测试与自动化。
+- **只靠截图**，用多模态模型；用自然语言写目标和断言。
+- **两种用法：** 加进现有 Playwright / Vitest，或让 Agent 通过 Skills 自主测。
+- 方法名在官方 API 里：`aiAct`、`aiQuery`、`aiAssert` 等（以 [API reference](https://midscenejs.com/introduction) 链出去的 reference 为准）。
+
+不要把旧摘抄里的 `await ai('Navigate to booking page')` 写成 Midscene 现行 API。
+
+## 接到 Playwright
+
+逐步命令、fixture 名以官方 [Integrate with Playwright](https://midscenejs.com/integrate-with-playwright) 为准。该页还链示例仓库 `web-infra-dev/midscene-example`。
+
+<!-- TODO: 待核实 --> 本页不抄一份可能过期的 `npm i` 包名表；打开上面官方页复制。
+
+示例项目（官方页原文）：
+
+- 直接集成：https://github.com/web-infra-dev/midscene-example/blob/main/playwright-demo
+- Playwright test：https://github.com/web-infra-dev/midscene-example/blob/main/playwright-testing-demo
+
+## 目录里其它工具
+
+- **Qodo**：原 Codium。官网定位已是 AI code review 平台，不是「只写单测的插件」。去 [qodo.ai](https://www.qodo.ai/)。
+- **ZeroStep / Reflect**：地图一行。2026-08-19 未把它们的安装命令核进本 Tutorial。
+
+## 下一步
+
+[速查](./testing-ai-cheatsheet.md) · 本站技术笔记 [Midscene UI 自动化](/zh/tech/testing/midscene-ui-automation)


### PR DESCRIPTION
Closes #106

Shelf category, not a vendor. Main tutorial is Midscene (official vision + Playwright). Qodo / ZeroStep / Reflect are directory rows. Old ZeroStep `ai()` snippet is not treated as Midscene API.

| Official | This site |
|----------|-----------|
| Midscene | Tutorial |
| Qodo / ZeroStep / Reflect | Directory row |
| Playwright | Host, not an AI product |

Did not edit gallery/sidebar (parent integration pass).