### PR TITLE
docs(othertools): expand Other tools directory for #107

### DIFF
--- a/.claude/skills/doc-research/references/othertools.md
+++ b/.claude/skills/doc-research/references/othertools.md
@@ -1,0 +1,7 @@
+# Other tools 维护参考
+
+本页是**目录**，不是第五个厂商家族。每行必须有官方 URL。#70–#85 与 Claude/Cursor/Gemini/Grok/Pi/OpenClaw/Figma/Testing 已覆盖的产品只链走。
+
+```
+docs(othertools): ...
+```

--- a/docs/products/othertools/index.md
+++ b/docs/products/othertools/index.md
@@ -1,0 +1,45 @@
+---
+title: Other tools directory
+description: AI products that are not first-class families on this site. Each row has an official name, official URL, and a destination. Not a second Claude/Cursor tutorial.
+domain: product
+tags:
+  - directory
+role: map
+---
+
+# Other tools directory
+
+> A **directory**, not a vendor. First-class families (Claude / Cursor / Gemini / Grok / #70–#85 / Pi / OpenClaw / Figma AI / Testing AI) get one row and a link. New rows need a reachable official page.
+
+## Already on this site
+
+| Official name | Official URL | This site |
+|---------------|--------------|-----------|
+| Claude | https://claude.com/ | [Claude](/products/claude/) |
+| Cursor | https://cursor.com/ | [Cursor](/products/cursor/) |
+| Gemini | https://gemini.google.com/ | [Gemini](/products/gemini/) |
+| Grok | https://grok.com/ | [Grok](/products/grok/) |
+| Copilot | https://github.com/features/copilot | [Copilot](/products/copilot/) |
+| Codex | https://openai.com/codex | [Codex](/products/codex/) |
+| Pi | https://pi.dev/ | [Pi](/products/pi-agent/) |
+| OpenClaw | https://openclaw.ai/ | [OpenClaw](/products/openclaw/) |
+| Figma AI | https://www.figma.com/ai/ | [Figma AI](/products/figma-ai/) |
+| Midscene / Testing | https://midscenejs.com/ | [Testing AI](/products/testing-ai/) |
+
+## Directory rows (no install tutorial here)
+
+| Official name | Official URL | What it is | This site |
+|---------------|--------------|------------|-----------|
+| Aider | https://aider.chat/ | Terminal pair-programming agent | Directory row |
+| Continue | https://www.continue.dev/ | Open-source IDE assistant | Directory row |
+| Cline | https://github.com/cline/cline | VS Code agent | Directory row |
+| Windsurf | https://windsurf.com/ | Codeium IDE | Directory row |
+| Tabby | https://tabby.tabbyml.com/ | Self-hosted autocomplete | Directory row |
+| v0 | https://v0.dev/ | Vercel UI generation | Directory row |
+| Bolt | https://bolt.new/ | In-browser fullstack preview | Directory row |
+| Lovable | https://lovable.dev/ | App from natural language | Directory row |
+| DeepWiki | https://deepwiki.com/ | GitHub repo as wiki | Directory row |
+| fish.audio | https://fish.audio/ | Text to speech | Directory row |
+| Ollama | https://ollama.com/ | Local models | Link [Ollama](/products/ollama) (no install here) |
+
+Taobao / Douyin / WeChat / ECS: **out of scope**.

--- a/docs/zh/products/othertools/index.md
+++ b/docs/zh/products/othertools/index.md
@@ -1,0 +1,55 @@
+---
+title: 其他工具目录
+description: 未单独成套的 AI 产品一览。每行有官方名、官方 URL、本站去向。不是第二套 Claude/Cursor 教程。
+domain: product
+tags:
+  - directory
+role: map
+---
+
+# 其他工具目录
+
+> 本页是**目录**，不是一个厂商。已经单独成套的产品（Claude / Cursor / Gemini / Grok / #70–#85 / Pi / OpenClaw / Figma AI / Testing AI）只在这里占一行并链走。
+>
+> 新增行必须能打开官方页。找不到安装命令就不要编。
+
+## 本站已有手册（只链走）
+
+| 官方名称 | 官方 URL | 本站去向 |
+|----------|----------|----------|
+| Claude | https://claude.com/ | [Claude](/zh/products/claude/) |
+| Cursor | https://cursor.com/ | [Cursor](/zh/products/cursor/) |
+| Gemini | https://gemini.google.com/ | [Gemini](/zh/products/gemini/) |
+| Grok | https://grok.com/ | [Grok](/zh/products/grok/) |
+| Copilot | https://github.com/features/copilot | [Copilot](/zh/products/copilot/) |
+| Codex | https://openai.com/codex | [Codex](/zh/products/codex/) |
+| Pi | https://pi.dev/ | [Pi](/zh/products/pi-agent/) |
+| OpenClaw | https://openclaw.ai/ | [OpenClaw](/zh/products/openclaw/) |
+| Figma AI | https://www.figma.com/ai/ | [Figma AI](/zh/products/figma-ai/) |
+| Midscene / Testing | https://midscenejs.com/ | [Testing AI](/zh/products/testing-ai/) |
+
+#70–#85（Kimi、Trae、豆包、百炼等）见产品货架，本目录不重复教程。
+
+## 目录一行（本站不写安装主教程）
+
+| 官方名称 | 官方 URL | 是什么 | 本站去向 |
+|----------|----------|--------|----------|
+| Aider | https://aider.chat/ | 终端结对编程 agent | 目录一行 |
+| Continue | https://www.continue.dev/ | 开源 IDE 助手 | 目录一行 |
+| Cline | https://github.com/cline/cline | VS Code agent | 目录一行 |
+| Windsurf | https://windsurf.com/ | Codeium 出品的 IDE | 目录一行 |
+| Tabby | https://tabby.tabbyml.com/ | 自托管补全 | 目录一行 |
+| v0 | https://v0.dev/ | Vercel 生成 UI | 目录一行 |
+| Bolt | https://bolt.new/ | 浏览器里出全栈预览 | 目录一行 |
+| Lovable | https://lovable.dev/ | 自然语言出应用 | 目录一行 |
+| DeepWiki | https://deepwiki.com/ | 把 GitHub 仓库读成 wiki（现页旧链） | 目录一行 |
+| fish.audio | https://fish.audio/ | 文本转语音 | 目录一行 |
+| Ollama | https://ollama.com/ | 本机跑模型 | 链 [Ollama](/zh/products/ollama)（本目录不写安装） |
+
+## 非本站
+
+淘宝 / 抖音 / 微信 / ECS / 支付：**非本站**。
+
+## 本页不是什么
+
+不是「把上面每一行做成五文件家族」。密度够、且本站还没有手册时，另开 issue。


### PR DESCRIPTION
Closes #107

Single directory page. Each row has official name + https + 本站去向. No second tutorial for Claude/Cursor/Gemini/Grok/#70-85/Pi/OpenClaw/Figma/Testing.

Rows added: Aider, Continue, Cline, Windsurf, Tabby, v0, Bolt, Lovable, DeepWiki, fish.audio, Ollama (link only).

Did not edit gallery/sidebar (parent integration pass).